### PR TITLE
fix: correct circuit breaker test assertions for probe=0 interval

### DIFF
--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMIntegrationTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/llm/LLMIntegrationTest.java
@@ -228,11 +228,10 @@ class LLMIntegrationTest {
 
     @Test
     void fallbackNeuron_halfOpenSuccessTransitionsToClosed() {
+        // probe=0: getState() transitions OPEN → HALF_OPEN immediately on the first call
         LLMFallbackNeuron n = new LLMFallbackNeuron(1L, mockChain, 1L, 1, 0);
-        n.recordFailure(); // → OPEN
-        assertEquals(LLMFallbackNeuron.CircuitState.OPEN, n.getState());
-        // probe interval = 0 → immediately transitions to HALF_OPEN on next getState()
-        assertEquals(LLMFallbackNeuron.CircuitState.HALF_OPEN, n.getState());
+        n.recordFailure(); // CLOSED → OPEN
+        assertEquals(LLMFallbackNeuron.CircuitState.HALF_OPEN, n.getState()); // probe=0 → instant transition
         assertTrue(n.isLLMCallAllowed());
         n.recordSuccess(); // HALF_OPEN → CLOSED
         assertEquals(LLMFallbackNeuron.CircuitState.CLOSED, n.getState());
@@ -242,9 +241,12 @@ class LLMIntegrationTest {
     void fallbackNeuron_halfOpenFailureReopens() {
         LLMFallbackNeuron n = new LLMFallbackNeuron(1L, mockChain, 1L, 1, 0);
         n.recordFailure(); // CLOSED → OPEN
-        n.getState();      // OPEN → HALF_OPEN
+        n.getState();      // OPEN → HALF_OPEN (probe=0)
+        // Switch to a large probe so OPEN stays OPEN after the next failure
+        n.setHalfOpenProbeIntervalMs(Long.MAX_VALUE);
         n.recordFailure(); // HALF_OPEN → OPEN
-        assertEquals(LLMFallbackNeuron.CircuitState.OPEN, n.getState());
+        assertEquals(LLMFallbackNeuron.CircuitState.OPEN, n.getState()); // probe=MAX_VALUE → stays OPEN
+        assertFalse(n.isLLMCallAllowed());
     }
 
     @Test


### PR DESCRIPTION
With halfOpenProbeIntervalMs=0, getState() transitions OPEN→HALF_OPEN on the very first call because elapsed >= 0 is always true. Two tests had incorrect expectations:

- fallbackNeuron_halfOpenSuccessTransitionsToClosed: removed the stale OPEN assertion before the HALF_OPEN one — with probe=0 they collapse to one call.
- fallbackNeuron_halfOpenFailureReopens: switch probe interval to Long.MAX_VALUE after reaching HALF_OPEN so the OPEN state is observable after the second recordFailure() call.