### PR TITLE
Fix 4 test failures in JSONHelper and ProcessingFrequencySignal

### DIFF
--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/cycleprocessing/ProcessingFrequencySignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/cycleprocessing/ProcessingFrequencySignal.java
@@ -6,7 +6,7 @@ import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 public class ProcessingFrequencySignal extends AbstractSignal<ProcessingFrequencySignalItem> implements ISignal<ProcessingFrequencySignalItem> {
 
     public ProcessingFrequencySignal(ProcessingFrequencySignalItem value, Integer sourceLayer, Long sourceNeuron, Integer timeAlive, String description, boolean fromExternalNet, String inputName, boolean needToRemoveDuringLearning, boolean needToProcessDuringLearning, String name) {
-        super(value, sourceLayer, sourceNeuron, timeAlive, description, fromExternalNet, inputName, needToRemoveDuringLearning, needToProcessDuringLearning, ProcessingFrequencySignal.class.getName(), ProcessingFrequencySignal.class.getCanonicalName());
+        super(value, sourceLayer, sourceNeuron, timeAlive, description, fromExternalNet, inputName, needToRemoveDuringLearning, needToProcessDuringLearning, name, ProcessingFrequencySignal.class.getCanonicalName());
     }
 
     @Override

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/util/json/JSONHelper.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/util/json/JSONHelper.java
@@ -16,7 +16,7 @@ public class JSONHelper implements IDeserializationHelper {
         JsonObject jobject = jelement.getAsJsonObject();
         JsonElement field = jobject.get(fieldName);
         if (field == null || field.isJsonNull()) {
-            return null;
+            throw new IllegalArgumentException("Field not found or null: " + fieldName);
         }
         return field.getAsString();
     }


### PR DESCRIPTION
- ProcessingFrequencySignal: constructor was ignoring the name parameter and hardcoding ProcessingFrequencySignal.class.getName(); copySignal() now correctly preserves the original signal name via this.getName()
- JSONHelper.extractField: return null for missing fields was changed to throw IllegalArgumentException so callers get an explicit failure

https://claude.ai/code/session_019zPqPrsoKFCw8TMfsTtmPA