### PR TITLE
Fix 6 type-mismatch and missing-method compilation errors

### DIFF
--- a/worker/src/main/java/com/rakovpublic/jneuropallium/ai/neurons/features/FeatureDetectorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/ai/neurons/features/FeatureDetectorNeuron.java
@@ -30,6 +30,6 @@ public class FeatureDetectorNeuron extends ModulatableNeuron {
     public double[] getWeightedTemplate() { return weightedTemplate; }
     public void setWeightedTemplate(double[] weightedTemplate) { this.weightedTemplate = weightedTemplate; }
 
-    public double getDetectionThreshold() { return detectionThreshold; }
-    public void setDetectionThreshold(double detectionThreshold) { this.detectionThreshold = detectionThreshold; }
+    public double getThreshold() { return detectionThreshold; }
+    public void setThreshold(double detectionThreshold) { this.detectionThreshold = detectionThreshold; }
 }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/ai/neurons/features/InhibitoryInterneuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/ai/neurons/features/InhibitoryInterneuron.java
@@ -8,27 +8,27 @@ import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
  */
 public class InhibitoryInterneuron extends ModulatableNeuron {
 
-    private int layerId;
+    private String layerId;
     private double inhibitionStrength;
 
     public InhibitoryInterneuron() {
         super();
-        this.layerId = 0;
+        this.layerId = "0";
         this.inhibitionStrength = 1.0;
     }
 
     public InhibitoryInterneuron(Long neuronId,
                                  com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain chain,
                                  Long run,
-                                 int layerId,
+                                 String layerId,
                                  double inhibitionStrength) {
         super(neuronId, chain, run);
         this.layerId = layerId;
         this.inhibitionStrength = inhibitionStrength;
     }
 
-    public int getLayerId() { return layerId; }
-    public void setLayerId(int layerId) { this.layerId = layerId; }
+    public String getLayerId() { return layerId; }
+    public void setLayerId(String layerId) { this.layerId = layerId; }
 
     public double getInhibitionStrength() { return inhibitionStrength; }
     public void setInhibitionStrength(double inhibitionStrength) { this.inhibitionStrength = inhibitionStrength; }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/ai/neurons/harm/HarmEvaluationNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/ai/neurons/harm/HarmEvaluationNeuron.java
@@ -2,8 +2,11 @@ package com.rakovpublic.jneuropallium.ai.neurons.harm;
 
 import com.rakovpublic.jneuropallium.ai.model.HarmThreshold;
 import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.ai.signals.fast.ConsequenceSimulationSignal;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -15,11 +18,13 @@ public class HarmEvaluationNeuron extends ModulatableNeuron {
 
     private HarmThreshold threshold;
     private Map<String, HarmThreshold> dimensionThresholds;
+    private Map<String, List<ConsequenceSimulationSignal>> pendingSimulations;
 
     public HarmEvaluationNeuron() {
         super();
         this.threshold = new HarmThreshold();
         this.dimensionThresholds = new HashMap<>();
+        this.pendingSimulations = new HashMap<>();
         initDefaultDimensionThresholds();
     }
 
@@ -30,6 +35,7 @@ public class HarmEvaluationNeuron extends ModulatableNeuron {
         super(neuronId, chain, run);
         this.threshold = threshold;
         this.dimensionThresholds = new HashMap<>();
+        this.pendingSimulations = new HashMap<>();
         initDefaultDimensionThresholds();
     }
 
@@ -46,4 +52,7 @@ public class HarmEvaluationNeuron extends ModulatableNeuron {
 
     public Map<String, HarmThreshold> getDimensionThresholds() { return dimensionThresholds; }
     public void setDimensionThresholds(Map<String, HarmThreshold> dimensionThresholds) { this.dimensionThresholds = dimensionThresholds; }
+
+    public Map<String, List<ConsequenceSimulationSignal>> getPendingSimulations() { return pendingSimulations; }
+    public void setPendingSimulations(Map<String, List<ConsequenceSimulationSignal>> pendingSimulations) { this.pendingSimulations = pendingSimulations; }
 }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/ai/neurons/learning/HebbianLearningNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/ai/neurons/learning/HebbianLearningNeuron.java
@@ -13,7 +13,7 @@ public class HebbianLearningNeuron extends ModulatableNeuron {
 
     private double achThreshold;
     private double learningRate;
-    private Map<Long, Double> synapticWeights;
+    private Map<String, Double> synapticWeights;
 
     public HebbianLearningNeuron() {
         super();
@@ -33,7 +33,7 @@ public class HebbianLearningNeuron extends ModulatableNeuron {
         this.synapticWeights = new HashMap<>();
     }
 
-    public void applyWeightDelta(Long targetNeuronId, double delta) {
+    public void applyWeightDelta(String targetNeuronId, double delta) {
         if (targetNeuronId == null) return;
         synapticWeights.merge(targetNeuronId, delta, Double::sum);
     }
@@ -44,6 +44,6 @@ public class HebbianLearningNeuron extends ModulatableNeuron {
     public double getLearningRate() { return learningRate; }
     public void setLearningRate(double learningRate) { this.learningRate = learningRate; }
 
-    public Map<Long, Double> getSynapticWeights() { return synapticWeights; }
-    public void setSynapticWeights(Map<Long, Double> synapticWeights) { this.synapticWeights = synapticWeights; }
+    public Map<String, Double> getSynapticWeights() { return synapticWeights; }
+    public void setSynapticWeights(Map<String, Double> synapticWeights) { this.synapticWeights = synapticWeights; }
 }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/ai/neurons/memory/PredictionErrorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/ai/neurons/memory/PredictionErrorNeuron.java
@@ -10,13 +10,13 @@ public class PredictionErrorNeuron extends ModulatableNeuron {
 
     private double thetaPositive;
     private double thetaNegative;
-    private Long planningNeuronId;
+    private String planningNeuronId;
 
     public PredictionErrorNeuron() {
         super();
         this.thetaPositive = 0.1;
         this.thetaNegative = -0.1;
-        this.planningNeuronId = 0L;
+        this.planningNeuronId = "0";
     }
 
     public PredictionErrorNeuron(Long neuronId,
@@ -24,7 +24,7 @@ public class PredictionErrorNeuron extends ModulatableNeuron {
                                  Long run,
                                  double thetaPositive,
                                  double thetaNegative,
-                                 Long planningNeuronId) {
+                                 String planningNeuronId) {
         super(neuronId, chain, run);
         this.thetaPositive = thetaPositive;
         this.thetaNegative = thetaNegative;
@@ -37,6 +37,6 @@ public class PredictionErrorNeuron extends ModulatableNeuron {
     public double getThetaNegative() { return thetaNegative; }
     public void setThetaNegative(double thetaNegative) { this.thetaNegative = thetaNegative; }
 
-    public Long getPlanningNeuronId() { return planningNeuronId; }
-    public void setPlanningNeuronId(Long planningNeuronId) { this.planningNeuronId = planningNeuronId; }
+    public String getPlanningNeuronId() { return planningNeuronId; }
+    public void setPlanningNeuronId(String planningNeuronId) { this.planningNeuronId = planningNeuronId; }
 }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/ai/signals/fast/MotorCommandSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/ai/signals/fast/MotorCommandSignal.java
@@ -24,6 +24,14 @@ public class MotorCommandSignal extends BaseSignal {
     public String getActionPlanId() { return actionPlanId; }
     public void setActionPlanId(String actionPlanId) { this.actionPlanId = actionPlanId; }
 
+    /** Returns the L2 norm of params as a magnitude estimate for competitive selection. */
+    public double getMagnitudeEstimate() {
+        if (params == null || params.length == 0) return 0.0;
+        double sumSq = 0;
+        for (double p : params) sumSq += p * p;
+        return Math.sqrt(sumSq);
+    }
+
     @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return MotorCommandSignal.class; }
     @Override public String getDescription() { return "MotorCommandSignal"; }
     @Override public <K extends ISignal<Void>> K copySignal() {


### PR DESCRIPTION
- FeatureDetectorNeuron: rename getDetectionThreshold() → getThreshold()
- InhibitoryInterneuron: change layerId field/getter/setter from int → String
- HarmEvaluationNeuron: add pendingSimulations map and getPendingSimulations()
- MotorCommandSignal: add getMagnitudeEstimate() (L2 norm of params)
- HebbianLearningNeuron: change applyWeightDelta(Long,double) → (String,double) and Map<Long,Double> → Map<String,Double>
- PredictionErrorNeuron: change planningNeuronId field/getter/setter from Long → String

https://claude.ai/code/session_019zPqPrsoKFCw8TMfsTtmPA