### PR TITLE
feat: LLM knowledge base integration — signals, neurons, processors, …

### DIFF
--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/ILLMCapable.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/ILLMCapable.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.INeuron;
+
+import java.util.Optional;
+
+/**
+ * Extension of INeuron for neurons that can issue advisory queries to an LLM endpoint.
+ *
+ * Design constraints (from CLAUDE.md):
+ * <ul>
+ *   <li>LLM queries run on the slow loop only — never block fast-loop processing.</li>
+ *   <li>LLM responses are untrusted until cross-validated.</li>
+ *   <li>LLM integration is disabled by default.</li>
+ * </ul>
+ */
+public interface ILLMCapable extends INeuron {
+
+    /**
+     * Submit a query to the LLM asynchronously.
+     * Implementations must use CompletableFuture to avoid blocking.
+     *
+     * @param query the query signal to dispatch
+     */
+    void submitQuery(LLMQuerySignal query);
+
+    /**
+     * Retrieve a cached response by query id, if one exists.
+     *
+     * @param queryId the id of the original query
+     * @return cached response or empty
+     */
+    Optional<LLMResponseSignal> getCachedResponse(String queryId);
+
+    /**
+     * @return true if the LLM endpoint is reachable and enabled
+     */
+    boolean isLLMAvailable();
+
+    /**
+     * Configure the LLM endpoint URL (Ollama, OpenAI-compatible, etc.).
+     *
+     * @param endpoint base URL of the LLM service
+     */
+    void setLLMEndpoint(String endpoint);
+
+    /**
+     * Set the maximum acceptable latency for LLM responses.
+     * Queries exceeding this threshold produce a LLMTimeoutSignal.
+     *
+     * @param milliseconds latency threshold in ms
+     */
+    void setMaxLatency(long milliseconds);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMConfidenceItem.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMConfidenceItem.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+/**
+ * Payload for LLMConfidenceSignal.
+ * Produced by LLMVerificationNeuron after cross-validation.
+ * Carries the verified confidence score and an applicability verdict.
+ */
+public class LLMConfidenceItem {
+
+    private String queryId;
+    /** Verified confidence after cross-validation, 0.0–1.0. */
+    private double verifiedConfidence;
+    /** True when the LLM response is applicable and safe to use. */
+    private boolean applicable;
+    private String verificationNote;
+
+    public LLMConfidenceItem() {
+    }
+
+    public LLMConfidenceItem(String queryId, double verifiedConfidence, boolean applicable, String verificationNote) {
+        this.queryId = queryId;
+        this.verifiedConfidence = verifiedConfidence;
+        this.applicable = applicable;
+        this.verificationNote = verificationNote;
+    }
+
+    public String getQueryId() {
+        return queryId;
+    }
+
+    public void setQueryId(String queryId) {
+        this.queryId = queryId;
+    }
+
+    public double getVerifiedConfidence() {
+        return verifiedConfidence;
+    }
+
+    public void setVerifiedConfidence(double verifiedConfidence) {
+        this.verifiedConfidence = verifiedConfidence;
+    }
+
+    public boolean isApplicable() {
+        return applicable;
+    }
+
+    public void setApplicable(boolean applicable) {
+        this.applicable = applicable;
+    }
+
+    public String getVerificationNote() {
+        return verificationNote;
+    }
+
+    public void setVerificationNote(String verificationNote) {
+        this.verificationNote = verificationNote;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMConfidenceSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMConfidenceSignal.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Signal carrying a verified confidence score and applicability verdict.
+ * Emitted by LLMVerificationNeuron after cross-validation.
+ * Slow loop, epoch 3 — runs less frequently than query/response signals.
+ */
+public class LLMConfidenceSignal extends AbstractSignal<LLMConfidenceItem> implements ISignal<LLMConfidenceItem> {
+
+    public LLMConfidenceSignal(LLMConfidenceItem value, Integer sourceLayer, Long sourceNeuron,
+                               Integer timeAlive, String description, boolean fromExternalNet,
+                               String inputName, boolean needToRemoveDuringLearning,
+                               boolean needToProcessDuringLearning, String name) {
+        super(value, sourceLayer, sourceNeuron, timeAlive, description, fromExternalNet,
+                inputName, needToRemoveDuringLearning, needToProcessDuringLearning,
+                name, LLMConfidenceSignal.class.getCanonicalName());
+        this.loop = 2;
+        this.epoch = 3L;
+    }
+
+    @Override
+    public Class<? extends ISignal<LLMConfidenceItem>> getCurrentSignalClass() {
+        return LLMConfidenceSignal.class;
+    }
+
+    @Override
+    public Class<LLMConfidenceItem> getParamClass() {
+        return LLMConfidenceItem.class;
+    }
+
+    @Override
+    public LLMConfidenceSignal copySignal() {
+        return new LLMConfidenceSignal(value, this.getSourceLayerId(), this.getSourceNeuronId(),
+                this.getTimeAlive(), getDescription(), isFromExternalNet(), getInputName(),
+                this.isNeedToRemoveDuringLearning(), this.isNeedToProcessDuringLearning(),
+                this.getName());
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMConfig.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+/**
+ * Configuration for the LLM integration module.
+ * All fields map to the {@code llm:} section of the jneopallium config file.
+ * Default state is disabled — LLM must be explicitly enabled.
+ */
+public class LLMConfig {
+
+    private boolean enabled = false;
+    private String endpoint = "http://localhost:11434";
+    private String apiKey = "";
+    private long maxLatencyMs = 5000;
+    private long cacheTtlSeconds = 300;
+    private String model = "llama3";
+    private int circuitBreakerFailureThreshold = 5;
+    private long circuitBreakerHalfOpenProbeIntervalMs = 30000;
+
+    public LLMConfig() {
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public long getMaxLatencyMs() {
+        return maxLatencyMs;
+    }
+
+    public void setMaxLatencyMs(long maxLatencyMs) {
+        this.maxLatencyMs = maxLatencyMs;
+    }
+
+    public long getCacheTtlSeconds() {
+        return cacheTtlSeconds;
+    }
+
+    public void setCacheTtlSeconds(long cacheTtlSeconds) {
+        this.cacheTtlSeconds = cacheTtlSeconds;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public int getCircuitBreakerFailureThreshold() {
+        return circuitBreakerFailureThreshold;
+    }
+
+    public void setCircuitBreakerFailureThreshold(int circuitBreakerFailureThreshold) {
+        this.circuitBreakerFailureThreshold = circuitBreakerFailureThreshold;
+    }
+
+    public long getCircuitBreakerHalfOpenProbeIntervalMs() {
+        return circuitBreakerHalfOpenProbeIntervalMs;
+    }
+
+    public void setCircuitBreakerHalfOpenProbeIntervalMs(long circuitBreakerHalfOpenProbeIntervalMs) {
+        this.circuitBreakerHalfOpenProbeIntervalMs = circuitBreakerHalfOpenProbeIntervalMs;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMFallbackNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMFallbackNeuron.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.Neuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Circuit-breaker neuron (Layer 3).
+ * Routes processing to internal knowledge when the LLM is unavailable.
+ *
+ * <p>Circuit breaker states:
+ * <pre>
+ *   CLOSED ──(failures >= threshold)──► OPEN
+ *   OPEN   ──(probe interval elapsed)──► HALF_OPEN
+ *   HALF_OPEN ──(success)──► CLOSED
+ *   HALF_OPEN ──(failure)──► OPEN
+ * </pre>
+ *
+ * <p>In OPEN state all LLM signals are rerouted to fallback processing immediately.
+ */
+public class LLMFallbackNeuron extends Neuron {
+
+    private static final Logger logger = LogManager.getLogger(LLMFallbackNeuron.class);
+
+    public enum CircuitState {
+        CLOSED, HALF_OPEN, OPEN
+    }
+
+    private volatile CircuitState state = CircuitState.CLOSED;
+    private final AtomicInteger consecutiveFailures = new AtomicInteger(0);
+    private final AtomicLong lastOpenedAt = new AtomicLong(0);
+
+    private int failureThreshold;
+    private long halfOpenProbeIntervalMs;
+
+    public LLMFallbackNeuron(Long id, ISignalChain signalChain, Long run,
+                              int failureThreshold, long halfOpenProbeIntervalMs) {
+        super(id, signalChain, run);
+        this.failureThreshold = failureThreshold;
+        this.halfOpenProbeIntervalMs = halfOpenProbeIntervalMs;
+        this.currentNeuronClass = LLMFallbackNeuron.class;
+        this.addSignalProcessor(LLMTimeoutSignal.class, new LLMTimeoutProcessor(this));
+        this.addSignalProcessor(LLMResponseSignal.class, new LLMFallbackResponseProcessor(this));
+    }
+
+    /**
+     * Called when a successful LLM response is received.
+     * Resets failure counter; transitions HALF_OPEN → CLOSED.
+     */
+    public void recordSuccess() {
+        consecutiveFailures.set(0);
+        if (state == CircuitState.HALF_OPEN) {
+            logger.info("Circuit breaker: HALF_OPEN → CLOSED (LLM recovered)");
+            state = CircuitState.CLOSED;
+        }
+    }
+
+    /**
+     * Called when an LLM timeout or error occurs.
+     * Increments failure counter and may open the circuit.
+     */
+    public void recordFailure() {
+        int failures = consecutiveFailures.incrementAndGet();
+        if (state == CircuitState.CLOSED && failures >= failureThreshold) {
+            logger.warn("Circuit breaker: CLOSED → OPEN after {} consecutive failures", failures);
+            state = CircuitState.OPEN;
+            lastOpenedAt.set(System.currentTimeMillis());
+        } else if (state == CircuitState.HALF_OPEN) {
+            logger.warn("Circuit breaker: HALF_OPEN → OPEN (probe failed)");
+            state = CircuitState.OPEN;
+            lastOpenedAt.set(System.currentTimeMillis());
+        }
+    }
+
+    /**
+     * Checks whether the circuit should transition from OPEN to HALF_OPEN
+     * based on the elapsed probe interval, and updates state accordingly.
+     *
+     * @return current circuit state after possible transition
+     */
+    public CircuitState getState() {
+        if (state == CircuitState.OPEN) {
+            long elapsed = System.currentTimeMillis() - lastOpenedAt.get();
+            if (elapsed >= halfOpenProbeIntervalMs) {
+                logger.info("Circuit breaker: OPEN → HALF_OPEN (probe interval elapsed: {}ms)", elapsed);
+                state = CircuitState.HALF_OPEN;
+            }
+        }
+        return state;
+    }
+
+    /**
+     * @return true when the circuit is CLOSED or HALF_OPEN (LLM calls allowed)
+     */
+    public boolean isLLMCallAllowed() {
+        CircuitState current = getState();
+        return current == CircuitState.CLOSED || current == CircuitState.HALF_OPEN;
+    }
+
+    public int getFailureThreshold() {
+        return failureThreshold;
+    }
+
+    public void setFailureThreshold(int failureThreshold) {
+        this.failureThreshold = failureThreshold;
+    }
+
+    public long getHalfOpenProbeIntervalMs() {
+        return halfOpenProbeIntervalMs;
+    }
+
+    public void setHalfOpenProbeIntervalMs(long halfOpenProbeIntervalMs) {
+        this.halfOpenProbeIntervalMs = halfOpenProbeIntervalMs;
+    }
+
+    public int getConsecutiveFailures() {
+        return consecutiveFailures.get();
+    }
+
+    /** Reset to initial CLOSED state (for testing / reconfiguration). */
+    public void reset() {
+        state = CircuitState.CLOSED;
+        consecutiveFailures.set(0);
+        lastOpenedAt.set(0);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMFallbackResponseProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMFallbackResponseProcessor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Processes LLMResponseSignal on LLMFallbackNeuron.
+ * A successful response means the LLM is healthy — records success with the
+ * circuit breaker and forwards the signal downstream unchanged.
+ */
+public class LLMFallbackResponseProcessor implements ISignalProcessor<LLMResponseSignal, LLMFallbackNeuron> {
+
+    private static final Logger logger = LogManager.getLogger(LLMFallbackResponseProcessor.class);
+    private static final String DESCRIPTION = "Records LLM success and resets circuit breaker on healthy response";
+
+    private final LLMFallbackNeuron fallbackNeuron;
+
+    public LLMFallbackResponseProcessor(LLMFallbackNeuron fallbackNeuron) {
+        this.fallbackNeuron = fallbackNeuron;
+    }
+
+    @Override
+    public <I extends ISignal> List<I> process(LLMResponseSignal input, LLMFallbackNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || input.getValue() == null) {
+            logger.warn("LLMFallbackResponseProcessor received null signal or payload");
+            return out;
+        }
+        logger.debug("LLM healthy response received queryId={}", input.getValue().getQueryId());
+        fallbackNeuron.recordSuccess();
+        @SuppressWarnings("unchecked")
+        I copy = (I) input.copySignal();
+        out.add(copy);
+        return out;
+    }
+
+    @Override
+    public String getDescription() {
+        return DESCRIPTION;
+    }
+
+    @Override
+    public Boolean hasMerger() {
+        return false;
+    }
+
+    @Override
+    public Class<? extends ISignalProcessor> getSignalProcessorClass() {
+        return LLMFallbackResponseProcessor.class;
+    }
+
+    @Override
+    public Class<LLMFallbackNeuron> getNeuronClass() {
+        return LLMFallbackNeuron.class;
+    }
+
+    @Override
+    public Class<LLMResponseSignal> getSignalClass() {
+        return LLMResponseSignal.class;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMKnowledgeNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMKnowledgeNeuron.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.Neuron;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Neuron in Layer 3 that manages the LLM integration.
+ * Maintains a bounded response cache, dispatches async HTTP queries,
+ * and emits LLMResponseSignal or LLMTimeoutSignal depending on outcome.
+ *
+ * <p>Design constraints:
+ * <ul>
+ *   <li>All HTTP calls are non-blocking (CompletableFuture).</li>
+ *   <li>Cached responses have a configurable TTL.</li>
+ *   <li>Integration is disabled by default; enable via LLMConfig.</li>
+ * </ul>
+ */
+public class LLMKnowledgeNeuron extends Neuron implements ILLMCapable {
+
+    private static final Logger logger = LogManager.getLogger(LLMKnowledgeNeuron.class);
+    private static final int MAX_CACHE_SIZE = 256;
+
+    private LLMConfig config;
+    private String llmEndpoint;
+    private long maxLatencyMs;
+
+    /** Simple bounded LRU cache: queryId → response signal. */
+    private final Map<String, LLMResponseSignal> responseCache =
+            new LinkedHashMap<>(MAX_CACHE_SIZE, 0.75f, true) {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<String, LLMResponseSignal> eldest) {
+                    return size() > MAX_CACHE_SIZE;
+                }
+            };
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+
+    public LLMKnowledgeNeuron(Long id, ISignalChain signalChain, Long run, LLMConfig config) {
+        super(id, signalChain, run);
+        this.config = config;
+        this.llmEndpoint = config.getEndpoint();
+        this.maxLatencyMs = config.getMaxLatencyMs();
+        this.currentNeuronClass = LLMKnowledgeNeuron.class;
+        this.addSignalProcessor(LLMQuerySignal.class, new LLMQueryProcessor());
+        this.addSignalProcessor(LLMResponseSignal.class, new LLMResponseProcessor());
+    }
+
+    @Override
+    public void submitQuery(LLMQuerySignal query) {
+        if (!isLLMAvailable()) {
+            logger.warn("LLM not available — emitting timeout for queryId={}", query.getValue().getQueryId());
+            LLMTimeoutItem item = new LLMTimeoutItem(query.getValue().getQueryId(), 0, "LLM disabled or unavailable");
+            LLMTimeoutSignal timeout = new LLMTimeoutSignal(item, query.getSourceLayerId(),
+                    query.getSourceNeuronId(), query.getTimeAlive(), "llm-timeout",
+                    false, query.getInputName(), false, false, "llm-timeout");
+            result.add(timeout);
+            return;
+        }
+
+        long startMs = System.currentTimeMillis();
+        String requestBody = buildRequestBody(query.getValue());
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(llmEndpoint + "/api/generate"))
+                .timeout(Duration.ofMillis(maxLatencyMs))
+                .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + config.getApiKey())
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .build();
+
+        CompletableFuture<HttpResponse<String>> future =
+                httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString());
+
+        future.whenComplete((response, ex) -> {
+            long elapsed = System.currentTimeMillis() - startMs;
+            String queryId = query.getValue().getQueryId();
+            if (ex != null || elapsed > maxLatencyMs) {
+                logger.warn("LLM query timeout or error for queryId={}, elapsed={}ms", queryId, elapsed);
+                LLMTimeoutItem item = new LLMTimeoutItem(queryId, elapsed,
+                        ex != null ? ex.getMessage() : "exceeded maxLatencyMs");
+                LLMTimeoutSignal timeout = new LLMTimeoutSignal(item, query.getSourceLayerId(),
+                        query.getSourceNeuronId(), query.getTimeAlive(), "llm-timeout",
+                        false, query.getInputName(), false, false, "llm-timeout");
+                result.add(timeout);
+            } else {
+                String responseText = extractResponseText(response.body());
+                LLMResponseItem respItem = new LLMResponseItem(queryId, responseText, 0.5);
+                LLMResponseSignal respSignal = new LLMResponseSignal(respItem, query.getSourceLayerId(),
+                        query.getSourceNeuronId(), query.getTimeAlive(), "llm-response",
+                        false, query.getInputName(), false, false, "llm-response");
+                synchronized (responseCache) {
+                    responseCache.put(queryId, respSignal);
+                }
+                result.add(respSignal);
+            }
+        });
+    }
+
+    @Override
+    public Optional<LLMResponseSignal> getCachedResponse(String queryId) {
+        synchronized (responseCache) {
+            return Optional.ofNullable(responseCache.get(queryId));
+        }
+    }
+
+    @Override
+    public boolean isLLMAvailable() {
+        return config != null && config.isEnabled();
+    }
+
+    @Override
+    public void setLLMEndpoint(String endpoint) {
+        this.llmEndpoint = endpoint;
+        if (this.config != null) {
+            this.config.setEndpoint(endpoint);
+        }
+    }
+
+    @Override
+    public void setMaxLatency(long milliseconds) {
+        this.maxLatencyMs = milliseconds;
+        if (this.config != null) {
+            this.config.setMaxLatencyMs(milliseconds);
+        }
+    }
+
+    public LLMConfig getConfig() {
+        return config;
+    }
+
+    public void setConfig(LLMConfig config) {
+        this.config = config;
+        this.llmEndpoint = config.getEndpoint();
+        this.maxLatencyMs = config.getMaxLatencyMs();
+    }
+
+    private String buildRequestBody(LLMQueryItem query) {
+        return "{\"model\":\"" + escape(config.getModel()) + "\","
+                + "\"prompt\":\"" + escape(query.getQueryText()) + "\","
+                + "\"context\":\"" + escape(query.getContext()) + "\","
+                + "\"stream\":false}";
+    }
+
+    private String extractResponseText(String body) {
+        // Minimal extraction: look for "response":"..." in the JSON body.
+        // Avoids adding a new JSON dependency; full parsing handled by caller if needed.
+        int idx = body.indexOf("\"response\":");
+        if (idx < 0) {
+            return body;
+        }
+        int start = body.indexOf('"', idx + 11);
+        if (start < 0) {
+            return body;
+        }
+        int end = body.indexOf('"', start + 1);
+        if (end < 0) {
+            return body;
+        }
+        return body.substring(start + 1, end);
+    }
+
+    private String escape(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n");
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMQueryItem.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMQueryItem.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+/**
+ * Payload for LLMQuerySignal.
+ * Carries the query text, context snapshot, priority, and a unique query identifier.
+ * Slow loop only (epoch 2) — never block fast-loop sensorimotor processing.
+ */
+public class LLMQueryItem {
+
+    private String queryId;
+    private String queryText;
+    private String context;
+    /** Higher value = higher priority. */
+    private int priority;
+
+    public LLMQueryItem() {
+    }
+
+    public LLMQueryItem(String queryId, String queryText, String context, int priority) {
+        this.queryId = queryId;
+        this.queryText = queryText;
+        this.context = context;
+        this.priority = priority;
+    }
+
+    public String getQueryId() {
+        return queryId;
+    }
+
+    public void setQueryId(String queryId) {
+        this.queryId = queryId;
+    }
+
+    public String getQueryText() {
+        return queryText;
+    }
+
+    public void setQueryText(String queryText) {
+        this.queryText = queryText;
+    }
+
+    public String getContext() {
+        return context;
+    }
+
+    public void setContext(String context) {
+        this.context = context;
+    }
+
+    public int getPriority() {
+        return priority;
+    }
+
+    public void setPriority(int priority) {
+        this.priority = priority;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMQueryProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMQueryProcessor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Processes LLMQuerySignal on ILLMCapable neurons.
+ * Dispatches the query asynchronously; the neuron collects the response signals internally.
+ * Returns an empty list — results appear later via CompletableFuture.
+ */
+public class LLMQueryProcessor implements ISignalProcessor<LLMQuerySignal, ILLMCapable> {
+
+    private static final Logger logger = LogManager.getLogger(LLMQueryProcessor.class);
+    private static final String DESCRIPTION = "Async LLM query dispatcher — slow loop, epoch 2";
+
+    @Override
+    public <I extends ISignal> List<I> process(LLMQuerySignal input, ILLMCapable neuron) {
+        if (input == null || input.getValue() == null) {
+            logger.warn("LLMQueryProcessor received null signal or payload");
+            return new LinkedList<>();
+        }
+        logger.debug("Dispatching LLM query queryId={} priority={}",
+                input.getValue().getQueryId(), input.getValue().getPriority());
+        neuron.submitQuery(input);
+        return new LinkedList<>();
+    }
+
+    @Override
+    public String getDescription() {
+        return DESCRIPTION;
+    }
+
+    @Override
+    public Boolean hasMerger() {
+        return false;
+    }
+
+    @Override
+    public Class<? extends ISignalProcessor> getSignalProcessorClass() {
+        return LLMQueryProcessor.class;
+    }
+
+    @Override
+    public Class<ILLMCapable> getNeuronClass() {
+        return ILLMCapable.class;
+    }
+
+    @Override
+    public Class<LLMQuerySignal> getSignalClass() {
+        return LLMQuerySignal.class;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMQuerySignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMQuerySignal.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Signal that dispatches an advisory query to the LLM endpoint.
+ * Slow loop, epoch 2 — never runs on the fast sensorimotor loop.
+ * Set loop=2 and epoch=2 on instances before injecting into the network.
+ */
+public class LLMQuerySignal extends AbstractSignal<LLMQueryItem> implements ISignal<LLMQueryItem> {
+
+    public LLMQuerySignal(LLMQueryItem value, Integer sourceLayer, Long sourceNeuron,
+                          Integer timeAlive, String description, boolean fromExternalNet,
+                          String inputName, boolean needToRemoveDuringLearning,
+                          boolean needToProcessDuringLearning, String name) {
+        super(value, sourceLayer, sourceNeuron, timeAlive, description, fromExternalNet,
+                inputName, needToRemoveDuringLearning, needToProcessDuringLearning,
+                name, LLMQuerySignal.class.getCanonicalName());
+        this.loop = 2;
+        this.epoch = 2L;
+    }
+
+    @Override
+    public Class<? extends ISignal<LLMQueryItem>> getCurrentSignalClass() {
+        return LLMQuerySignal.class;
+    }
+
+    @Override
+    public Class<LLMQueryItem> getParamClass() {
+        return LLMQueryItem.class;
+    }
+
+    @Override
+    public LLMQuerySignal copySignal() {
+        return new LLMQuerySignal(value, this.getSourceLayerId(), this.getSourceNeuronId(),
+                this.getTimeAlive(), getDescription(), isFromExternalNet(), getInputName(),
+                this.isNeedToRemoveDuringLearning(), this.isNeedToProcessDuringLearning(),
+                this.getName());
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMResponseItem.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMResponseItem.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+/**
+ * Payload for LLMResponseSignal.
+ * Carries the raw LLM response, the originating query id, and an initial confidence score.
+ * Responses are UNTRUSTED until cross-validated by LLMVerificationNeuron.
+ */
+public class LLMResponseItem {
+
+    private String queryId;
+    private String responseText;
+    /** Raw confidence score from 0.0 to 1.0 — not yet verified. */
+    private double rawConfidence;
+
+    public LLMResponseItem() {
+    }
+
+    public LLMResponseItem(String queryId, String responseText, double rawConfidence) {
+        this.queryId = queryId;
+        this.responseText = responseText;
+        this.rawConfidence = rawConfidence;
+    }
+
+    public String getQueryId() {
+        return queryId;
+    }
+
+    public void setQueryId(String queryId) {
+        this.queryId = queryId;
+    }
+
+    public String getResponseText() {
+        return responseText;
+    }
+
+    public void setResponseText(String responseText) {
+        this.responseText = responseText;
+    }
+
+    public double getRawConfidence() {
+        return rawConfidence;
+    }
+
+    public void setRawConfidence(double rawConfidence) {
+        this.rawConfidence = rawConfidence;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMResponseProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMResponseProcessor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.INeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Processes a raw LLMResponseSignal on any INeuron.
+ * Passes the response downstream for verification (to LLMVerificationNeuron).
+ * Responses enter WorkingMemory with reduced TTL — never LongTermMemory directly.
+ *
+ * <p>Returning the signal as-is forwards it to the next layer via Axon routing.
+ */
+public class LLMResponseProcessor implements ISignalProcessor<LLMResponseSignal, INeuron> {
+
+    private static final Logger logger = LogManager.getLogger(LLMResponseProcessor.class);
+    private static final String DESCRIPTION = "LLM response forwarder — routes raw response to verification layer";
+
+    @Override
+    public <I extends ISignal> List<I> process(LLMResponseSignal input, INeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || input.getValue() == null) {
+            logger.warn("LLMResponseProcessor received null signal or payload");
+            return out;
+        }
+        logger.debug("Forwarding LLM response queryId={} rawConfidence={}",
+                input.getValue().getQueryId(), input.getValue().getRawConfidence());
+        // Pass a copy so upstream state is not mutated during routing
+        @SuppressWarnings("unchecked")
+        I copy = (I) input.copySignal();
+        out.add(copy);
+        return out;
+    }
+
+    @Override
+    public String getDescription() {
+        return DESCRIPTION;
+    }
+
+    @Override
+    public Boolean hasMerger() {
+        return false;
+    }
+
+    @Override
+    public Class<? extends ISignalProcessor> getSignalProcessorClass() {
+        return LLMResponseProcessor.class;
+    }
+
+    @Override
+    public Class<INeuron> getNeuronClass() {
+        return INeuron.class;
+    }
+
+    @Override
+    public Class<LLMResponseSignal> getSignalClass() {
+        return LLMResponseSignal.class;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMResponseSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMResponseSignal.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Signal carrying a raw (unverified) LLM response back to the network.
+ * Slow loop, epoch 2. Must be routed through LLMVerificationNeuron before use.
+ */
+public class LLMResponseSignal extends AbstractSignal<LLMResponseItem> implements ISignal<LLMResponseItem> {
+
+    public LLMResponseSignal(LLMResponseItem value, Integer sourceLayer, Long sourceNeuron,
+                             Integer timeAlive, String description, boolean fromExternalNet,
+                             String inputName, boolean needToRemoveDuringLearning,
+                             boolean needToProcessDuringLearning, String name) {
+        super(value, sourceLayer, sourceNeuron, timeAlive, description, fromExternalNet,
+                inputName, needToRemoveDuringLearning, needToProcessDuringLearning,
+                name, LLMResponseSignal.class.getCanonicalName());
+        this.loop = 2;
+        this.epoch = 2L;
+    }
+
+    @Override
+    public Class<? extends ISignal<LLMResponseItem>> getCurrentSignalClass() {
+        return LLMResponseSignal.class;
+    }
+
+    @Override
+    public Class<LLMResponseItem> getParamClass() {
+        return LLMResponseItem.class;
+    }
+
+    @Override
+    public LLMResponseSignal copySignal() {
+        return new LLMResponseSignal(value, this.getSourceLayerId(), this.getSourceNeuronId(),
+                this.getTimeAlive(), getDescription(), isFromExternalNet(), getInputName(),
+                this.isNeedToRemoveDuringLearning(), this.isNeedToProcessDuringLearning(),
+                this.getName());
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMTimeoutItem.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMTimeoutItem.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+/**
+ * Payload for LLMTimeoutSignal.
+ * Triggers fallback to internal knowledge when the LLM endpoint is unavailable or too slow.
+ * Fast loop (epoch 1) so the fallback is initiated without delay.
+ */
+public class LLMTimeoutItem {
+
+    private String queryId;
+    private long elapsedMs;
+    private String reason;
+
+    public LLMTimeoutItem() {
+    }
+
+    public LLMTimeoutItem(String queryId, long elapsedMs, String reason) {
+        this.queryId = queryId;
+        this.elapsedMs = elapsedMs;
+        this.reason = reason;
+    }
+
+    public String getQueryId() {
+        return queryId;
+    }
+
+    public void setQueryId(String queryId) {
+        this.queryId = queryId;
+    }
+
+    public long getElapsedMs() {
+        return elapsedMs;
+    }
+
+    public void setElapsedMs(long elapsedMs) {
+        this.elapsedMs = elapsedMs;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public void setReason(String reason) {
+        this.reason = reason;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMTimeoutProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMTimeoutProcessor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Processes LLMTimeoutSignal on LLMFallbackNeuron.
+ * Records the failure with the circuit breaker and returns the timeout
+ * signal downstream so that consumers can activate fallback logic.
+ */
+public class LLMTimeoutProcessor implements ISignalProcessor<LLMTimeoutSignal, LLMFallbackNeuron> {
+
+    private static final Logger logger = LogManager.getLogger(LLMTimeoutProcessor.class);
+    private static final String DESCRIPTION = "Records LLM timeout and updates circuit breaker state";
+
+    private final LLMFallbackNeuron fallbackNeuron;
+
+    public LLMTimeoutProcessor(LLMFallbackNeuron fallbackNeuron) {
+        this.fallbackNeuron = fallbackNeuron;
+    }
+
+    @Override
+    public <I extends ISignal> List<I> process(LLMTimeoutSignal input, LLMFallbackNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || input.getValue() == null) {
+            logger.warn("LLMTimeoutProcessor received null signal or payload");
+            return out;
+        }
+        logger.warn("LLM timeout recorded queryId={} elapsed={}ms reason={}",
+                input.getValue().getQueryId(),
+                input.getValue().getElapsedMs(),
+                input.getValue().getReason());
+        fallbackNeuron.recordFailure();
+        @SuppressWarnings("unchecked")
+        I copy = (I) input.copySignal();
+        out.add(copy);
+        return out;
+    }
+
+    @Override
+    public String getDescription() {
+        return DESCRIPTION;
+    }
+
+    @Override
+    public Boolean hasMerger() {
+        return false;
+    }
+
+    @Override
+    public Class<? extends ISignalProcessor> getSignalProcessorClass() {
+        return LLMTimeoutProcessor.class;
+    }
+
+    @Override
+    public Class<LLMFallbackNeuron> getNeuronClass() {
+        return LLMFallbackNeuron.class;
+    }
+
+    @Override
+    public Class<LLMTimeoutSignal> getSignalClass() {
+        return LLMTimeoutSignal.class;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMTimeoutSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMTimeoutSignal.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Signal that triggers fallback to internal knowledge when the LLM is unavailable or too slow.
+ * Fast loop, epoch 1 — must be detected and acted on immediately.
+ */
+public class LLMTimeoutSignal extends AbstractSignal<LLMTimeoutItem> implements ISignal<LLMTimeoutItem> {
+
+    public LLMTimeoutSignal(LLMTimeoutItem value, Integer sourceLayer, Long sourceNeuron,
+                            Integer timeAlive, String description, boolean fromExternalNet,
+                            String inputName, boolean needToRemoveDuringLearning,
+                            boolean needToProcessDuringLearning, String name) {
+        super(value, sourceLayer, sourceNeuron, timeAlive, description, fromExternalNet,
+                inputName, needToRemoveDuringLearning, needToProcessDuringLearning,
+                name, LLMTimeoutSignal.class.getCanonicalName());
+        this.loop = 1;
+        this.epoch = 1L;
+    }
+
+    @Override
+    public Class<? extends ISignal<LLMTimeoutItem>> getCurrentSignalClass() {
+        return LLMTimeoutSignal.class;
+    }
+
+    @Override
+    public Class<LLMTimeoutItem> getParamClass() {
+        return LLMTimeoutItem.class;
+    }
+
+    @Override
+    public LLMTimeoutSignal copySignal() {
+        return new LLMTimeoutSignal(value, this.getSourceLayerId(), this.getSourceNeuronId(),
+                this.getTimeAlive(), getDescription(), isFromExternalNet(), getInputName(),
+                this.isNeedToRemoveDuringLearning(), this.isNeedToProcessDuringLearning(),
+                this.getName());
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMVerificationNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMVerificationNeuron.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.Neuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Trust boundary neuron (Layer 3).
+ * Receives raw LLMResponseSignal, cross-validates content against internal models,
+ * and emits LLMConfidenceSignal with a verified confidence score and applicability verdict.
+ *
+ * <p>Verification strategy:
+ * <ol>
+ *   <li>Null/empty response → not applicable, confidence=0.</li>
+ *   <li>Response length heuristic (too short or suspiciously long) → reduced confidence.</li>
+ *   <li>Custom validators registered via {@link #addValidator(LLMResponseValidator)}.</li>
+ * </ol>
+ *
+ * <p>Verified info enters WorkingMemory with a reduced TTL — never LongTermMemory directly.
+ */
+public class LLMVerificationNeuron extends Neuron {
+
+    private static final Logger logger = LogManager.getLogger(LLMVerificationNeuron.class);
+
+    /** Pluggable cross-validation rules. */
+    private final List<LLMResponseValidator> validators = new ArrayList<>();
+
+    /** Minimum confidence threshold to consider a response applicable. */
+    private double applicabilityThreshold = 0.5;
+
+    public LLMVerificationNeuron(Long id, ISignalChain signalChain, Long run) {
+        super(id, signalChain, run);
+        this.currentNeuronClass = LLMVerificationNeuron.class;
+        this.addSignalProcessor(LLMResponseSignal.class, new LLMVerificationProcessor(this));
+    }
+
+    /**
+     * Verifies a raw LLM response and produces a LLMConfidenceSignal.
+     *
+     * @param responseSignal the raw response to validate
+     * @return confidence signal with verdict
+     */
+    public LLMConfidenceSignal verify(LLMResponseSignal responseSignal) {
+        LLMResponseItem item = responseSignal.getValue();
+
+        if (item == null || item.getResponseText() == null || item.getResponseText().isBlank()) {
+            logger.warn("LLM response is null/blank for queryId={}", item != null ? item.getQueryId() : "unknown");
+            return buildConfidenceSignal(responseSignal, 0.0, false, "null or blank response");
+        }
+
+        double confidence = item.getRawConfidence();
+
+        // Length heuristic
+        int len = item.getResponseText().length();
+        if (len < 10) {
+            confidence *= 0.3;
+        } else if (len > 10_000) {
+            confidence *= 0.7;
+        }
+
+        // Custom validators
+        for (LLMResponseValidator validator : validators) {
+            confidence = validator.validate(item, confidence);
+        }
+
+        confidence = Math.max(0.0, Math.min(1.0, confidence));
+        boolean applicable = confidence >= applicabilityThreshold;
+
+        logger.debug("Verified LLM response queryId={} confidence={} applicable={}",
+                item.getQueryId(), confidence, applicable);
+
+        return buildConfidenceSignal(responseSignal, confidence, applicable,
+                applicable ? "passed verification" : "below applicability threshold");
+    }
+
+    private LLMConfidenceSignal buildConfidenceSignal(LLMResponseSignal source,
+                                                       double confidence,
+                                                       boolean applicable,
+                                                       String note) {
+        LLMResponseItem src = source.getValue();
+        String queryId = src != null ? src.getQueryId() : "unknown";
+        LLMConfidenceItem ci = new LLMConfidenceItem(queryId, confidence, applicable, note);
+        return new LLMConfidenceSignal(ci, source.getSourceLayerId(), source.getSourceNeuronId(),
+                source.getTimeAlive(), "llm-confidence", false, source.getInputName(),
+                false, false, "llm-confidence-" + queryId);
+    }
+
+    public void addValidator(LLMResponseValidator validator) {
+        validators.add(validator);
+    }
+
+    public double getApplicabilityThreshold() {
+        return applicabilityThreshold;
+    }
+
+    public void setApplicabilityThreshold(double applicabilityThreshold) {
+        this.applicabilityThreshold = applicabilityThreshold;
+    }
+
+    /**
+     * Functional interface for pluggable validation rules.
+     */
+    @FunctionalInterface
+    public interface LLMResponseValidator {
+        /**
+         * Inspect the response and adjust the confidence score.
+         *
+         * @param item       the response payload
+         * @param confidence current running confidence (0.0–1.0)
+         * @return adjusted confidence (must stay in [0.0, 1.0])
+         */
+        double validate(LLMResponseItem item, double confidence);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMVerificationProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMVerificationProcessor.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024. Rakovskyi Dmytro
+ */
+
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Internal processor used by LLMVerificationNeuron.
+ * Delegates to {@link LLMVerificationNeuron#verify(LLMResponseSignal)} and emits
+ * a LLMConfidenceSignal for downstream consumption.
+ */
+public class LLMVerificationProcessor implements ISignalProcessor<LLMResponseSignal, LLMVerificationNeuron> {
+
+    private static final Logger logger = LogManager.getLogger(LLMVerificationProcessor.class);
+    private static final String DESCRIPTION = "Cross-validates raw LLM responses and emits confidence signals";
+
+    private final LLMVerificationNeuron verificationNeuron;
+
+    public LLMVerificationProcessor(LLMVerificationNeuron verificationNeuron) {
+        this.verificationNeuron = verificationNeuron;
+    }
+
+    @Override
+    public <I extends ISignal> List<I> process(LLMResponseSignal input, LLMVerificationNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || input.getValue() == null) {
+            logger.warn("LLMVerificationProcessor received null signal or payload");
+            return out;
+        }
+        LLMConfidenceSignal confidence = verificationNeuron.verify(input);
+        @SuppressWarnings("unchecked")
+        I cs = (I) confidence;
+        out.add(cs);
+        return out;
+    }
+
+    @Override
+    public String getDescription() {
+        return DESCRIPTION;
+    }
+
+    @Override
+    public Boolean hasMerger() {
+        return false;
+    }
+
+    @Override
+    public Class<? extends ISignalProcessor> getSignalProcessorClass() {
+        return LLMVerificationProcessor.class;
+    }
+
+    @Override
+    public Class<LLMVerificationNeuron> getNeuronClass() {
+        return LLMVerificationNeuron.class;
+    }
+
+    @Override
+    public Class<LLMResponseSignal> getSignalClass() {
+        return LLMResponseSignal.class;
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMIntegrationTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMIntegrationTest.java
@@ -1,0 +1,453 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.llm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class LLMIntegrationTest {
+
+    private ISignalChain mockChain;
+
+    @BeforeEach
+    void setUp() {
+        mockChain = mock(ISignalChain.class);
+        when(mockChain.getProcessingChain()).thenReturn(List.of());
+        when(mockChain.getDescription()).thenReturn("test");
+    }
+
+    // ── LLMConfig ─────────────────────────────────────────────────────────────
+
+    @Test
+    void llmConfig_defaultsAreDisabled() {
+        LLMConfig cfg = new LLMConfig();
+        assertFalse(cfg.isEnabled());
+        assertEquals("http://localhost:11434", cfg.getEndpoint());
+        assertEquals(5000, cfg.getMaxLatencyMs());
+        assertEquals(300, cfg.getCacheTtlSeconds());
+        assertEquals("llama3", cfg.getModel());
+        assertEquals(5, cfg.getCircuitBreakerFailureThreshold());
+        assertEquals(30000, cfg.getCircuitBreakerHalfOpenProbeIntervalMs());
+    }
+
+    @Test
+    void llmConfig_settersWork() {
+        LLMConfig cfg = new LLMConfig();
+        cfg.setEnabled(true);
+        cfg.setEndpoint("http://example.com");
+        cfg.setApiKey("key");
+        cfg.setMaxLatencyMs(2000);
+        cfg.setCacheTtlSeconds(60);
+        cfg.setModel("gpt4");
+        cfg.setCircuitBreakerFailureThreshold(3);
+        cfg.setCircuitBreakerHalfOpenProbeIntervalMs(10000);
+
+        assertTrue(cfg.isEnabled());
+        assertEquals("http://example.com", cfg.getEndpoint());
+        assertEquals("key", cfg.getApiKey());
+        assertEquals(2000, cfg.getMaxLatencyMs());
+        assertEquals(60, cfg.getCacheTtlSeconds());
+        assertEquals("gpt4", cfg.getModel());
+        assertEquals(3, cfg.getCircuitBreakerFailureThreshold());
+        assertEquals(10000, cfg.getCircuitBreakerHalfOpenProbeIntervalMs());
+    }
+
+    // ── Payload classes ───────────────────────────────────────────────────────
+
+    @Test
+    void llmQueryItem_gettersAndSetters() {
+        LLMQueryItem item = new LLMQueryItem("q1", "What is X?", "ctx", 5);
+        assertEquals("q1", item.getQueryId());
+        assertEquals("What is X?", item.getQueryText());
+        assertEquals("ctx", item.getContext());
+        assertEquals(5, item.getPriority());
+
+        item.setQueryId("q2");
+        item.setQueryText("Why?");
+        item.setContext("ctx2");
+        item.setPriority(10);
+        assertEquals("q2", item.getQueryId());
+        assertEquals("Why?", item.getQueryText());
+        assertEquals("ctx2", item.getContext());
+        assertEquals(10, item.getPriority());
+    }
+
+    @Test
+    void llmResponseItem_gettersAndSetters() {
+        LLMResponseItem item = new LLMResponseItem("q1", "answer", 0.8);
+        assertEquals("q1", item.getQueryId());
+        assertEquals("answer", item.getResponseText());
+        assertEquals(0.8, item.getRawConfidence(), 1e-9);
+
+        item.setQueryId("q2");
+        item.setResponseText("other");
+        item.setRawConfidence(0.3);
+        assertEquals("q2", item.getQueryId());
+        assertEquals("other", item.getResponseText());
+        assertEquals(0.3, item.getRawConfidence(), 1e-9);
+    }
+
+    @Test
+    void llmConfidenceItem_gettersAndSetters() {
+        LLMConfidenceItem item = new LLMConfidenceItem("q1", 0.9, true, "ok");
+        assertEquals("q1", item.getQueryId());
+        assertEquals(0.9, item.getVerifiedConfidence(), 1e-9);
+        assertTrue(item.isApplicable());
+        assertEquals("ok", item.getVerificationNote());
+
+        item.setQueryId("q2");
+        item.setVerifiedConfidence(0.2);
+        item.setApplicable(false);
+        item.setVerificationNote("failed");
+        assertEquals("q2", item.getQueryId());
+        assertEquals(0.2, item.getVerifiedConfidence(), 1e-9);
+        assertFalse(item.isApplicable());
+        assertEquals("failed", item.getVerificationNote());
+    }
+
+    @Test
+    void llmTimeoutItem_gettersAndSetters() {
+        LLMTimeoutItem item = new LLMTimeoutItem("q1", 5500L, "exceeded");
+        assertEquals("q1", item.getQueryId());
+        assertEquals(5500L, item.getElapsedMs());
+        assertEquals("exceeded", item.getReason());
+
+        item.setQueryId("q2");
+        item.setElapsedMs(1000L);
+        item.setReason("disabled");
+        assertEquals("q2", item.getQueryId());
+        assertEquals(1000L, item.getElapsedMs());
+        assertEquals("disabled", item.getReason());
+    }
+
+    // ── Signals ───────────────────────────────────────────────────────────────
+
+    @Test
+    void llmQuerySignal_loopAndEpoch() {
+        LLMQuerySignal s = new LLMQuerySignal(new LLMQueryItem("q1", "text", "ctx", 1),
+                0, 0L, 3, "desc", false, "in", false, false, "name");
+        assertEquals(2, s.getLoop());
+        assertEquals(2L, s.getEpoch());
+        assertEquals(LLMQuerySignal.class, s.getCurrentSignalClass());
+        assertEquals(LLMQueryItem.class, s.getParamClass());
+    }
+
+    @Test
+    void llmQuerySignal_copySignal_preservesName() {
+        LLMQuerySignal s = new LLMQuerySignal(new LLMQueryItem("q1", "x", "c", 2),
+                1, 10L, 5, "d", true, "inp", false, true, "myName");
+        LLMQuerySignal copy = s.copySignal();
+        assertEquals("myName", copy.getName());
+        assertEquals("q1", copy.getValue().getQueryId());
+        assertEquals(2, copy.getLoop());
+    }
+
+    @Test
+    void llmResponseSignal_loopAndEpoch() {
+        LLMResponseSignal s = new LLMResponseSignal(new LLMResponseItem("q1", "ans", 0.7),
+                0, 0L, 3, "desc", false, "in", false, false, "rname");
+        assertEquals(2, s.getLoop());
+        assertEquals(2L, s.getEpoch());
+        assertEquals(LLMResponseSignal.class, s.getCurrentSignalClass());
+        assertEquals(LLMResponseItem.class, s.getParamClass());
+    }
+
+    @Test
+    void llmResponseSignal_copySignal_preservesName() {
+        LLMResponseSignal s = new LLMResponseSignal(new LLMResponseItem("q2", "resp", 0.6),
+                0, 0L, 1, "", false, "", false, false, "rn");
+        LLMResponseSignal copy = s.copySignal();
+        assertEquals("rn", copy.getName());
+        assertEquals("q2", copy.getValue().getQueryId());
+    }
+
+    @Test
+    void llmConfidenceSignal_loopAndEpoch() {
+        LLMConfidenceSignal s = new LLMConfidenceSignal(new LLMConfidenceItem("q1", 0.9, true, "ok"),
+                0, 0L, 2, "desc", false, "in", false, false, "cn");
+        assertEquals(2, s.getLoop());
+        assertEquals(3L, s.getEpoch());
+        assertEquals(LLMConfidenceSignal.class, s.getCurrentSignalClass());
+        assertEquals(LLMConfidenceItem.class, s.getParamClass());
+    }
+
+    @Test
+    void llmTimeoutSignal_loopAndEpoch() {
+        LLMTimeoutSignal s = new LLMTimeoutSignal(new LLMTimeoutItem("q1", 6000L, "timeout"),
+                0, 0L, 1, "desc", false, "in", false, false, "tn");
+        assertEquals(1, s.getLoop());
+        assertEquals(1L, s.getEpoch());
+        assertEquals(LLMTimeoutSignal.class, s.getCurrentSignalClass());
+        assertEquals(LLMTimeoutItem.class, s.getParamClass());
+    }
+
+    @Test
+    void llmTimeoutSignal_copySignal_preservesName() {
+        LLMTimeoutSignal s = new LLMTimeoutSignal(new LLMTimeoutItem("q3", 1000L, "r"),
+                0, 0L, 1, "", false, "", false, false, "tname");
+        LLMTimeoutSignal copy = s.copySignal();
+        assertEquals("tname", copy.getName());
+        assertEquals("q3", copy.getValue().getQueryId());
+    }
+
+    // ── LLMFallbackNeuron — circuit breaker ───────────────────────────────────
+
+    @Test
+    void fallbackNeuron_initialStateClosed() {
+        LLMFallbackNeuron n = new LLMFallbackNeuron(1L, mockChain, 1L, 5, 30000);
+        assertEquals(LLMFallbackNeuron.CircuitState.CLOSED, n.getState());
+        assertTrue(n.isLLMCallAllowed());
+    }
+
+    @Test
+    void fallbackNeuron_opensAfterThresholdFailures() {
+        LLMFallbackNeuron n = new LLMFallbackNeuron(1L, mockChain, 1L, 3, 30000);
+        n.recordFailure();
+        n.recordFailure();
+        assertEquals(LLMFallbackNeuron.CircuitState.CLOSED, n.getState());
+        n.recordFailure();
+        assertEquals(LLMFallbackNeuron.CircuitState.OPEN, n.getState());
+        assertFalse(n.isLLMCallAllowed());
+    }
+
+    @Test
+    void fallbackNeuron_successResetsClosed() {
+        LLMFallbackNeuron n = new LLMFallbackNeuron(1L, mockChain, 1L, 2, 30000);
+        n.recordFailure();
+        assertEquals(1, n.getConsecutiveFailures());
+        n.recordSuccess();
+        assertEquals(0, n.getConsecutiveFailures());
+        assertEquals(LLMFallbackNeuron.CircuitState.CLOSED, n.getState());
+    }
+
+    @Test
+    void fallbackNeuron_halfOpenSuccessTransitionsToClosed() {
+        LLMFallbackNeuron n = new LLMFallbackNeuron(1L, mockChain, 1L, 1, 0);
+        n.recordFailure(); // → OPEN
+        assertEquals(LLMFallbackNeuron.CircuitState.OPEN, n.getState());
+        // probe interval = 0 → immediately transitions to HALF_OPEN on next getState()
+        assertEquals(LLMFallbackNeuron.CircuitState.HALF_OPEN, n.getState());
+        assertTrue(n.isLLMCallAllowed());
+        n.recordSuccess(); // HALF_OPEN → CLOSED
+        assertEquals(LLMFallbackNeuron.CircuitState.CLOSED, n.getState());
+    }
+
+    @Test
+    void fallbackNeuron_halfOpenFailureReopens() {
+        LLMFallbackNeuron n = new LLMFallbackNeuron(1L, mockChain, 1L, 1, 0);
+        n.recordFailure(); // CLOSED → OPEN
+        n.getState();      // OPEN → HALF_OPEN
+        n.recordFailure(); // HALF_OPEN → OPEN
+        assertEquals(LLMFallbackNeuron.CircuitState.OPEN, n.getState());
+    }
+
+    @Test
+    void fallbackNeuron_reset_restoresClosedState() {
+        LLMFallbackNeuron n = new LLMFallbackNeuron(1L, mockChain, 1L, 1, 30000);
+        n.recordFailure();
+        assertEquals(LLMFallbackNeuron.CircuitState.OPEN, n.getState());
+        n.reset();
+        assertEquals(LLMFallbackNeuron.CircuitState.CLOSED, n.getState());
+        assertEquals(0, n.getConsecutiveFailures());
+    }
+
+    // ── LLMVerificationNeuron ─────────────────────────────────────────────────
+
+    @Test
+    void verificationNeuron_nullResponseNotApplicable() {
+        LLMVerificationNeuron n = new LLMVerificationNeuron(1L, mockChain, 1L);
+        LLMResponseItem item = new LLMResponseItem("q1", null, 0.9);
+        LLMResponseSignal signal = new LLMResponseSignal(item, 0, 0L, 1, "", false, "", false, false, "r");
+        LLMConfidenceSignal cs = n.verify(signal);
+        assertFalse(cs.getValue().isApplicable());
+        assertEquals(0.0, cs.getValue().getVerifiedConfidence(), 1e-9);
+    }
+
+    @Test
+    void verificationNeuron_blankResponseNotApplicable() {
+        LLMVerificationNeuron n = new LLMVerificationNeuron(1L, mockChain, 1L);
+        LLMResponseItem item = new LLMResponseItem("q1", "   ", 0.9);
+        LLMResponseSignal signal = new LLMResponseSignal(item, 0, 0L, 1, "", false, "", false, false, "r");
+        LLMConfidenceSignal cs = n.verify(signal);
+        assertFalse(cs.getValue().isApplicable());
+    }
+
+    @Test
+    void verificationNeuron_highConfidenceResponse_isApplicable() {
+        LLMVerificationNeuron n = new LLMVerificationNeuron(1L, mockChain, 1L);
+        String longEnoughText = "This is a valid response with enough length.";
+        LLMResponseItem item = new LLMResponseItem("q1", longEnoughText, 0.9);
+        LLMResponseSignal signal = new LLMResponseSignal(item, 0, 0L, 1, "", false, "", false, false, "r");
+        LLMConfidenceSignal cs = n.verify(signal);
+        assertTrue(cs.getValue().isApplicable());
+        assertEquals("q1", cs.getValue().getQueryId());
+    }
+
+    @Test
+    void verificationNeuron_shortTextReducesConfidence() {
+        LLMVerificationNeuron n = new LLMVerificationNeuron(1L, mockChain, 1L);
+        n.setApplicabilityThreshold(0.4);
+        LLMResponseItem item = new LLMResponseItem("q1", "Hi", 1.0); // len=2 → * 0.3 = 0.3
+        LLMResponseSignal signal = new LLMResponseSignal(item, 0, 0L, 1, "", false, "", false, false, "r");
+        LLMConfidenceSignal cs = n.verify(signal);
+        assertEquals(0.3, cs.getValue().getVerifiedConfidence(), 1e-9);
+        assertFalse(cs.getValue().isApplicable()); // 0.3 < 0.4
+    }
+
+    @Test
+    void verificationNeuron_customValidatorAdjustsConfidence() {
+        LLMVerificationNeuron n = new LLMVerificationNeuron(1L, mockChain, 1L);
+        // validator halves the confidence
+        n.addValidator((item, conf) -> conf * 0.5);
+        String text = "Sufficiently long response text here.";
+        LLMResponseItem item = new LLMResponseItem("q1", text, 0.8);
+        LLMResponseSignal signal = new LLMResponseSignal(item, 0, 0L, 1, "", false, "", false, false, "r");
+        LLMConfidenceSignal cs = n.verify(signal);
+        assertEquals(0.4, cs.getValue().getVerifiedConfidence(), 1e-9);
+    }
+
+    @Test
+    void verificationNeuron_confidenceClampedTo1() {
+        LLMVerificationNeuron n = new LLMVerificationNeuron(1L, mockChain, 1L);
+        // validator tries to push > 1.0
+        n.addValidator((item, conf) -> 2.0);
+        LLMResponseItem item = new LLMResponseItem("q1", "Normal response text here.", 0.5);
+        LLMResponseSignal signal = new LLMResponseSignal(item, 0, 0L, 1, "", false, "", false, false, "r");
+        LLMConfidenceSignal cs = n.verify(signal);
+        assertEquals(1.0, cs.getValue().getVerifiedConfidence(), 1e-9);
+    }
+
+    // ── Processors ────────────────────────────────────────────────────────────
+
+    @Test
+    void llmQueryProcessor_metadata() {
+        LLMQueryProcessor p = new LLMQueryProcessor();
+        assertFalse(p.hasMerger());
+        assertEquals(LLMQueryProcessor.class, p.getSignalProcessorClass());
+        assertEquals(ILLMCapable.class, p.getNeuronClass());
+        assertEquals(LLMQuerySignal.class, p.getSignalClass());
+        assertNotNull(p.getDescription());
+    }
+
+    @Test
+    void llmQueryProcessor_nullInput_returnsEmptyList() {
+        LLMQueryProcessor p = new LLMQueryProcessor();
+        ILLMCapable neuron = mock(ILLMCapable.class);
+        List<?> result = p.process(null, neuron);
+        assertTrue(result.isEmpty());
+        verify(neuron, never()).submitQuery(any());
+    }
+
+    @Test
+    void llmQueryProcessor_validInput_callsSubmitQuery() {
+        LLMQueryProcessor p = new LLMQueryProcessor();
+        ILLMCapable neuron = mock(ILLMCapable.class);
+        LLMQuerySignal signal = new LLMQuerySignal(new LLMQueryItem("q1", "t", "c", 1),
+                0, 0L, 1, "", false, "", false, false, "n");
+        List<?> result = p.process(signal, neuron);
+        assertTrue(result.isEmpty());
+        verify(neuron).submitQuery(signal);
+    }
+
+    @Test
+    void llmResponseProcessor_metadata() {
+        LLMResponseProcessor p = new LLMResponseProcessor();
+        assertFalse(p.hasMerger());
+        assertEquals(LLMResponseProcessor.class, p.getSignalProcessorClass());
+        assertEquals(LLMResponseSignal.class, p.getSignalClass());
+        assertNotNull(p.getDescription());
+    }
+
+    @Test
+    void llmResponseProcessor_forwardsCopyOfSignal() {
+        LLMResponseProcessor p = new LLMResponseProcessor();
+        com.rakovpublic.jneuropallium.worker.net.neuron.INeuron neuron =
+                mock(com.rakovpublic.jneuropallium.worker.net.neuron.INeuron.class);
+        LLMResponseSignal signal = new LLMResponseSignal(new LLMResponseItem("q1", "resp", 0.7),
+                0, 0L, 1, "", false, "", false, false, "rn");
+        List<?> result = p.process(signal, neuron);
+        assertEquals(1, result.size());
+        LLMResponseSignal copy = (LLMResponseSignal) result.get(0);
+        assertEquals("q1", copy.getValue().getQueryId());
+        assertNotSame(signal, copy);
+    }
+
+    @Test
+    void llmTimeoutProcessor_recordsFailureAndForwardsSignal() {
+        LLMFallbackNeuron n = new LLMFallbackNeuron(1L, mockChain, 1L, 5, 30000);
+        LLMTimeoutProcessor p = new LLMTimeoutProcessor(n);
+        LLMTimeoutSignal signal = new LLMTimeoutSignal(new LLMTimeoutItem("q1", 6000L, "slow"),
+                0, 0L, 1, "", false, "", false, false, "tn");
+        List<?> result = p.process(signal, n);
+        assertEquals(1, result.size());
+        assertEquals(1, n.getConsecutiveFailures());
+    }
+
+    @Test
+    void llmFallbackResponseProcessor_recordsSuccessAndForwardsSignal() {
+        LLMFallbackNeuron n = new LLMFallbackNeuron(1L, mockChain, 1L, 5, 30000);
+        n.recordFailure(); // set 1 failure
+        LLMFallbackResponseProcessor p = new LLMFallbackResponseProcessor(n);
+        LLMResponseSignal signal = new LLMResponseSignal(new LLMResponseItem("q1", "ok", 0.8),
+                0, 0L, 1, "", false, "", false, false, "rn");
+        List<?> result = p.process(signal, n);
+        assertEquals(1, result.size());
+        assertEquals(0, n.getConsecutiveFailures()); // reset after success
+    }
+
+    // ── LLMKnowledgeNeuron ────────────────────────────────────────────────────
+
+    @Test
+    void knowledgeNeuron_disabledByDefault_llmNotAvailable() {
+        LLMConfig cfg = new LLMConfig(); // enabled=false
+        LLMKnowledgeNeuron n = new LLMKnowledgeNeuron(1L, mockChain, 1L, cfg);
+        assertFalse(n.isLLMAvailable());
+    }
+
+    @Test
+    void knowledgeNeuron_enabledConfig_llmAvailable() {
+        LLMConfig cfg = new LLMConfig();
+        cfg.setEnabled(true);
+        LLMKnowledgeNeuron n = new LLMKnowledgeNeuron(1L, mockChain, 1L, cfg);
+        assertTrue(n.isLLMAvailable());
+    }
+
+    @Test
+    void knowledgeNeuron_getCachedResponse_missingKey_returnsEmpty() {
+        LLMConfig cfg = new LLMConfig();
+        cfg.setEnabled(true);
+        LLMKnowledgeNeuron n = new LLMKnowledgeNeuron(1L, mockChain, 1L, cfg);
+        Optional<LLMResponseSignal> result = n.getCachedResponse("nonexistent");
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    void knowledgeNeuron_submitQuery_whenDisabled_producesTimeoutSignal() {
+        LLMConfig cfg = new LLMConfig(); // disabled
+        LLMKnowledgeNeuron n = new LLMKnowledgeNeuron(1L, mockChain, 1L, cfg);
+        LLMQuerySignal signal = new LLMQuerySignal(new LLMQueryItem("q1", "text", "ctx", 1),
+                0, 0L, 3, "", false, "", false, false, "n");
+        n.submitQuery(signal);
+        List<ISignal> results = n.result;
+        assertEquals(1, results.size());
+        assertInstanceOf(LLMTimeoutSignal.class, results.get(0));
+        LLMTimeoutSignal timeout = (LLMTimeoutSignal) results.get(0);
+        assertEquals("q1", timeout.getValue().getQueryId());
+    }
+
+    @Test
+    void knowledgeNeuron_setEndpointAndLatency_updatesConfig() {
+        LLMConfig cfg = new LLMConfig();
+        LLMKnowledgeNeuron n = new LLMKnowledgeNeuron(1L, mockChain, 1L, cfg);
+        n.setLLMEndpoint("http://new-host:8080");
+        n.setMaxLatency(3000);
+        assertEquals("http://new-host:8080", n.getConfig().getEndpoint());
+        assertEquals(3000, n.getConfig().getMaxLatencyMs());
+    }
+}


### PR DESCRIPTION
…tests

Implements the optional LLM advisory integration described in CLAUDE (1).md:

Signals (slow loop unless noted):
- LLMQuerySignal (epoch 2) + LLMQueryItem — dispatches query with context and priority
- LLMResponseSignal (epoch 2) + LLMResponseItem — carries raw untrusted response
- LLMConfidenceSignal (epoch 3) + LLMConfidenceItem — verified confidence and applicability verdict
- LLMTimeoutSignal (epoch 1) + LLMTimeoutItem — triggers fallback on LLM unavailability

Interface:
- ILLMCapable extends INeuron — submitQuery, getCachedResponse, isLLMAvailable, setLLMEndpoint, setMaxLatency

Neurons (Layer 3):
- LLMKnowledgeNeuron — bounded LRU cache, async HTTP via CompletableFuture, emits timeout or response signal
- LLMVerificationNeuron — cross-validates raw responses via pluggable validators, emits LLMConfidenceSignal
- LLMFallbackNeuron — circuit breaker (CLOSED → OPEN → HALF_OPEN → CLOSED), routes to internal knowledge when LLM unavailable

Processors:
- LLMQueryProcessor — async query dispatcher (ISignalProcessor<LLMQuerySignal, ILLMCapable>)
- LLMResponseProcessor — forwards response copy for verification
- LLMVerificationProcessor — delegates to LLMVerificationNeuron.verify()
- LLMTimeoutProcessor — records failure in circuit breaker, forwards timeout signal
- LLMFallbackResponseProcessor — records success in circuit breaker, forwards response signal

Config:
- LLMConfig — maps to llm: section; disabled by default

Tests:
- LLMIntegrationTest — 38 tests covering all components