### PR TITLE
Implement CLAUDE.md modules A-E (affect, embodiment, curiosity, glia,…

### DIFF
--- a/docs/modules/affect.md
+++ b/docs/modules/affect.md
@@ -1,0 +1,63 @@
+# Module A — Affect subsystem
+
+## Abstract
+
+The affect module adds a lightweight limbic analogue to the jneopallium framework: fast valence/arousal tagging (amygdala-like), slow interoceptive integration (insula-like), cross-system broadcast of affective state, and diffuse modulation of learning-rate and harm thresholds. Default is `enabled: false`; when disabled the module is byte-identical to baseline.
+
+## Design principles
+
+- **No silent operation.** All state changes emit the standard transparency/log signal wherever the signal would cause a structural or threshold change.
+- **State lives on the neuron, not the processor.** Processors are stateless; `AmygdalaValenceNeuron`, `AnteriorInsulaNeuron`, `AffectIntegrationNeuron`, and `AffectModulationNeuron` hold all state.
+- **Hard safety constraint preserved.** The module never modifies the `EthicalPriorityNeuron` weights or the hard harm thresholds. It multiplies a dynamic "recency bias" factor only.
+
+## Signals
+
+| Signal | Loop / Epoch | Purpose |
+|---|---|---|
+| `AffectStateSignal` | 2 / 1 | Broadcast valence/arousal summary. |
+| `InteroceptiveSignal` | 1 / 2 | Energy, homeostatic error, pain. |
+| `AppraisalSignal` | 1 / 2 | Goal delta, novelty, controllability. |
+
+## Neurons
+
+| Neuron | Layer | Role |
+|---|---|---|
+| `AmygdalaValenceNeuron` | 2 | Fast threat/reward tagging of `SpikeSignal`. |
+| `AnteriorInsulaNeuron` | 2 | Integrates interoceptive streams (EMA). |
+| `AffectIntegrationNeuron` | 2 | Appraisal × interoception → `AffectStateSignal`. |
+| `AffectModulationNeuron` | 7 | Broadcast modulator: learning rate, harm thresholds. |
+
+## Processors
+
+- `InteroceptionProcessor` — updates the insula EMA.
+- `ValenceTaggingProcessor` — tags `SpikeSignal` with valence.
+- `AffectIntegrationProcessor` — feeds appraisal into amygdala valence.
+
+## Integration
+
+`AffectModulationNeuron` produces modulation factors:
+
+- `shortTermLearningScale = 1 + arousal`
+- `longTermConsolidationScale = 1 − 0.5·arousal`
+- `harmThresholdMultiplier = clamp((1 − valence)/2 + arousal, 1.0, 5.0)`
+
+## Configuration
+
+```yaml
+affect:
+  enabled: false
+  valence-decay-ticks: 300
+  arousal-decay-ticks: 150
+  harm-threshold-clamp: [1.0, 5.0]
+```
+
+## Tests
+
+`AffectModuleTest` covers signals, neurons, processors, and config defaults.
+
+## References
+
+- LeDoux, J.E. (1998). *The Emotional Brain*. Simon & Schuster.
+- Craig, A.D. (2002). How do you feel? Interoception and the anterior insula. *Nature Reviews Neuroscience* 3, 655–666.
+- Russell, J.A. (1980). A circumplex model of affect. *J. Personality and Social Psychology* 39, 1161–1178.
+- Damasio, A. (1994). *Descartes' Error*. Putnam.

--- a/docs/modules/curiosity.md
+++ b/docs/modules/curiosity.md
@@ -1,0 +1,68 @@
+# Module C — Intrinsic motivation / curiosity
+
+## Abstract
+
+Adds intrinsic-reward machinery so an agent explores even without extrinsic reward. Four complementary drives are implemented: novelty (hippocampal CA1-like), learning progress (Oudeyer & Kaplan), empowerment (Klyubin), and boredom-driven inhibition of return. Depends on the embodiment module for empowerment's forward-model inputs.
+
+## Design principles
+
+- **Composable drives.** Each drive is one neuron + one signal; higher-level policy is free to combine them.
+- **Pure state on the neuron.** Bloom filters, EMA windows, and visit counts live on the neurons; processors remain stateless.
+- **Safety-preserving.** Curiosity only biases action-selection; it cannot bypass the harm gate.
+
+## Signals
+
+| Signal | Loop / Epoch | Purpose |
+|---|---|---|
+| `NoveltySignal` | 1 / 2 | Novelty score + context hash. |
+| `LearningProgressSignal` | 2 / 2 | Domain + error derivative. |
+| `EmpowermentSignal` | 2 / 3 | State id + mutual-information estimate. |
+| `BoredomSignal` | 2 / 2 | Familiarity for a context. |
+
+## Neurons
+
+| Neuron | Layer | Role |
+|---|---|---|
+| `NoveltyDetectorNeuron` | 1 | Decaying Bloom filter over context hashes. |
+| `LearningProgressNeuron` | 6 | Per-domain dError/dt → intrinsic reward when decreasing. |
+| `EmpowermentNeuron` | 4 | Empowerment from sampled action rollouts. |
+| `BoredomNeuron` | 2 | Visit counts → attention suppression on over-familiar contexts. |
+
+## Integration
+
+`ActionSelectionNeuron` adds a dendrite for `NoveltySignal` and `EmpowermentSignal` and modifies its softmax:
+
+```
+score = extrinsic + β_nov · novelty + β_emp · empowerment
+```
+
+`BoredomNeuron` emits `AttentionGateSignal(suppress=true)` for contexts whose familiarity has crossed the configured threshold, forcing the planner to explore.
+
+## Configuration
+
+```yaml
+curiosity:
+  enabled: false
+  novelty:
+    hash-bits: 2048
+    decay-ticks: 1000
+  learning-progress:
+    window-ticks: 200
+  empowerment:
+    horizon: 3
+    n-action-samples: 8
+  weights:
+    beta-novelty: 0.2
+    beta-empowerment: 0.1
+```
+
+## Tests
+
+`CuriosityModuleTest` covers novelty decay, learning-progress reward sign, empowerment ordering over rollout diversity, boredom saturation and suppression gate, signal copy/clamp semantics, and config defaults.
+
+## References
+
+- Lisman, J.E. & Grace, A.A. (2005). The hippocampal-VTA loop. *Neuron* 46(5), 703–713.
+- Oudeyer, P-Y. & Kaplan, F. (2007). What is intrinsic motivation? *Frontiers in Neurorobotics* 1:6.
+- Klyubin, A.S., Polani, D., Nehaniv, C.L. (2005). Empowerment. *IEEE CEC*.
+- Pathak, D. et al. (2017). Curiosity-driven Exploration by Self-supervised Prediction. *ICML*.

--- a/docs/modules/embodiment.md
+++ b/docs/modules/embodiment.md
@@ -1,0 +1,62 @@
+# Module B — Embodiment / proprioception
+
+## Abstract
+
+This module adds a body-schema representation and a cerebellar-style efference-copy circuit: every motor command spawns a parallel predicted-outcome signal, which a reafference comparator later matches against the actual proprioceptive feedback. Mismatches surface to the harm discriminator as a free mechanical-failure channel. The module also supports runtime tool incorporation (tools extend the body schema) and damage tracking per effector.
+
+## Design principles
+
+- **Branch-point parity.** `EfferenceCopyNeuron` sits between `PlanningNeuron` and `HarmGateNeuron` so every motor intention spawns a copy before execution.
+- **Reversible tool incorporation.** `ToolIncorporationNeuron` stores the prior effector state and restores it on release; if the slot had no prior state, it is removed.
+- **Safety reuse.** Proprioceptive mismatch is emitted as `HarmFeedbackSignal(source="mechanical")` — no new logic on the harm side.
+
+## Signals
+
+| Signal | Loop / Epoch | Purpose |
+|---|---|---|
+| `ProprioceptiveSignal` | 1 / 1 | Effector joint states + timestamp. |
+| `EfferenceCopySignal` | 1 / 1 | Predicted outcome of a motor command. |
+| `BodySchemaUpdateSignal` | 2 / 3 | Per-effector capability update. |
+| `SensorimotorContingencySignal` | 1 / 2 | Action ↔ sensory-delta binding. |
+
+## Neurons
+
+| Neuron | Layer | Role |
+|---|---|---|
+| `EfferenceCopyNeuron` | 4 | Produces `EfferenceCopySignal` from `MotorCommandSignal`. |
+| `BodySchemaNeuron` | 2 | Maintains `BodySchema` map. |
+| `ToolIncorporationNeuron` | 2 | Extends body schema with tools. |
+| `ReafferenceComparatorNeuron` | 1 | Proprioceptive-vs-predicted mismatch → harm feedback. |
+
+## Integration
+
+- `ReafferenceComparatorNeuron` emits `HarmFeedbackSignal` with `source="mechanical"` when RMS mismatch ≥ `failureEmitThreshold`.
+- `BodySchemaNeuron.onProprioceptive` auto-registers previously-unseen effectors.
+- `ToolIncorporationNeuron` records the prior schema slot; `release()` restores it or removes the slot entirely if the tool occupied a fresh slot.
+
+## Configuration
+
+```yaml
+embodiment:
+  enabled: false
+  effectors:
+    - id: 0
+      name: left-arm
+      dof: 7
+      health-threshold: 0.3
+  efference-copy:
+    mismatch-threshold: 0.15
+    failure-emit-threshold: 0.4
+  tool-incorporation:
+    enabled: true
+    timeout-ticks: 600
+```
+
+## Tests
+
+`EmbodimentModuleTest` covers efference-copy generation, reafference mismatch, tool incorporation/release, proprioceptive auto-registration, signal copy semantics, and config defaults.
+
+## References
+
+- Wolpert, D.M., Miall, R.C., Kawato, M. (1998). Internal models in the cerebellum. *TICS* 2(9), 338–347.
+- Maravita, A. & Iriki, A. (2004). Tools for the body (schema). *TICS* 8(2), 79–86.

--- a/docs/modules/glia.md
+++ b/docs/modules/glia.md
@@ -1,0 +1,67 @@
+# Module D — Glial support layer
+
+## Abstract
+
+Adds astrocytic, microglial, and oligodendrocyte-analogue neurons plus the headline capability: **activity-dependent per-connection propagation delay** via `DelayedAxon`. This is genuinely new infrastructure — the existing `Axon` class is unchanged; a subclass carries a per-target delay map, and a new `DelayQueue` holds signals until their release tick.
+
+## Design principles
+
+- **No core modification.** `Axon` is untouched; `DelayedAxon extends Axon` adds the delay map. A dispatcher wrapper uses `DelayQueue` to release delayed signals.
+- **Myelination never hurts.** The accelerate operation reduces delay monotonically and cannot push below `min-delay-ticks`. Demyelination restores baseline but never exceeds it.
+- **Pruning is cautious.** `MicroglialPruningNeuron` honors `min-inactivity-ticks` and a per-epoch cap on prunings.
+- **Single source of destruction.** Only `MicroglialPruningNeuron` emits `PruningSignal`; no other module is authorized to sever a connection.
+
+## Signals
+
+| Signal | Loop / Epoch | Purpose |
+|---|---|---|
+| `CalciumWaveSignal` | 2 / 1 | Astrocytic regional activity. |
+| `GliotransmitterSignal` | 2 / 2 | Glutamate / ATP / D-serine release. |
+| `PruningSignal` | 2 / 5 | Prune request from microglia. |
+| `MyelinationSignal` | 2 / 10 | Update delay on a connection. |
+
+## Neurons
+
+| Neuron | Role |
+|---|---|
+| `AstrocyteNeuron` | Integrates local activity; emits calcium waves and gliotransmitters. |
+| `MicroglialPruningNeuron` | Inactivity-tracking pruning with a per-epoch cap. |
+| `MyelinationNeuron` | Counts usage per window and issues delay-reduction signals. |
+
+## Integration
+
+- `DelayedAxon.getDelay(target)` is inspected by the dispatcher wrapper; if non-zero, the signal is enqueued in `DelayQueue` with `releaseAtTick = currentTick + delay`.
+- `MetaplasticityNeuron` continues to adjust weights; `MicroglialPruningNeuron` owns actual connection removal.
+- `MyelinationNeuron.applyTo(DelayedAxon, MyelinationSignal)` respects the clamp `[min, baseline]`.
+
+## Configuration
+
+```yaml
+glia:
+  enabled: false
+  astrocytes:
+    per-layer: true
+    calcium-wave-threshold: 0.4
+  microglia:
+    pruning-enabled: true
+    min-inactivity-ticks: 2000
+    max-prunings-per-epoch: 10
+  myelination:
+    enabled: true
+    baseline-delay-ticks: 5
+    min-delay-ticks: 1
+    activity-window: 500
+    delay-decrement-per-window: 1
+```
+
+## Tests
+
+`GliaModuleTest` covers delay clamping, monotonic acceleration, demyelination baseline, `DelayQueue` release semantics at exact tick, calcium-wave emission, microglial safety window and epoch cap, myelination floor behavior, signal copy/frequency assertions, and config defaults.
+
+## References
+
+- Fields, R.D. (2015). Activity-dependent myelination. *Nature Rev. Neurosci.* 16(12), 756–767.
+- Gibson, E.M. et al. (2014). Neuronal activity promotes oligodendrogenesis and adaptive myelination. *Science* 344(6183), 1252304.
+- Schafer, D.P. et al. (2012). Microglia sculpt postnatal neural circuits. *Neuron* 74(4), 691–705.
+- Araque, A. et al. (2014). Gliotransmitters travel in time and space. *Neuron* 81(4), 728–739.
+- Volterra, A. & Meldolesi, J. (2005). Astrocytes: From brain glue to communication elements. *Nature Rev. Neurosci.* 6, 626–640.

--- a/docs/modules/sleep.md
+++ b/docs/modules/sleep.md
@@ -1,0 +1,68 @@
+# Module E — Sleep / replay / offline consolidation
+
+## Abstract
+
+Implements a circadian sleep controller, hippocampal replay, sharp-wave ripples targeting long-term memory, and REM-sleep dreaming. Depends on the glia module (sleep-gated myelination boost) and on the existing `CircadianNeuron`. The headline publishable claim is reduced forgetting when the sleep cycle is enabled on the reference benchmark.
+
+## Design principles
+
+- **Safety-preserving.** REM-generated plans are marked `priority=low, source=DREAM` and must still pass through `HarmGateNeuron` before any motor execution. The test `DreamPlanSafetyTest`-equivalent asserts unsafe dreams are rejected at the planner.
+- **Gate, don't modify.** During NREM the fast-loop signal magnitudes are attenuated by `1 - depth`. The gate is configurable, not hard-coded.
+- **Single ownership.** Only `SleepControllerNeuron` owns the phase state; all other sleep neurons query it.
+
+## Signals
+
+| Signal | Loop / Epoch | Purpose |
+|---|---|---|
+| `SleepStateSignal` | 2 / 10 | Current phase + depth. |
+| `ReplaySignal` | 2 / 3 | Compressed episode replay. |
+| `SharpWaveRippleSignal` | 2 / 1 | Compressed burst replay to LTM. |
+| `DreamSignal` | 2 / 5 | REM-generated recombined episode. |
+
+## Neurons
+
+| Neuron | Layer | Role |
+|---|---|---|
+| `SleepControllerNeuron` | 7 | Advances the WAKE → NREM2 → NREM3 → REM cycle. |
+| `HippocampalReplayNeuron` | 3 | Top-K salience-ordered episode replay. |
+| `SharpWaveRippleNeuron` | 3 | NREM3-only burst replay. |
+| `REMDreamingNeuron` | 3 | REM recombination with planner-safety gate. |
+
+## Integration
+
+- During NREM3, `MyelinationNeuron.setConsolidationBoost` is scaled by `sleep.consolidation-boost` (default 3.0), accelerating offline myelination.
+- `MetaplasticityNeuron` runs at 3x normal rate under NREM3.
+- REM dreams whose novelty exceeds `dreaming.max-novelty-for-planning` are filtered out at `REMDreamingNeuron.isPlanningCandidate(...)`, ensuring wild recombinations never reach the planner as candidate plans.
+- Consolidation fast-path: `SharpWaveRippleSignal` is recognized by `LongTermMemoryNeuron`'s consolidation processor and treated with elevated importance.
+
+## Configuration
+
+```yaml
+sleep:
+  enabled: false
+  circadian:
+    cycle-ticks: 10000
+    nrem-fraction: 0.6
+    rem-fraction: 0.15
+  replay:
+    direction: REVERSE
+    compression-ratio: 10.0
+    top-k-episodes: 20
+  dreaming:
+    recombination-count: 5
+    max-novelty-for-planning: 0.7
+  consolidation-boost: 3.0
+```
+
+## Tests
+
+`SleepModuleTest` covers: full-cycle phase visit (WAKE → NREM2 → NREM3 → REM ordering), NREM3 deeper than NREM2, replay reverse/forward correctness, top-K salience ordering, NREM3 gating of sharp-wave ripples, REM-only dreaming, dream-safety gate at the planner, signal ProcessingFrequency correctness, and config defaults.
+
+## References
+
+- Wilson, M.A. & McNaughton, B.L. (1994). Reactivation of hippocampal ensemble memories during sleep. *Science* 265(5172), 676–679.
+- Foster, D.J. & Wilson, M.A. (2006). Reverse replay. *Nature* 440, 680–683.
+- Buzsáki, G. (2015). Hippocampal sharp wave-ripple. *Hippocampus* 25(10), 1073–1188.
+- Wamsley, E.J. & Stickgold, R. (2011). Memory, sleep, and dreaming. *Sleep Medicine Clinics* 6(1), 97–108.
+- Diekelmann, S. & Born, J. (2010). The memory function of sleep. *Nature Rev. Neurosci.* 11, 114–126.
+- Saper, C.B. et al. (2005). Hypothalamic regulation of sleep and circadian rhythms. *Nature* 437, 1257–1263.

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/AffectConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/AffectConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Configuration for the affect subsystem.
+ * Maps to the {@code affect:} top-level section of the jneopallium config.
+ * Default {@link #enabled} is {@code false} — affect must be opt-in.
+ */
+public class AffectConfig {
+
+    private boolean enabled = false;
+    private int valenceDecayTicks = 300;
+    private int arousalDecayTicks = 150;
+    private double harmThresholdClampMin = 1.0;
+    private double harmThresholdClampMax = 5.0;
+    private List<String> interoceptionSources = Arrays.asList("energy", "homeostasis", "pain");
+    private int interoceptionSamplingEpoch = 2;
+
+    public AffectConfig() {}
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    public int getValenceDecayTicks() { return valenceDecayTicks; }
+    public void setValenceDecayTicks(int valenceDecayTicks) { this.valenceDecayTicks = valenceDecayTicks; }
+
+    public int getArousalDecayTicks() { return arousalDecayTicks; }
+    public void setArousalDecayTicks(int arousalDecayTicks) { this.arousalDecayTicks = arousalDecayTicks; }
+
+    public double getHarmThresholdClampMin() { return harmThresholdClampMin; }
+    public void setHarmThresholdClampMin(double harmThresholdClampMin) { this.harmThresholdClampMin = harmThresholdClampMin; }
+
+    public double getHarmThresholdClampMax() { return harmThresholdClampMax; }
+    public void setHarmThresholdClampMax(double harmThresholdClampMax) { this.harmThresholdClampMax = harmThresholdClampMax; }
+
+    public List<String> getInteroceptionSources() { return interoceptionSources; }
+    public void setInteroceptionSources(List<String> interoceptionSources) { this.interoceptionSources = interoceptionSources; }
+
+    public int getInteroceptionSamplingEpoch() { return interoceptionSamplingEpoch; }
+    public void setInteroceptionSamplingEpoch(int e) { this.interoceptionSamplingEpoch = e; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/AffectIntegrationNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/AffectIntegrationNeuron.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.affect.AffectStateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.affect.AppraisalSignal;
+
+/**
+ * Combines appraisal + interoceptive summary into a unified AffectState and
+ * emits {@link AffectStateSignal}.
+ * Layer 2, loop=2 / epoch=1.
+ * <p>Biological analogue: ventromedial prefrontal / orbitofrontal integration
+ * of cognitive appraisal and interoception.
+ */
+public class AffectIntegrationNeuron extends ModulatableNeuron implements IAffectiveNeuron {
+
+    private double valence;
+    private double arousal;
+    private long tick;
+    private String contextId;
+    private double firingThreshold;
+    private final double baselineThreshold;
+
+    public AffectIntegrationNeuron() {
+        super();
+        this.firingThreshold = 0.5;
+        this.baselineThreshold = 0.5;
+    }
+
+    public AffectIntegrationNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+        this.firingThreshold = 0.5;
+        this.baselineThreshold = 0.5;
+    }
+
+    /**
+     * Combine cognitive appraisal with an interoceptive summary and emit a new state.
+     *
+     * @param goalDelta cognitive goal-progress delta
+     * @param novelty context novelty in [0,1]
+     * @param controllability perceived control in [0,1]
+     * @param homeostaticError current body error in [0,1]
+     * @param painMagnitude current pain in [0,1]
+     * @return broadcast-ready AffectStateSignal
+     */
+    public AffectStateSignal integrate(double goalDelta, double novelty,
+                                       double controllability,
+                                       double homeostaticError,
+                                       double painMagnitude) {
+        double v = Math.tanh(goalDelta) - 0.5 * clamp01(painMagnitude) - 0.3 * clamp01(homeostaticError);
+        double a = clamp01(0.5 * clamp01(novelty) + 0.5 * clamp01(painMagnitude) + 0.25 * (1 - clamp01(controllability)));
+        this.valence = clamp(v, -1.0, 1.0);
+        this.arousal = a;
+        this.tick++;
+        AffectStateSignal out = new AffectStateSignal(valence, arousal, contextId);
+        out.setSourceNeuronId(this.getId());
+        return out;
+    }
+
+    @Override public AffectState currentState() { return new AffectState(valence, arousal, tick); }
+
+    @Override
+    public void modulateThreshold(double arousalFactor) {
+        double factor = clamp01(arousalFactor);
+        this.firingThreshold = Math.max(0.05, baselineThreshold * (1.0 - 0.5 * factor));
+    }
+
+    @Override
+    public void onAppraisal(AppraisalSignal s) {
+        if (s == null) return;
+        this.valence = clamp(this.valence + 0.3 * s.getGoalDelta(), -1.0, 1.0);
+        this.arousal = clamp01(this.arousal + 0.2 * s.getNovelty());
+    }
+
+    public String getContextId() { return contextId; }
+    public void setContextId(String contextId) { this.contextId = contextId; }
+
+    public double getValence() { return valence; }
+    public double getArousal() { return arousal; }
+    public double getFiringThreshold() { return firingThreshold; }
+    public double getBaselineThreshold() { return baselineThreshold; }
+
+    private static double clamp(double v, double lo, double hi) { return Math.max(lo, Math.min(hi, v)); }
+    private static double clamp01(double v) { return clamp(v, 0.0, 1.0); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/AffectModulationNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/AffectModulationNeuron.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.affect.AffectStateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.affect.AppraisalSignal;
+
+/**
+ * Broadcasts {@link AffectStateSignal} as a neuromodulatory gain on
+ * learning rates and harm thresholds.
+ * Layer 7, loop=2 / epoch=1.
+ * <p>Biological analogue: brainstem/diencephalic neuromodulatory nuclei
+ * (locus coeruleus, raphe nuclei, VTA) broadcasting global state.
+ */
+public class AffectModulationNeuron extends ModulatableNeuron implements IAffectiveNeuron {
+
+    private double valence;
+    private double arousal;
+    private long lastUpdateTick;
+    private double firingThreshold;
+    private final double baselineThreshold;
+
+    /** Short-term learning scale = 1 + arousal. */
+    private double shortTermLearningScale;
+    /** Long-term consolidation scale = 1 - 0.5 * arousal. */
+    private double longTermConsolidationScale;
+    /** Exploration bonus multiplier derived from valence. */
+    private double explorationBonus;
+    /** Harm threshold multiplier derived from valence + arousal, clamped. */
+    private double harmThresholdMultiplier;
+
+    private double harmClampMin = 1.0;
+    private double harmClampMax = 5.0;
+
+    public AffectModulationNeuron() {
+        super();
+        this.firingThreshold = 0.5;
+        this.baselineThreshold = 0.5;
+        this.shortTermLearningScale = 1.0;
+        this.longTermConsolidationScale = 1.0;
+        this.explorationBonus = 1.0;
+        this.harmThresholdMultiplier = 1.0;
+    }
+
+    public AffectModulationNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+        this.firingThreshold = 0.5;
+        this.baselineThreshold = 0.5;
+        this.shortTermLearningScale = 1.0;
+        this.longTermConsolidationScale = 1.0;
+        this.explorationBonus = 1.0;
+        this.harmThresholdMultiplier = 1.0;
+    }
+
+    /**
+     * Accept a new {@link AffectStateSignal} and update modulation scales.
+     */
+    public void onAffect(AffectStateSignal s) {
+        if (s == null) return;
+        this.valence = s.getValence();
+        this.arousal = s.getArousal();
+        this.lastUpdateTick++;
+        // Per CLAUDE.md §4.5:
+        this.shortTermLearningScale = 1.0 + arousal;
+        this.longTermConsolidationScale = Math.max(0.0, 1.0 - 0.5 * arousal);
+        this.explorationBonus = valence < 0 ? Math.max(0.0, 1.0 + valence) : 1.0;
+        double raw = (1.0 - valence) / 2.0 + arousal;
+        this.harmThresholdMultiplier = clamp(raw, harmClampMin, harmClampMax);
+    }
+
+    @Override public AffectState currentState() { return new AffectState(valence, arousal, lastUpdateTick); }
+
+    @Override
+    public void modulateThreshold(double arousalFactor) {
+        double f = clamp(arousalFactor, 0.0, 1.0);
+        this.firingThreshold = Math.max(0.05, baselineThreshold * (1.0 - 0.5 * f));
+    }
+
+    @Override
+    public void onAppraisal(AppraisalSignal s) {
+        if (s == null) return;
+        this.valence = clamp(this.valence + 0.2 * s.getGoalDelta(), -1.0, 1.0);
+        this.arousal = clamp(this.arousal + 0.2 * s.getNovelty(), 0.0, 1.0);
+    }
+
+    public double getShortTermLearningScale() { return shortTermLearningScale; }
+    public double getLongTermConsolidationScale() { return longTermConsolidationScale; }
+    public double getExplorationBonus() { return explorationBonus; }
+    public double getHarmThresholdMultiplier() { return harmThresholdMultiplier; }
+
+    public double getHarmClampMin() { return harmClampMin; }
+    public void setHarmClampMin(double harmClampMin) { this.harmClampMin = harmClampMin; }
+    public double getHarmClampMax() { return harmClampMax; }
+    public void setHarmClampMax(double harmClampMax) { this.harmClampMax = harmClampMax; }
+
+    public double getValence() { return valence; }
+    public double getArousal() { return arousal; }
+    public double getFiringThreshold() { return firingThreshold; }
+    public double getBaselineThreshold() { return baselineThreshold; }
+
+    private static double clamp(double v, double lo, double hi) { return Math.max(lo, Math.min(hi, v)); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/AffectState.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/AffectState.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect;
+
+import java.io.Serializable;
+
+/**
+ * Immutable snapshot of an affective neuron's current state.
+ * Biological analogue: instantaneous read-out of the valence/arousal axes
+ * used by the circumplex model of affect (Russell 1980).
+ */
+public final class AffectState implements Serializable {
+
+    private final double valence;
+    private final double arousal;
+    private final long asOfTick;
+
+    public AffectState(double valence, double arousal, long asOfTick) {
+        this.valence = Math.max(-1.0, Math.min(1.0, valence));
+        this.arousal = Math.max(0.0, Math.min(1.0, arousal));
+        this.asOfTick = asOfTick;
+    }
+
+    public double getValence() { return valence; }
+    public double getArousal() { return arousal; }
+    public long getAsOfTick() { return asOfTick; }
+
+    @Override
+    public String toString() {
+        return "AffectState{valence=" + valence + ", arousal=" + arousal + ", asOfTick=" + asOfTick + '}';
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/AmygdalaValenceNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/AmygdalaValenceNeuron.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.affect.AppraisalSignal;
+
+/**
+ * Amygdala-like fast threat/reward tagging neuron.
+ * Layer 2, loop=1 / epoch=1 — runs on the fast sensory loop.
+ * <p>Biological analogue: basolateral &amp; central amygdala nuclei
+ * (LeDoux 1998).
+ */
+public class AmygdalaValenceNeuron extends ModulatableNeuron implements IAffectiveNeuron {
+
+    private double valence;
+    private double arousal;
+    private long lastTick;
+    private double firingThreshold;
+    private final double baselineThreshold;
+
+    public AmygdalaValenceNeuron() {
+        super();
+        this.firingThreshold = 0.5;
+        this.baselineThreshold = 0.5;
+    }
+
+    public AmygdalaValenceNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+        this.firingThreshold = 0.5;
+        this.baselineThreshold = 0.5;
+    }
+
+    /**
+     * Tag an incoming spike magnitude with valence. Threat-positive input
+     * (high magnitude combined with low controllability) produces a
+     * negative-valence emission.
+     *
+     * @param spikeMagnitude incoming spike magnitude
+     * @param threatCue non-negative cue strength (pain or threat)
+     * @return the updated valence in [-1,1]
+     */
+    public double tag(double spikeMagnitude, double threatCue) {
+        double v = -clamp01(threatCue) + 0.5 * Math.tanh(spikeMagnitude - 1.0);
+        this.valence = clamp(v, -1.0, 1.0);
+        this.arousal = clamp01(Math.max(threatCue, Math.abs(spikeMagnitude)));
+        this.lastTick++;
+        return this.valence;
+    }
+
+    @Override
+    public AffectState currentState() {
+        return new AffectState(valence, arousal, lastTick);
+    }
+
+    @Override
+    public void modulateThreshold(double arousalFactor) {
+        double factor = clamp01(arousalFactor);
+        this.firingThreshold = Math.max(0.05, baselineThreshold * (1.0 - 0.5 * factor));
+    }
+
+    @Override
+    public void onAppraisal(AppraisalSignal s) {
+        if (s == null) return;
+        this.valence = clamp(this.valence + 0.5 * s.getGoalDelta(), -1.0, 1.0);
+        this.arousal = clamp01(this.arousal + 0.25 * s.getNovelty());
+    }
+
+    public double getValence() { return valence; }
+    public double getArousal() { return arousal; }
+    public double getFiringThreshold() { return firingThreshold; }
+    public double getBaselineThreshold() { return baselineThreshold; }
+
+    private static double clamp(double v, double lo, double hi) {
+        return Math.max(lo, Math.min(hi, v));
+    }
+    private static double clamp01(double v) { return clamp(v, 0.0, 1.0); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/AnteriorInsulaNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/AnteriorInsulaNeuron.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.affect.InteroceptiveSignal;
+
+/**
+ * Anterior-insula-like integrator for body-state streams.
+ * Layer 2, loop=1 / epoch=2.
+ * <p>Biological analogue: anterior insular cortex integrates
+ * interoceptive signals into a unified body-state percept (Craig 2009).
+ */
+public class AnteriorInsulaNeuron extends ModulatableNeuron implements IInteroceptive {
+
+    private double homeostaticError;
+    private double energyBudget;
+    private double averagedPain;
+    private int sampleCount;
+
+    public AnteriorInsulaNeuron() {
+        super();
+        this.energyBudget = 1.0;
+    }
+
+    public AnteriorInsulaNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+        this.energyBudget = 1.0;
+    }
+
+    /**
+     * Integrate a new interoceptive sample with exponential moving average.
+     *
+     * @param s interoceptive signal
+     */
+    public void integrate(InteroceptiveSignal s) {
+        if (s == null) return;
+        double alpha = 0.2;
+        this.homeostaticError = (1 - alpha) * this.homeostaticError + alpha * s.getHomeostaticError();
+        this.energyBudget = (1 - alpha) * this.energyBudget + alpha * s.getEnergyBudget();
+        this.averagedPain = (1 - alpha) * this.averagedPain + alpha * s.getPainMagnitude();
+        sampleCount++;
+    }
+
+    @Override
+    public double readHomeostaticError() { return homeostaticError; }
+
+    @Override
+    public double readEnergyBudget() { return energyBudget; }
+
+    public double getAveragedPain() { return averagedPain; }
+    public int getSampleCount() { return sampleCount; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/IAffectiveNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/IAffectiveNeuron.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.INeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.affect.AppraisalSignal;
+
+/**
+ * Contract for neurons that track a valence/arousal affective state
+ * and can modulate their firing threshold as a function of arousal.
+ * <p>Biological analogue: amygdala + anterior insula projection neurons
+ * (see Damasio 1996, Craig 2009).
+ */
+public interface IAffectiveNeuron extends INeuron {
+
+    /**
+     * @return the current immutable affect snapshot.
+     */
+    AffectState currentState();
+
+    /**
+     * Adjust firing threshold as a function of arousal.
+     * Higher arousal → lower threshold (easier firing); biological
+     * locus-coeruleus norepinephrine effect.
+     *
+     * @param arousalFactor current arousal in [0,1]
+     */
+    void modulateThreshold(double arousalFactor);
+
+    /**
+     * React to an incoming cognitive appraisal.
+     *
+     * @param s appraisal signal
+     */
+    void onAppraisal(AppraisalSignal s);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/IInteroceptive.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/IInteroceptive.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.INeuron;
+
+/**
+ * Contract for neurons that summarise body-state telemetry.
+ * Biological analogue: anterior insula and primary interoceptive cortex.
+ */
+public interface IInteroceptive extends INeuron {
+
+    /**
+     * @return the current homeostatic error (0 = perfect, larger = worse).
+     */
+    double readHomeostaticError();
+
+    /**
+     * @return the current energy budget reading (arbitrary positive units).
+     */
+    double readEnergyBudget();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/package-info.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * Affect subsystem — biologically-inspired valence/arousal modulation layer.
+ *
+ * <p>Biological analogue: limbic system (amygdala, anterior insula, cingulate)
+ * plus ascending interoceptive pathways. Implements the circumplex model of
+ * affect (Russell 1980) on top of the {@code INeuron} abstraction.
+ *
+ * <p>Key classes:
+ * <ul>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect.AmygdalaValenceNeuron}
+ *       — fast loop threat/reward tagging.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect.AnteriorInsulaNeuron}
+ *       — interoceptive integration.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect.AffectIntegrationNeuron}
+ *       — appraisal + interoception integration; emits AffectStateSignal.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect.AffectModulationNeuron}
+ *       — broadcasts modulation to learning, harm, attention.</li>
+ * </ul>
+ *
+ * <p>References:
+ * <ul>
+ *   <li>LeDoux, J. (1998). The Emotional Brain.</li>
+ *   <li>Craig, A.D. (2009). How do you feel — now? Nat Rev Neurosci 10:59–70.</li>
+ *   <li>Russell, J.A. (1980). A circumplex model of affect.
+ *       J Pers Soc Psychol 39(6):1161–1178.</li>
+ *   <li>Damasio, A. (1996). The somatic marker hypothesis.
+ *       Philos Trans R Soc Lond B 351:1413–1420.</li>
+ * </ul>
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/curiosity/BoredomNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/curiosity/BoredomNeuron.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.curiosity;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.ai.signals.fast.AttentionGateSignal;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.curiosity.BoredomSignal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tracks how frequently a context has been visited. When familiarity
+ * crosses a threshold, emits an {@link AttentionGateSignal} suppressing
+ * attention to that context (inhibition-of-return) to force exploration.
+ * Layer 2, loop=2 / epoch=2.
+ * <p>Biological analogue: habituation in inferior-temporal cortex driving
+ * inhibition-of-return in superior colliculus (Itti &amp; Koch 2001).
+ */
+public class BoredomNeuron extends ModulatableNeuron {
+
+    private final Map<String, Integer> visitCount = new HashMap<>();
+    private double familiarityThreshold = 0.7;
+    private int saturationVisits = 20;
+
+    public BoredomNeuron() { super(); }
+
+    public BoredomNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+    }
+
+    public BoredomSignal visit(String contextHash) {
+        if (contextHash == null) return null;
+        int count = visitCount.getOrDefault(contextHash, 0) + 1;
+        visitCount.put(contextHash, count);
+        double familiarity = Math.min(1.0, (double) count / saturationVisits);
+        BoredomSignal b = new BoredomSignal(contextHash, familiarity);
+        b.setSourceNeuronId(this.getId());
+        return b;
+    }
+
+    /**
+     * If the context is over-familiar, emit an attention-gate suppressing it;
+     * otherwise return null.
+     */
+    public AttentionGateSignal maybeSuppress(String contextHash) {
+        Integer count = visitCount.get(contextHash);
+        if (count == null) return null;
+        double familiarity = Math.min(1.0, (double) count / saturationVisits);
+        if (familiarity < familiarityThreshold) return null;
+        AttentionGateSignal gate = new AttentionGateSignal(familiarity, contextHash, true);
+        gate.setSourceNeuronId(this.getId());
+        return gate;
+    }
+
+    public void reset(String contextHash) {
+        if (contextHash != null) visitCount.remove(contextHash);
+    }
+
+    public double getFamiliarityThreshold() { return familiarityThreshold; }
+    public void setFamiliarityThreshold(double t) { this.familiarityThreshold = Math.max(0.0, Math.min(1.0, t)); }
+    public int getSaturationVisits() { return saturationVisits; }
+    public void setSaturationVisits(int s) { this.saturationVisits = Math.max(1, s); }
+    public int visitsFor(String contextHash) { return visitCount.getOrDefault(contextHash, 0); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/curiosity/CuriosityConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/curiosity/CuriosityConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.curiosity;
+
+/**
+ * Configuration for the curiosity / intrinsic-motivation subsystem.
+ * Maps to the {@code curiosity:} top-level section of the jneopallium
+ * config. Default {@link #enabled} is {@code false} — the module must be
+ * opt-in.
+ */
+public class CuriosityConfig {
+
+    public static class Novelty {
+        private int hashBits = 2048;
+        private int decayTicks = 1000;
+        public int getHashBits() { return hashBits; }
+        public void setHashBits(int hashBits) { this.hashBits = hashBits; }
+        public int getDecayTicks() { return decayTicks; }
+        public void setDecayTicks(int decayTicks) { this.decayTicks = decayTicks; }
+    }
+
+    public static class LearningProgress {
+        private int windowTicks = 200;
+        public int getWindowTicks() { return windowTicks; }
+        public void setWindowTicks(int windowTicks) { this.windowTicks = windowTicks; }
+    }
+
+    public static class Empowerment {
+        private int horizon = 3;
+        private int nActionSamples = 8;
+        public int getHorizon() { return horizon; }
+        public void setHorizon(int horizon) { this.horizon = horizon; }
+        public int getNActionSamples() { return nActionSamples; }
+        public void setNActionSamples(int nActionSamples) { this.nActionSamples = nActionSamples; }
+    }
+
+    public static class Weights {
+        private double betaNovelty = 0.2;
+        private double betaEmpowerment = 0.1;
+        public double getBetaNovelty() { return betaNovelty; }
+        public void setBetaNovelty(double betaNovelty) { this.betaNovelty = betaNovelty; }
+        public double getBetaEmpowerment() { return betaEmpowerment; }
+        public void setBetaEmpowerment(double betaEmpowerment) { this.betaEmpowerment = betaEmpowerment; }
+    }
+
+    private boolean enabled = false;
+    private Novelty novelty = new Novelty();
+    private LearningProgress learningProgress = new LearningProgress();
+    private Empowerment empowerment = new Empowerment();
+    private Weights weights = new Weights();
+
+    public CuriosityConfig() {}
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    public Novelty getNovelty() { return novelty; }
+    public void setNovelty(Novelty novelty) { this.novelty = novelty; }
+
+    public LearningProgress getLearningProgress() { return learningProgress; }
+    public void setLearningProgress(LearningProgress learningProgress) { this.learningProgress = learningProgress; }
+
+    public Empowerment getEmpowerment() { return empowerment; }
+    public void setEmpowerment(Empowerment empowerment) { this.empowerment = empowerment; }
+
+    public Weights getWeights() { return weights; }
+    public void setWeights(Weights weights) { this.weights = weights; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/curiosity/EmpowermentNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/curiosity/EmpowermentNeuron.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.curiosity;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.curiosity.EmpowermentSignal;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Estimates empowerment — mutual information between the agent's action
+ * choice and future state — using a plug-in estimator over sampled action
+ * rollouts provided by a forward model (depends on embodiment module's
+ * {@code EfferenceCopySignal}).
+ * Layer 4, loop=2 / epoch=3.
+ * <p>Biological analogue: prefrontal computation of controllability,
+ * aligned with Klyubin et al. (2005) "empowerment" measure.
+ */
+public class EmpowermentNeuron extends ModulatableNeuron {
+
+    private int horizon = 3;
+    private int nActionSamples = 8;
+
+    public EmpowermentNeuron() { super(); }
+
+    public EmpowermentNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+    }
+
+    /**
+     * Estimate mutual information I(A;S') by counting distinct reachable
+     * future-state bins from the supplied action rollouts.
+     *
+     * @param stateId current discrete state id
+     * @param rollouts each entry is a list of reachable future-state ids
+     *                 when that action is taken
+     * @return an {@link EmpowermentSignal}
+     */
+    public EmpowermentSignal estimate(int stateId, List<List<Integer>> rollouts) {
+        if (rollouts == null || rollouts.isEmpty()) {
+            return finalSignal(stateId, 0.0);
+        }
+        Set<Integer> reachable = new HashSet<>();
+        int totalFutures = 0;
+        int actionCount = 0;
+        for (List<Integer> futures : rollouts) {
+            if (futures == null || futures.isEmpty()) continue;
+            actionCount++;
+            for (Integer f : futures) {
+                if (f != null) {
+                    reachable.add(f);
+                    totalFutures++;
+                }
+            }
+        }
+        if (actionCount < 2 || totalFutures == 0) {
+            return finalSignal(stateId, 0.0);
+        }
+        double avgFuturesPerAction = (double) totalFutures / actionCount;
+        double distinct = reachable.size();
+        double mi = Math.log(distinct) - Math.log(avgFuturesPerAction);
+        if (mi < 0) mi = 0;
+        if (distinct > 0 && actionCount > 0) {
+            mi += Math.log(Math.min(distinct, actionCount)) * 0.5;
+        }
+        return finalSignal(stateId, mi);
+    }
+
+    private EmpowermentSignal finalSignal(int stateId, double mi) {
+        EmpowermentSignal s = new EmpowermentSignal(stateId, mi);
+        s.setSourceNeuronId(this.getId());
+        return s;
+    }
+
+    public int getHorizon() { return horizon; }
+    public void setHorizon(int horizon) { this.horizon = Math.max(1, horizon); }
+    public int getNActionSamples() { return nActionSamples; }
+    public void setNActionSamples(int nActionSamples) { this.nActionSamples = Math.max(1, nActionSamples); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/curiosity/LearningProgressNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/curiosity/LearningProgressNeuron.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.curiosity;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.curiosity.LearningProgressSignal;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tracks per-domain {@code d(error)/dt} over a sliding window and emits an
+ * intrinsic-reward {@link LearningProgressSignal} whose magnitude is positive
+ * when error is decreasing (learning) and negative when it grows.
+ * Layer 6, loop=2 / epoch=2.
+ * <p>Biological analogue: dopaminergic reward-prediction-error scaling with
+ * positive learning progress (Oudeyer &amp; Kaplan 2007).
+ */
+public class LearningProgressNeuron extends ModulatableNeuron {
+
+    private final Map<String, Deque<Double>> errorsByDomain = new HashMap<>();
+    private int windowTicks = 200;
+
+    public LearningProgressNeuron() { super(); }
+
+    public LearningProgressNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+    }
+
+    public LearningProgressSignal recordError(String domain, double error) {
+        if (domain == null) return null;
+        Deque<Double> window = errorsByDomain.computeIfAbsent(domain, k -> new ArrayDeque<>());
+        window.addLast(error);
+        while (window.size() > windowTicks) window.removeFirst();
+        double derivative = 0;
+        if (window.size() >= 2) {
+            double first = window.peekFirst();
+            double last = window.peekLast();
+            derivative = (last - first) / Math.max(1, window.size() - 1);
+        }
+        LearningProgressSignal sig = new LearningProgressSignal(domain, derivative);
+        sig.setSourceNeuronId(this.getId());
+        return sig;
+    }
+
+    /**
+     * Intrinsic reward — positive for decreasing error.
+     */
+    public double intrinsicReward(String domain) {
+        Deque<Double> window = errorsByDomain.get(domain);
+        if (window == null || window.size() < 2) return 0.0;
+        double first = window.peekFirst();
+        double last = window.peekLast();
+        double derivative = (last - first) / Math.max(1, window.size() - 1);
+        return -derivative;
+    }
+
+    public int getWindowTicks() { return windowTicks; }
+    public void setWindowTicks(int windowTicks) { this.windowTicks = Math.max(2, windowTicks); }
+    public int domainCount() { return errorsByDomain.size(); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/curiosity/NoveltyDetectorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/curiosity/NoveltyDetectorNeuron.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.curiosity;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.curiosity.NoveltySignal;
+
+import java.util.BitSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Hash-based novelty detector using a decaying Bloom-style filter over
+ * recent context hashes. Produces a {@link NoveltySignal} whose score is
+ * high for unseen contexts and decays as a context recurs.
+ * Layer 1, loop=1 / epoch=2.
+ * <p>Biological analogue: hippocampal CA1 novelty signal (Vinogradova 2001;
+ * Lisman &amp; Grace 2005 SN/VTA loop).
+ */
+public class NoveltyDetectorNeuron extends ModulatableNeuron {
+
+    private final int bitCount;
+    private final BitSet filter;
+    private final int decayTicks;
+    private final Map<String, Long> lastSeen = new LinkedHashMap<>();
+    private long tick;
+
+    public NoveltyDetectorNeuron() {
+        this(2048, 1000);
+    }
+
+    public NoveltyDetectorNeuron(int bitCount, int decayTicks) {
+        super();
+        this.bitCount = Math.max(64, bitCount);
+        this.filter = new BitSet(this.bitCount);
+        this.decayTicks = Math.max(1, decayTicks);
+    }
+
+    public NoveltyDetectorNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+        this.bitCount = 2048;
+        this.filter = new BitSet(this.bitCount);
+        this.decayTicks = 1000;
+    }
+
+    /**
+     * Evaluate novelty of a given context hash and insert it into the filter.
+     *
+     * @return a {@link NoveltySignal} with score in [0,1].
+     */
+    public NoveltySignal evaluate(String contextHash) {
+        if (contextHash == null) return new NoveltySignal(0.0, null);
+        tick++;
+        evictStale();
+        int[] bits = hashBits(contextHash);
+        boolean allSet = true;
+        for (int b : bits) {
+            if (!filter.get(b)) { allSet = false; break; }
+        }
+        Long prev = lastSeen.get(contextHash);
+        double score;
+        if (prev == null) {
+            score = allSet ? 0.5 : 1.0;
+        } else {
+            long age = tick - prev;
+            double recency = Math.min(1.0, (double) age / decayTicks);
+            score = Math.max(0.0, Math.min(1.0, recency));
+        }
+        for (int b : bits) filter.set(b);
+        lastSeen.put(contextHash, tick);
+        NoveltySignal out = new NoveltySignal(score, contextHash);
+        out.setSourceNeuronId(this.getId());
+        return out;
+    }
+
+    private void evictStale() {
+        long cutoff = tick - (long) decayTicks * 2L;
+        lastSeen.entrySet().removeIf(e -> e.getValue() < cutoff);
+    }
+
+    private int[] hashBits(String s) {
+        int h1 = s.hashCode();
+        int h2 = Integer.reverse(h1 ^ 0x9E3779B9);
+        int h3 = Integer.rotateLeft(h1, 11) ^ 0x85EBCA6B;
+        return new int[] {
+                Math.floorMod(h1, bitCount),
+                Math.floorMod(h2, bitCount),
+                Math.floorMod(h3, bitCount)
+        };
+    }
+
+    public long getTick() { return tick; }
+    public int getBitCount() { return bitCount; }
+    public int getDecayTicks() { return decayTicks; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/curiosity/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/curiosity/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * Intrinsic motivation / curiosity subsystem.
+ *
+ * <p>Biological analogue: hippocampal novelty detection driving SN/VTA
+ * dopaminergic bursts (Lisman &amp; Grace 2005) plus prefrontal
+ * controllability / empowerment estimates (Klyubin et al. 2005).
+ *
+ * <p>Key classes:
+ * <ul>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.curiosity.NoveltyDetectorNeuron}
+ *       — Bloom-filter novelty estimator.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.curiosity.LearningProgressNeuron}
+ *       — Oudeyer &amp; Kaplan (2007) learning-progress reward.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.curiosity.EmpowermentNeuron}
+ *       — Klyubin empowerment estimator.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.curiosity.BoredomNeuron}
+ *       — habituation-driven inhibition of return.</li>
+ * </ul>
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.curiosity;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/BodySchema.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/BodySchema.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.embodiment;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Snapshot of the agent's current body schema: known effectors and their
+ * capabilities.
+ * Biological analogue: posterior parietal body schema, updated by
+ * proprioceptive feedback and tool use (Head &amp; Holmes 1911, Maravita 2004).
+ */
+public final class BodySchema implements Serializable {
+
+    private final Map<Integer, EffectorCapability> effectors;
+
+    public BodySchema() {
+        this.effectors = new HashMap<>();
+    }
+
+    public BodySchema(Map<Integer, EffectorCapability> effectors) {
+        this.effectors = effectors == null ? new HashMap<>() : new HashMap<>(effectors);
+    }
+
+    public Map<Integer, EffectorCapability> getEffectors() {
+        return Collections.unmodifiableMap(effectors);
+    }
+
+    public EffectorCapability get(int effectorId) {
+        return effectors.get(effectorId);
+    }
+
+    public boolean has(int effectorId) {
+        return effectors.containsKey(effectorId);
+    }
+
+    public int size() { return effectors.size(); }
+
+    public BodySchema with(int effectorId, EffectorCapability cap) {
+        Map<Integer, EffectorCapability> m = new HashMap<>(effectors);
+        m.put(effectorId, cap);
+        return new BodySchema(m);
+    }
+
+    public BodySchema without(int effectorId) {
+        Map<Integer, EffectorCapability> m = new HashMap<>(effectors);
+        m.remove(effectorId);
+        return new BodySchema(m);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/BodySchemaNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/BodySchemaNeuron.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.embodiment;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.BodySchemaUpdateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.ProprioceptiveSignal;
+
+/**
+ * Maintains the agent's {@link BodySchema}.
+ * Layer 2, loop=2 / epoch=3.
+ * <p>Biological analogue: posterior parietal cortex body schema neurons.
+ */
+public class BodySchemaNeuron extends ModulatableNeuron implements IEmbodied {
+
+    private BodySchema schema;
+
+    public BodySchemaNeuron() {
+        super();
+        this.schema = new BodySchema();
+    }
+
+    public BodySchemaNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+        this.schema = new BodySchema();
+    }
+
+    @Override public BodySchema currentSchema() { return schema; }
+
+    @Override
+    public void onProprioceptive(ProprioceptiveSignal s) {
+        if (s == null) return;
+        // Verify the effector is known; unseen effector registers as unknown capability
+        if (!schema.has(s.getEffectorId())) {
+            schema = schema.with(s.getEffectorId(),
+                    new EffectorCapability(s.getJointStates().length,
+                            new double[s.getJointStates().length],
+                            new double[s.getJointStates().length], 1.0, false));
+        }
+    }
+
+    /**
+     * Apply a body-schema update.
+     *
+     * @param update schema update signal
+     */
+    public void onUpdate(BodySchemaUpdateSignal update) {
+        if (update == null) return;
+        if (update.getCapability() == null) {
+            schema = schema.without(update.getEffectorId());
+        } else {
+            schema = schema.with(update.getEffectorId(), update.getCapability());
+        }
+    }
+
+    /**
+     * Register an effector directly.
+     */
+    public void register(int effectorId, EffectorCapability cap) {
+        schema = schema.with(effectorId, cap);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/EffectorCapability.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/EffectorCapability.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.embodiment;
+
+import java.io.Serializable;
+import java.util.Arrays;
+
+/**
+ * Immutable description of an effector's capabilities.
+ * Biological analogue: posterior parietal body schema's entry for a single
+ * limb/tool (Maravita &amp; Iriki 2004).
+ */
+public final class EffectorCapability implements Serializable {
+
+    private final int dof;
+    private final double[] rangeMin;
+    private final double[] rangeMax;
+    private final double health;
+    private final boolean damaged;
+
+    public EffectorCapability(int dof, double[] rangeMin, double[] rangeMax, double health, boolean damaged) {
+        this.dof = dof;
+        this.rangeMin = rangeMin == null ? new double[0] : rangeMin.clone();
+        this.rangeMax = rangeMax == null ? new double[0] : rangeMax.clone();
+        this.health = Math.max(0.0, Math.min(1.0, health));
+        this.damaged = damaged;
+    }
+
+    public int getDof() { return dof; }
+    public double[] getRangeMin() { return rangeMin.clone(); }
+    public double[] getRangeMax() { return rangeMax.clone(); }
+    public double getHealth() { return health; }
+    public boolean isDamaged() { return damaged; }
+
+    @Override public String toString() {
+        return "EffectorCapability{dof=" + dof + ", health=" + health
+                + ", damaged=" + damaged
+                + ", min=" + Arrays.toString(rangeMin)
+                + ", max=" + Arrays.toString(rangeMax) + '}';
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/EfferenceCopyNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/EfferenceCopyNeuron.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.embodiment;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.ai.signals.fast.MotorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.EfferenceCopySignal;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Intercepts every {@link MotorCommandSignal} between {@code PlanningNeuron}
+ * and {@code HarmGateNeuron} and emits an {@link EfferenceCopySignal} in
+ * parallel.
+ * Layer 4 (planning boundary), loop=1 / epoch=1.
+ * <p>Biological analogue: the classic branch-point of a descending motor
+ * command to the cerebellar forward model (Wolpert 1998).
+ */
+public class EfferenceCopyNeuron extends ModulatableNeuron implements IEfferenceCopyProducer {
+
+    private static final AtomicLong COMMAND_COUNTER = new AtomicLong(0);
+
+    public EfferenceCopyNeuron() { super(); }
+
+    public EfferenceCopyNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+    }
+
+    @Override
+    public EfferenceCopySignal produceCopy(MotorCommandSignal motor) {
+        if (motor == null) return null;
+        long cmdId = COMMAND_COUNTER.incrementAndGet();
+        double[] predicted = motor.getParams() == null ? new double[0] : motor.getParams().clone();
+        EfferenceCopySignal copy = new EfferenceCopySignal(cmdId, predicted, motor.getEffectorId());
+        copy.setSourceNeuronId(this.getId());
+        return copy;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/EmbodimentConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/EmbodimentConfig.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.embodiment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Configuration for the embodiment subsystem.
+ * Maps to the {@code embodiment:} top-level section of the jneopallium config.
+ * Default {@link #enabled} is {@code false} — embodiment must be opt-in.
+ */
+public class EmbodimentConfig {
+
+    public static class EffectorSpec {
+        private int id;
+        private String name;
+        private int dof;
+        private double healthThreshold;
+
+        public EffectorSpec() {}
+        public EffectorSpec(int id, String name, int dof, double healthThreshold) {
+            this.id = id;
+            this.name = name;
+            this.dof = dof;
+            this.healthThreshold = healthThreshold;
+        }
+        public int getId() { return id; }
+        public void setId(int id) { this.id = id; }
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+        public int getDof() { return dof; }
+        public void setDof(int dof) { this.dof = dof; }
+        public double getHealthThreshold() { return healthThreshold; }
+        public void setHealthThreshold(double healthThreshold) { this.healthThreshold = healthThreshold; }
+    }
+
+    private boolean enabled = false;
+    private List<EffectorSpec> effectors = new ArrayList<>();
+    private double efferenceCopyMismatchThreshold = 0.15;
+    private double efferenceCopyFailureEmitThreshold = 0.4;
+    private boolean toolIncorporationEnabled = true;
+    private int toolIncorporationTimeoutTicks = 600;
+
+    public EmbodimentConfig() {}
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+    public List<EffectorSpec> getEffectors() { return effectors; }
+    public void setEffectors(List<EffectorSpec> effectors) { this.effectors = effectors; }
+
+    public double getEfferenceCopyMismatchThreshold() { return efferenceCopyMismatchThreshold; }
+    public void setEfferenceCopyMismatchThreshold(double v) { this.efferenceCopyMismatchThreshold = v; }
+
+    public double getEfferenceCopyFailureEmitThreshold() { return efferenceCopyFailureEmitThreshold; }
+    public void setEfferenceCopyFailureEmitThreshold(double v) { this.efferenceCopyFailureEmitThreshold = v; }
+
+    public boolean isToolIncorporationEnabled() { return toolIncorporationEnabled; }
+    public void setToolIncorporationEnabled(boolean toolIncorporationEnabled) { this.toolIncorporationEnabled = toolIncorporationEnabled; }
+
+    public int getToolIncorporationTimeoutTicks() { return toolIncorporationTimeoutTicks; }
+    public void setToolIncorporationTimeoutTicks(int toolIncorporationTimeoutTicks) { this.toolIncorporationTimeoutTicks = toolIncorporationTimeoutTicks; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/IEfferenceCopyProducer.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/IEfferenceCopyProducer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.embodiment;
+
+import com.rakovpublic.jneuropallium.ai.signals.fast.MotorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.neuron.INeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.EfferenceCopySignal;
+
+/**
+ * Contract for neurons that emit an efference copy for each motor command
+ * they intercept.
+ * Biological analogue: cerebellar / premotor branch points that send a
+ * forward-model copy in parallel with the descending motor command.
+ */
+public interface IEfferenceCopyProducer extends INeuron {
+
+    /**
+     * Produce an efference copy for the given motor command.
+     *
+     * @param motor intercepted motor command
+     * @return efference copy signal, or {@code null} if no copy is produced
+     */
+    EfferenceCopySignal produceCopy(MotorCommandSignal motor);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/IEmbodied.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/IEmbodied.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.embodiment;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.INeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.ProprioceptiveSignal;
+
+/**
+ * Contract for neurons that own or reflect a body schema.
+ * Biological analogue: posterior parietal cortex body-schema neurons.
+ */
+public interface IEmbodied extends INeuron {
+
+    /**
+     * @return the current body schema snapshot.
+     */
+    BodySchema currentSchema();
+
+    /**
+     * React to proprioceptive feedback.
+     *
+     * @param s proprioceptive signal
+     */
+    void onProprioceptive(ProprioceptiveSignal s);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/ReafferenceComparatorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/ReafferenceComparatorNeuron.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.embodiment;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.ai.signals.slow.HarmFeedbackSignal;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.EfferenceCopySignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.ProprioceptiveSignal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Compares a stored efference copy against actual proprioceptive feedback
+ * and emits a {@link HarmFeedbackSignal} when the mismatch crosses a
+ * failure-emit threshold.
+ * Layer 1, loop=1 / epoch=1.
+ * <p>Biological analogue: cerebellar Purkinje-cell comparator.
+ */
+public class ReafferenceComparatorNeuron extends ModulatableNeuron implements IEmbodied {
+
+    private final Map<Integer, EfferenceCopySignal> pendingByEffector = new HashMap<>();
+    private BodySchema schema = new BodySchema();
+    private double mismatchThreshold = 0.15;
+    private double failureEmitThreshold = 0.4;
+    private double lastMismatch;
+
+    public ReafferenceComparatorNeuron() { super(); }
+
+    public ReafferenceComparatorNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+    }
+
+    public void registerEfferenceCopy(EfferenceCopySignal s) {
+        if (s == null) return;
+        pendingByEffector.put(s.getEffectorId(), s);
+    }
+
+    @Override public BodySchema currentSchema() { return schema; }
+
+    @Override
+    public void onProprioceptive(ProprioceptiveSignal p) {
+        if (p == null) return;
+        EfferenceCopySignal expected = pendingByEffector.remove(p.getEffectorId());
+        if (expected == null) return;
+        double[] predicted = expected.getPredictedOutcome();
+        double[] actual = p.getJointStates();
+        int n = Math.min(predicted.length, actual.length);
+        double sumSq = 0;
+        for (int i = 0; i < n; i++) {
+            double d = predicted[i] - actual[i];
+            sumSq += d * d;
+        }
+        int maxLen = Math.max(predicted.length, actual.length);
+        if (maxLen == 0) {
+            lastMismatch = 0;
+            return;
+        }
+        lastMismatch = Math.sqrt(sumSq / Math.max(1, n));
+    }
+
+    /**
+     * Evaluate the last mismatch and, when over threshold, emit a
+     * hardware-failure harm feedback.
+     *
+     * @param actionPlanId id of the action plan associated with the motor command
+     * @return a {@link HarmFeedbackSignal} when the mismatch exceeds the
+     *         failure-emit threshold; {@code null} otherwise.
+     */
+    public HarmFeedbackSignal maybeEmitFailure(String actionPlanId) {
+        if (lastMismatch < failureEmitThreshold) return null;
+        HarmFeedbackSignal fb = new HarmFeedbackSignal(actionPlanId, true,
+                new double[]{lastMismatch, 0, 0, 0, 0}, "mechanical");
+        fb.setSourceNeuronId(this.getId());
+        return fb;
+    }
+
+    public double getLastMismatch() { return lastMismatch; }
+    public double getMismatchThreshold() { return mismatchThreshold; }
+    public void setMismatchThreshold(double mismatchThreshold) { this.mismatchThreshold = mismatchThreshold; }
+    public double getFailureEmitThreshold() { return failureEmitThreshold; }
+    public void setFailureEmitThreshold(double failureEmitThreshold) { this.failureEmitThreshold = failureEmitThreshold; }
+    public int pendingCount() { return pendingByEffector.size(); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/ToolIncorporationNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/ToolIncorporationNeuron.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.embodiment;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.BodySchemaUpdateSignal;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Extends the body schema when the agent holds or mounts a tool.
+ * Layer 2, loop=2 / epoch=5.
+ * <p>Biological analogue: parieto-premotor tool incorporation
+ * (Maravita &amp; Iriki 2004).
+ */
+public class ToolIncorporationNeuron extends ModulatableNeuron {
+
+    private final Map<Integer, EffectorCapability> priorSchema = new HashMap<>();
+    private final Set<Integer> toolEffectors = new HashSet<>();
+    private int timeoutTicks = 600;
+
+    public ToolIncorporationNeuron() { super(); }
+
+    public ToolIncorporationNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+    }
+
+    /**
+     * Incorporate a tool into the body schema, emitting a schema update.
+     *
+     * @param target existing {@link BodySchemaNeuron} to update
+     * @param effectorId id of the tool effector slot
+     * @param toolCapability tool's capability description
+     */
+    public BodySchemaUpdateSignal incorporate(BodySchemaNeuron target, int effectorId, EffectorCapability toolCapability) {
+        if (target == null || toolCapability == null) return null;
+        EffectorCapability prior = target.currentSchema().get(effectorId);
+        if (prior != null) priorSchema.put(effectorId, prior);
+        toolEffectors.add(effectorId);
+        target.register(effectorId, toolCapability);
+        BodySchemaUpdateSignal sig = new BodySchemaUpdateSignal(effectorId, toolCapability, false);
+        sig.setTool(true);
+        sig.setSourceNeuronId(this.getId());
+        return sig;
+    }
+
+    /**
+     * Reverse a prior tool incorporation, restoring the original effector (or removing it).
+     *
+     * @param target existing {@link BodySchemaNeuron}
+     * @param effectorId tool effector slot
+     */
+    public BodySchemaUpdateSignal release(BodySchemaNeuron target, int effectorId) {
+        if (target == null || !toolEffectors.contains(effectorId)) return null;
+        toolEffectors.remove(effectorId);
+        EffectorCapability prior = priorSchema.remove(effectorId);
+        if (prior == null) {
+            target.onUpdate(new BodySchemaUpdateSignal(effectorId, null, false));
+        } else {
+            target.register(effectorId, prior);
+        }
+        BodySchemaUpdateSignal sig = new BodySchemaUpdateSignal(effectorId, prior, false);
+        sig.setTool(false);
+        sig.setSourceNeuronId(this.getId());
+        return sig;
+    }
+
+    public boolean isToolEffector(int effectorId) { return toolEffectors.contains(effectorId); }
+
+    public int getTimeoutTicks() { return timeoutTicks; }
+    public void setTimeoutTicks(int timeoutTicks) { this.timeoutTicks = timeoutTicks; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * Embodiment / proprioception subsystem.
+ *
+ * <p>Biological analogue: posterior parietal cortex body-schema circuits
+ * plus cerebellar efference-copy forward models
+ * (Wolpert, Miall &amp; Kawato 1998; Maravita &amp; Iriki 2004).
+ *
+ * <p>Key classes:
+ * <ul>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.embodiment.EfferenceCopyNeuron}
+ *       — forward-model branch point.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.embodiment.BodySchemaNeuron}
+ *       — maintains effector body schema.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.embodiment.ToolIncorporationNeuron}
+ *       — extends body schema with tools.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.embodiment.ReafferenceComparatorNeuron}
+ *       — compares efference copy against actual proprioceptive input.</li>
+ * </ul>
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.embodiment;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/AstrocyteNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/AstrocyteNeuron.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.glia.CalciumWaveSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.glia.GliotransmitterSignal;
+
+/**
+ * Support neuron that integrates local activity and emits both a
+ * {@link CalciumWaveSignal} (when activity exceeds the calcium-wave
+ * threshold) and a {@link GliotransmitterSignal} regulating local
+ * excitability.
+ * Support layer; loop=2 / epoch=1.
+ * <p>Biological analogue: protoplasmic astrocyte at the tripartite
+ * synapse (Volterra &amp; Meldolesi 2005).
+ */
+public class AstrocyteNeuron extends ModulatableNeuron {
+
+    private final int regionId;
+    private double integratedActivity;
+    private double calciumWaveThreshold = 0.4;
+    private double propagationRadius = 1.0;
+
+    public AstrocyteNeuron() { this(0); }
+
+    public AstrocyteNeuron(int regionId) {
+        super();
+        this.regionId = regionId;
+    }
+
+    public AstrocyteNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+        this.regionId = 0;
+    }
+
+    public void accumulate(double activityDelta) {
+        integratedActivity = Math.max(0.0, integratedActivity + activityDelta);
+    }
+
+    /**
+     * Check the integrated activity and, if it exceeds threshold, emit a
+     * calcium wave. Clears the integrator as a side-effect of emission.
+     */
+    public CalciumWaveSignal maybeEmitWave() {
+        if (integratedActivity < calciumWaveThreshold) return null;
+        CalciumWaveSignal s = new CalciumWaveSignal(regionId, integratedActivity, propagationRadius);
+        s.setSourceNeuronId(this.getId());
+        integratedActivity = 0.0;
+        return s;
+    }
+
+    public GliotransmitterSignal release(GliotransmitterType t, double concentration) {
+        GliotransmitterSignal s = new GliotransmitterSignal(t, concentration, regionId);
+        s.setSourceNeuronId(this.getId());
+        return s;
+    }
+
+    public int getRegionId() { return regionId; }
+    public double getIntegratedActivity() { return integratedActivity; }
+    public double getCalciumWaveThreshold() { return calciumWaveThreshold; }
+    public void setCalciumWaveThreshold(double v) { this.calciumWaveThreshold = Math.max(0.0, v); }
+    public double getPropagationRadius() { return propagationRadius; }
+    public void setPropagationRadius(double v) { this.propagationRadius = Math.max(0.0, v); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/DelayQueue.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/DelayQueue.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia;
+
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Per-target delay queue used by the dispatcher wrapper around
+ * {@link DelayedAxon}. Signals are enqueued with a release-tick; calling
+ * {@link #releaseReady(long)} returns (and removes) all signals whose
+ * {@code releaseAtTick <= currentTick}.
+ * <p>State lives here, not in any {@link com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor}.
+ */
+public class DelayQueue {
+
+    private static class Entry {
+        final long releaseAtTick;
+        final long targetNeuronId;
+        final ISignal signal;
+        Entry(long releaseAtTick, long targetNeuronId, ISignal signal) {
+            this.releaseAtTick = releaseAtTick;
+            this.targetNeuronId = targetNeuronId;
+            this.signal = signal;
+        }
+    }
+
+    private final Map<Long, Deque<Entry>> byTarget = new HashMap<>();
+
+    public void enqueue(long currentTick, long targetNeuronId, ISignal signal, int delayTicks) {
+        if (signal == null) return;
+        long release = currentTick + Math.max(0, delayTicks);
+        byTarget.computeIfAbsent(targetNeuronId, k -> new ArrayDeque<>())
+                .add(new Entry(release, targetNeuronId, signal));
+    }
+
+    /**
+     * Return and remove every queued signal whose release tick has been
+     * reached. The returned list is ordered by target id, then FIFO.
+     */
+    public List<ReleasedSignal> releaseReady(long currentTick) {
+        List<ReleasedSignal> out = new ArrayList<>();
+        for (Map.Entry<Long, Deque<Entry>> bucket : byTarget.entrySet()) {
+            Deque<Entry> q = bucket.getValue();
+            while (!q.isEmpty() && q.peekFirst().releaseAtTick <= currentTick) {
+                Entry e = q.removeFirst();
+                out.add(new ReleasedSignal(e.targetNeuronId, e.signal));
+            }
+        }
+        byTarget.values().removeIf(Deque::isEmpty);
+        return out;
+    }
+
+    public int pending() {
+        int total = 0;
+        for (Deque<Entry> q : byTarget.values()) total += q.size();
+        return total;
+    }
+
+    public int pendingFor(long targetNeuronId) {
+        Deque<Entry> q = byTarget.get(targetNeuronId);
+        return q == null ? 0 : q.size();
+    }
+
+    public static class ReleasedSignal {
+        public final long targetNeuronId;
+        public final ISignal signal;
+        public ReleasedSignal(long targetNeuronId, ISignal signal) {
+            this.targetNeuronId = targetNeuronId;
+            this.signal = signal;
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/DelayedAxon.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/DelayedAxon.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.Axon;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Axon subclass that carries per-connection propagation delays in ticks.
+ * The signal dispatcher inspects {@link #getDelay(long)} and, if non-zero,
+ * enqueues the outgoing signal for delivery {@code delay} ticks later.
+ * <p>Biological analogue: myelinated axon with activity-dependent
+ * propagation speed (Fields 2015).
+ */
+public class DelayedAxon extends Axon {
+
+    private final Map<Long, Integer> perConnectionDelayTicks = new ConcurrentHashMap<>();
+    private int baselineDelayTicks = 5;
+    private int minDelayTicks = 1;
+
+    public DelayedAxon() { super(); }
+
+    public DelayedAxon(int baselineDelayTicks, int minDelayTicks) {
+        super();
+        this.baselineDelayTicks = Math.max(0, baselineDelayTicks);
+        this.minDelayTicks = Math.max(0, minDelayTicks);
+    }
+
+    /**
+     * @return the delay in ticks currently configured for a given target
+     * neuron, or {@code 0} if none configured.
+     */
+    public int getDelay(long targetNeuronId) {
+        Integer d = perConnectionDelayTicks.get(targetNeuronId);
+        return d == null ? 0 : d;
+    }
+
+    /**
+     * Set the delay for a target; the value is clamped into
+     * {@code [minDelayTicks, baselineDelayTicks]} so that myelination can
+     * never push a delay above the configured maximum.
+     */
+    public void setDelay(long targetNeuronId, int ticks) {
+        int clamped = Math.max(minDelayTicks, Math.min(baselineDelayTicks, ticks));
+        perConnectionDelayTicks.put(targetNeuronId, clamped);
+    }
+
+    /**
+     * Unconditionally remove any delay for a connection.
+     */
+    public void removeDelay(long targetNeuronId) {
+        perConnectionDelayTicks.remove(targetNeuronId);
+    }
+
+    /**
+     * Monotonic accelerator: reduces delay for a frequently-used path
+     * toward {@link #minDelayTicks} but never below it and never above
+     * {@link #baselineDelayTicks}. Used by {@link MyelinationNeuron}.
+     *
+     * @return the new delay after the decrement.
+     */
+    public int accelerate(long targetNeuronId, int decrement) {
+        int current = perConnectionDelayTicks.getOrDefault(targetNeuronId, baselineDelayTicks);
+        int next = Math.max(minDelayTicks, current - Math.max(0, decrement));
+        perConnectionDelayTicks.put(targetNeuronId, next);
+        return next;
+    }
+
+    /**
+     * Demyelinate: restore the baseline delay; never pushes beyond baseline.
+     */
+    public int demyelinate(long targetNeuronId) {
+        perConnectionDelayTicks.put(targetNeuronId, baselineDelayTicks);
+        return baselineDelayTicks;
+    }
+
+    public int getBaselineDelayTicks() { return baselineDelayTicks; }
+    public void setBaselineDelayTicks(int baselineDelayTicks) { this.baselineDelayTicks = Math.max(0, baselineDelayTicks); }
+    public int getMinDelayTicks() { return minDelayTicks; }
+    public void setMinDelayTicks(int minDelayTicks) { this.minDelayTicks = Math.max(0, minDelayTicks); }
+
+    public int connectionCount() { return perConnectionDelayTicks.size(); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/GliaConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/GliaConfig.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia;
+
+/**
+ * Configuration for the glial support subsystem (astrocytes, microglia,
+ * oligodendrocytes / myelination). Default {@link #enabled} is
+ * {@code false} — glial features are opt-in.
+ */
+public class GliaConfig {
+
+    public static class Astrocytes {
+        private boolean perLayer = true;
+        private double calciumWaveThreshold = 0.4;
+        public boolean isPerLayer() { return perLayer; }
+        public void setPerLayer(boolean perLayer) { this.perLayer = perLayer; }
+        public double getCalciumWaveThreshold() { return calciumWaveThreshold; }
+        public void setCalciumWaveThreshold(double v) { this.calciumWaveThreshold = v; }
+    }
+
+    public static class Microglia {
+        private boolean pruningEnabled = true;
+        private int minInactivityTicks = 2000;
+        private int maxPruningsPerEpoch = 10;
+        public boolean isPruningEnabled() { return pruningEnabled; }
+        public void setPruningEnabled(boolean v) { this.pruningEnabled = v; }
+        public int getMinInactivityTicks() { return minInactivityTicks; }
+        public void setMinInactivityTicks(int v) { this.minInactivityTicks = v; }
+        public int getMaxPruningsPerEpoch() { return maxPruningsPerEpoch; }
+        public void setMaxPruningsPerEpoch(int v) { this.maxPruningsPerEpoch = v; }
+    }
+
+    public static class Myelination {
+        private boolean enabled = true;
+        private int baselineDelayTicks = 5;
+        private int minDelayTicks = 1;
+        private int activityWindow = 500;
+        private int delayDecrementPerWindow = 1;
+        public boolean isEnabled() { return enabled; }
+        public void setEnabled(boolean v) { this.enabled = v; }
+        public int getBaselineDelayTicks() { return baselineDelayTicks; }
+        public void setBaselineDelayTicks(int v) { this.baselineDelayTicks = v; }
+        public int getMinDelayTicks() { return minDelayTicks; }
+        public void setMinDelayTicks(int v) { this.minDelayTicks = v; }
+        public int getActivityWindow() { return activityWindow; }
+        public void setActivityWindow(int v) { this.activityWindow = v; }
+        public int getDelayDecrementPerWindow() { return delayDecrementPerWindow; }
+        public void setDelayDecrementPerWindow(int v) { this.delayDecrementPerWindow = v; }
+    }
+
+    private boolean enabled = false;
+    private Astrocytes astrocytes = new Astrocytes();
+    private Microglia microglia = new Microglia();
+    private Myelination myelination = new Myelination();
+
+    public GliaConfig() {}
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public Astrocytes getAstrocytes() { return astrocytes; }
+    public void setAstrocytes(Astrocytes astrocytes) { this.astrocytes = astrocytes; }
+    public Microglia getMicroglia() { return microglia; }
+    public void setMicroglia(Microglia microglia) { this.microglia = microglia; }
+    public Myelination getMyelination() { return myelination; }
+    public void setMyelination(Myelination myelination) { this.myelination = myelination; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/GliotransmitterType.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/GliotransmitterType.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia;
+
+/**
+ * The gliotransmitter being released. Mirrors the three classical
+ * astrocytic gliotransmitters (Araque et al. 2014).
+ */
+public enum GliotransmitterType {
+    GLUTAMATE,
+    ATP,
+    D_SERINE
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/MicroglialPruningNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/MicroglialPruningNeuron.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.glia.PruningSignal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Emits {@link PruningSignal}s for connections that have been inactive
+ * for at least {@link #minInactivityTicks} and respects a per-epoch
+ * cap {@link #maxPruningsPerEpoch}.
+ * Support layer; loop=2 / epoch=5.
+ * <p>Biological analogue: microglial synaptic pruning
+ * (Schafer et al. 2012).
+ */
+public class MicroglialPruningNeuron extends ModulatableNeuron {
+
+    /** Connection key: encoded {@code (sourceId, targetId)}. */
+    private static class Key {
+        final long source;
+        final long target;
+        Key(long s, long t) { source = s; target = t; }
+        @Override public boolean equals(Object o) {
+            if (!(o instanceof Key)) return false;
+            Key k = (Key) o;
+            return k.source == source && k.target == target;
+        }
+        @Override public int hashCode() { return (int) (source * 31L + target); }
+    }
+
+    private final Map<Key, Long> lastActivityTick = new HashMap<>();
+    private long currentTick;
+    private int minInactivityTicks = 2000;
+    private int maxPruningsPerEpoch = 10;
+    private int emittedThisEpoch;
+
+    public MicroglialPruningNeuron() { super(); }
+
+    public MicroglialPruningNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+    }
+
+    public void tick() { currentTick++; }
+    public long getCurrentTick() { return currentTick; }
+
+    public void recordActivity(long sourceId, long targetId) {
+        lastActivityTick.put(new Key(sourceId, targetId), currentTick);
+    }
+
+    /**
+     * If the connection has been silent for at least
+     * {@link #minInactivityTicks} and the per-epoch cap is not exceeded,
+     * return a pruning signal; otherwise return {@code null}.
+     */
+    public PruningSignal maybePrune(long sourceId, long targetId, String reason) {
+        if (emittedThisEpoch >= maxPruningsPerEpoch) return null;
+        Key k = new Key(sourceId, targetId);
+        Long last = lastActivityTick.get(k);
+        long silent = (last == null) ? currentTick : currentTick - last;
+        if (silent < minInactivityTicks) return null;
+        emittedThisEpoch++;
+        lastActivityTick.remove(k);
+        PruningSignal p = new PruningSignal(sourceId, targetId, reason == null ? "inactivity" : reason);
+        p.setSourceNeuronId(this.getId());
+        return p;
+    }
+
+    public void resetEpochCounter() { emittedThisEpoch = 0; }
+
+    public int getMinInactivityTicks() { return minInactivityTicks; }
+    public void setMinInactivityTicks(int v) { this.minInactivityTicks = Math.max(1, v); }
+    public int getMaxPruningsPerEpoch() { return maxPruningsPerEpoch; }
+    public void setMaxPruningsPerEpoch(int v) { this.maxPruningsPerEpoch = Math.max(0, v); }
+    public int emittedThisEpoch() { return emittedThisEpoch; }
+    public int trackedConnections() { return lastActivityTick.size(); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/MyelinationNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/MyelinationNeuron.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.glia.MyelinationSignal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Tracks activity on connections and issues {@link MyelinationSignal}s
+ * that reduce the delay on frequently-used paths toward
+ * {@link #minDelayTicks} (but never below it). Biological invariant:
+ * myelination only decreases delay, demyelination restores baseline.
+ * Support layer; loop=2 / epoch=10.
+ * <p>Biological analogue: activity-dependent oligodendrocyte myelination
+ * (Fields 2015; Gibson et al. 2014).
+ */
+public class MyelinationNeuron extends ModulatableNeuron {
+
+    private final Map<Long, Integer> usageSinceLastWindow = new HashMap<>();
+    private final Map<Long, Integer> currentDelay = new HashMap<>();
+    private int baselineDelayTicks = 5;
+    private int minDelayTicks = 1;
+    private int activityWindow = 500;
+    private int delayDecrementPerWindow = 1;
+    private int usageThreshold = 10;
+    private double consolidationBoost = 1.0;
+
+    public MyelinationNeuron() { super(); }
+
+    public MyelinationNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+    }
+
+    public void recordUsage(long targetNeuronId) {
+        usageSinceLastWindow.merge(targetNeuronId, 1, Integer::sum);
+    }
+
+    /**
+     * After an activity window closes, examine usage counts and issue a
+     * myelination signal for any connection crossing {@link #usageThreshold},
+     * reducing its delay by up to {@link #delayDecrementPerWindow} ×
+     * {@link #consolidationBoost} ticks.
+     */
+    public MyelinationSignal evaluate(long sourceNeuronId, long targetNeuronId) {
+        int usage = usageSinceLastWindow.getOrDefault(targetNeuronId, 0);
+        if (usage < usageThreshold) return null;
+        int current = currentDelay.getOrDefault(targetNeuronId, baselineDelayTicks);
+        int decrement = (int) Math.round(delayDecrementPerWindow * consolidationBoost);
+        int next = Math.max(minDelayTicks, current - Math.max(1, decrement));
+        if (next >= current) return null;
+        currentDelay.put(targetNeuronId, next);
+        usageSinceLastWindow.put(targetNeuronId, 0);
+        MyelinationSignal m = new MyelinationSignal(sourceNeuronId, targetNeuronId, next);
+        m.setSourceNeuronId(this.getId());
+        return m;
+    }
+
+    /**
+     * Apply a myelination signal to a {@link DelayedAxon}. Honors the
+     * invariant that myelination never pushes delay above baseline.
+     */
+    public void applyTo(DelayedAxon axon, MyelinationSignal sig) {
+        if (axon == null || sig == null) return;
+        axon.setDelay(sig.getAxonTargetId(), sig.getNewDelayTicks());
+    }
+
+    /**
+     * Demyelinate: restore baseline delay on the given connection.
+     */
+    public void demyelinate(DelayedAxon axon, long targetNeuronId) {
+        if (axon != null) axon.demyelinate(targetNeuronId);
+        currentDelay.put(targetNeuronId, baselineDelayTicks);
+    }
+
+    public void resetWindow() { usageSinceLastWindow.clear(); }
+    public int currentDelayFor(long targetNeuronId) { return currentDelay.getOrDefault(targetNeuronId, baselineDelayTicks); }
+
+    public int getBaselineDelayTicks() { return baselineDelayTicks; }
+    public void setBaselineDelayTicks(int v) { this.baselineDelayTicks = Math.max(0, v); }
+    public int getMinDelayTicks() { return minDelayTicks; }
+    public void setMinDelayTicks(int v) { this.minDelayTicks = Math.max(0, v); }
+    public int getActivityWindow() { return activityWindow; }
+    public void setActivityWindow(int v) { this.activityWindow = Math.max(1, v); }
+    public int getDelayDecrementPerWindow() { return delayDecrementPerWindow; }
+    public void setDelayDecrementPerWindow(int v) { this.delayDecrementPerWindow = Math.max(1, v); }
+    public int getUsageThreshold() { return usageThreshold; }
+    public void setUsageThreshold(int v) { this.usageThreshold = Math.max(1, v); }
+    public double getConsolidationBoost() { return consolidationBoost; }
+    public void setConsolidationBoost(double v) { this.consolidationBoost = Math.max(1.0, v); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/package-info.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * Glial support subsystem — astrocytes, microglia, oligodendrocytes.
+ * Introduces activity-dependent per-connection propagation delay
+ * ({@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia.DelayedAxon})
+ * which is the headline capability of this module.
+ *
+ * <p>Biological analogues and citations:
+ * <ul>
+ *   <li>Astrocytic calcium waves &amp; gliotransmission: Volterra &amp;
+ *       Meldolesi 2005; Araque et al. 2014.</li>
+ *   <li>Microglial synaptic pruning: Schafer et al. 2012; Paolicelli et al.
+ *       2011.</li>
+ *   <li>Activity-dependent myelination: Fields 2015; Gibson et al. 2014.</li>
+ * </ul>
+ *
+ * <p>Key classes:
+ * <ul>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia.DelayedAxon}
+ *       — axon with per-connection myelination delays.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia.AstrocyteNeuron}
+ *       — local activity integrator.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia.MicroglialPruningNeuron}
+ *       — emits {@code PruningSignal}s for inactive connections.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia.MyelinationNeuron}
+ *       — accelerates frequently-used paths.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia.DelayQueue}
+ *       — dispatcher-side delay queue for delayed signal delivery.</li>
+ * </ul>
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/HippocampalReplayNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/HippocampalReplayNeuron.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.sleep;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.sleep.ReplaySignal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+/**
+ * Selects high-salience recent episodes and emits compressed replays in
+ * the configured direction. Maintains a bounded recent-episode buffer.
+ * Layer 3, loop=2 / epoch=3.
+ * <p>Biological analogue: CA1 place-cell sequence reactivation during
+ * rest (Wilson &amp; McNaughton 1994; Foster &amp; Wilson 2006).
+ */
+public class HippocampalReplayNeuron extends ModulatableNeuron {
+
+    private final LinkedHashMap<String, Episode> buffer = new LinkedHashMap<>();
+    private int topK = 20;
+    private double compressionRatio = 10.0;
+    private ReplayDirection direction = ReplayDirection.REVERSE;
+    private final Random rng = new Random(0xC0FFEEL);
+
+    public HippocampalReplayNeuron() { super(); }
+
+    public HippocampalReplayNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+    }
+
+    public void recordEpisode(String id, List<Long> neuronSequence, double salience) {
+        if (id == null || neuronSequence == null) return;
+        buffer.put(id, new Episode(id, new ArrayList<>(neuronSequence), Math.max(0.0, salience)));
+    }
+
+    /**
+     * Choose the top-K by salience and emit replays, each in the
+     * configured direction, at the configured compression ratio.
+     */
+    public List<ReplaySignal> emitTopK() {
+        List<Episode> eps = new ArrayList<>(buffer.values());
+        eps.sort((a, b) -> Double.compare(b.salience, a.salience));
+        List<ReplaySignal> out = new ArrayList<>();
+        int n = Math.min(topK, eps.size());
+        for (int i = 0; i < n; i++) {
+            Episode e = eps.get(i);
+            List<Long> seq = new ArrayList<>(e.sequence);
+            switch (direction) {
+                case REVERSE: Collections.reverse(seq); break;
+                case SHUFFLED: Collections.shuffle(seq, rng); break;
+                case FORWARD: default: break;
+            }
+            ReplaySignal r = new ReplaySignal(e.id, direction, compressionRatio, seq);
+            r.setSourceNeuronId(this.getId());
+            out.add(r);
+        }
+        return out;
+    }
+
+    public int bufferedEpisodes() { return buffer.size(); }
+    public int getTopK() { return topK; }
+    public void setTopK(int v) { this.topK = Math.max(0, v); }
+    public double getCompressionRatio() { return compressionRatio; }
+    public void setCompressionRatio(double v) { this.compressionRatio = Math.max(1.0, v); }
+    public ReplayDirection getDirection() { return direction; }
+    public void setDirection(ReplayDirection d) { this.direction = d == null ? ReplayDirection.REVERSE : d; }
+
+    private static class Episode {
+        final String id;
+        final List<Long> sequence;
+        final double salience;
+        Episode(String id, List<Long> sequence, double salience) {
+            this.id = id; this.sequence = sequence; this.salience = salience;
+        }
+    }
+
+    public Map<String, Double> debugSalienceMap() {
+        Map<String, Double> m = new LinkedHashMap<>();
+        for (Map.Entry<String, Episode> e : buffer.entrySet()) m.put(e.getKey(), e.getValue().salience);
+        return m;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/REMDreamingNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/REMDreamingNeuron.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.sleep;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.sleep.DreamSignal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+/**
+ * Recombines episode bindings during REM to generate candidate plans with
+ * {@code priority=low, source=DREAM}. Consumers must still route those
+ * candidates through {@code HarmGateNeuron} before any motor execution —
+ * the safety invariant for sleep-generated plans.
+ * Layer 3, loop=2 / epoch=5.
+ * <p>Biological analogue: prefrontal-cortex REM recombination
+ * (Wamsley &amp; Stickgold 2011).
+ */
+public class REMDreamingNeuron extends ModulatableNeuron {
+
+    private int recombinationCount = 5;
+    private double maxNoveltyForPlanning = 0.7;
+    private final Random rng = new Random(0xBEEFBEEFL);
+
+    public REMDreamingNeuron() { super(); }
+
+    public REMDreamingNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+    }
+
+    /**
+     * Generate up to {@link #recombinationCount} dream signals by shuffled
+     * recombination of bindings across the supplied episodes. Dreams whose
+     * novelty exceeds {@link #maxNoveltyForPlanning} are still emitted so
+     * tests can validate that a high-harm dream still reaches the harm gate
+     * — the safety invariant for REM-originated plans.
+     */
+    public List<DreamSignal> recombine(SleepPhase phase, List<List<Long>> episodes) {
+        List<DreamSignal> out = new ArrayList<>();
+        if (phase != SleepPhase.REM || episodes == null || episodes.isEmpty()) return out;
+        List<Long> pool = new ArrayList<>();
+        for (List<Long> e : episodes) if (e != null) pool.addAll(e);
+        if (pool.isEmpty()) return out;
+        Set<Long> seenInPool = new HashSet<>(pool);
+        for (int i = 0; i < recombinationCount; i++) {
+            List<Long> shuffled = new ArrayList<>(pool);
+            Collections.shuffle(shuffled, rng);
+            int size = Math.min(shuffled.size(), 1 + rng.nextInt(Math.max(1, pool.size())));
+            List<Long> bindings = new ArrayList<>(shuffled.subList(0, size));
+            Set<Long> uniq = new HashSet<>(bindings);
+            double novelty = seenInPool.isEmpty() ? 0.0
+                    : 1.0 - ((double) uniq.size() / seenInPool.size());
+            DreamSignal d = new DreamSignal(bindings, clamp01(novelty));
+            d.setSourceNeuronId(this.getId());
+            out.add(d);
+        }
+        return out;
+    }
+
+    /**
+     * Filter predicate used by a planner to reject unsafe high-novelty
+     * dreams from being proposed as plans.
+     */
+    public boolean isPlanningCandidate(DreamSignal dream) {
+        if (dream == null) return false;
+        return dream.getNoveltyScore() <= maxNoveltyForPlanning;
+    }
+
+    private static double clamp01(double v) { return Math.max(0.0, Math.min(1.0, v)); }
+
+    public int getRecombinationCount() { return recombinationCount; }
+    public void setRecombinationCount(int v) { this.recombinationCount = Math.max(1, v); }
+    public double getMaxNoveltyForPlanning() { return maxNoveltyForPlanning; }
+    public void setMaxNoveltyForPlanning(double v) { this.maxNoveltyForPlanning = clamp01(v); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/ReplayDirection.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/ReplayDirection.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.sleep;
+
+/**
+ * Direction in which a hippocampal replay traverses a recorded episode.
+ * Biological default is {@link #REVERSE} during rest immediately after
+ * experience (Foster &amp; Wilson 2006).
+ */
+public enum ReplayDirection {
+    FORWARD,
+    REVERSE,
+    SHUFFLED
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/SharpWaveRippleNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/SharpWaveRippleNeuron.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.sleep;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.sleep.SharpWaveRippleSignal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Emits a compressed burst replay during NREM3. Output is routed to
+ * {@code LongTermMemoryNeuron}'s consolidation processor via the fast-path
+ * documented in the autonomous-AI paper.
+ * Layer 3, loop=2 / epoch=1.
+ * <p>Biological analogue: hippocampal sharp-wave ripples (Buzsáki 2015).
+ */
+public class SharpWaveRippleNeuron extends ModulatableNeuron {
+
+    private double minNrem3Depth = 0.6;
+
+    public SharpWaveRippleNeuron() { super(); }
+
+    public SharpWaveRippleNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+    }
+
+    /**
+     * Emit a sharp-wave ripple for the provided neuron sequence if the
+     * controller phase is NREM3 with depth &gt;= {@link #minNrem3Depth}.
+     */
+    public SharpWaveRippleSignal maybeEmit(SleepPhase phase, double depth, List<Long> neuronSequence, double power) {
+        if (phase != SleepPhase.NREM3) return null;
+        if (depth < minNrem3Depth) return null;
+        List<Long> seq = neuronSequence == null ? new ArrayList<>() : new ArrayList<>(neuronSequence);
+        SharpWaveRippleSignal s = new SharpWaveRippleSignal(seq, power);
+        s.setSourceNeuronId(this.getId());
+        return s;
+    }
+
+    public double getMinNrem3Depth() { return minNrem3Depth; }
+    public void setMinNrem3Depth(double v) { this.minNrem3Depth = Math.max(0.0, Math.min(1.0, v)); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/SleepConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/SleepConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.sleep;
+
+/**
+ * Configuration for the sleep / replay / offline-consolidation subsystem.
+ * Default {@link #enabled} is {@code false} — sleep must be opt-in.
+ */
+public class SleepConfig {
+
+    public static class Circadian {
+        private int cycleTicks = 10000;
+        private double nremFraction = 0.6;
+        private double remFraction = 0.15;
+        public int getCycleTicks() { return cycleTicks; }
+        public void setCycleTicks(int v) { this.cycleTicks = v; }
+        public double getNremFraction() { return nremFraction; }
+        public void setNremFraction(double v) { this.nremFraction = v; }
+        public double getRemFraction() { return remFraction; }
+        public void setRemFraction(double v) { this.remFraction = v; }
+    }
+
+    public static class Replay {
+        private ReplayDirection direction = ReplayDirection.REVERSE;
+        private double compressionRatio = 10.0;
+        private int topKEpisodes = 20;
+        public ReplayDirection getDirection() { return direction; }
+        public void setDirection(ReplayDirection d) { this.direction = d; }
+        public double getCompressionRatio() { return compressionRatio; }
+        public void setCompressionRatio(double v) { this.compressionRatio = v; }
+        public int getTopKEpisodes() { return topKEpisodes; }
+        public void setTopKEpisodes(int v) { this.topKEpisodes = v; }
+    }
+
+    public static class Dreaming {
+        private int recombinationCount = 5;
+        private double maxNoveltyForPlanning = 0.7;
+        public int getRecombinationCount() { return recombinationCount; }
+        public void setRecombinationCount(int v) { this.recombinationCount = v; }
+        public double getMaxNoveltyForPlanning() { return maxNoveltyForPlanning; }
+        public void setMaxNoveltyForPlanning(double v) { this.maxNoveltyForPlanning = v; }
+    }
+
+    private boolean enabled = false;
+    private Circadian circadian = new Circadian();
+    private Replay replay = new Replay();
+    private Dreaming dreaming = new Dreaming();
+    private double consolidationBoost = 3.0;
+
+    public SleepConfig() {}
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public Circadian getCircadian() { return circadian; }
+    public void setCircadian(Circadian circadian) { this.circadian = circadian; }
+    public Replay getReplay() { return replay; }
+    public void setReplay(Replay replay) { this.replay = replay; }
+    public Dreaming getDreaming() { return dreaming; }
+    public void setDreaming(Dreaming dreaming) { this.dreaming = dreaming; }
+    public double getConsolidationBoost() { return consolidationBoost; }
+    public void setConsolidationBoost(double v) { this.consolidationBoost = Math.max(1.0, v); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/SleepControllerNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/SleepControllerNeuron.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.sleep;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.sleep.SleepStateSignal;
+
+/**
+ * Drives the sleep-wake cycle on a fixed circadian period supplied by
+ * {@code CircadianNeuron}. Emits {@link SleepStateSignal}s with the
+ * current phase and depth and gates other sleep neurons.
+ * Layer 7, loop=2 / epoch=10.
+ * <p>Biological analogue: suprachiasmatic-nucleus + brainstem sleep-wake
+ * control (Saper et al. 2005).
+ */
+public class SleepControllerNeuron extends ModulatableNeuron {
+
+    private int cycleTicks = 10000;
+    private double nremFraction = 0.6;
+    private double remFraction = 0.15;
+    private long tick;
+    private SleepPhase phase = SleepPhase.WAKE;
+
+    public SleepControllerNeuron() { super(); }
+
+    public SleepControllerNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+    }
+
+    public SleepStateSignal advance() {
+        tick++;
+        double progress = (tick % cycleTicks) / (double) cycleTicks;
+        double wakeEnd = 1.0 - (nremFraction + remFraction);
+        double nremEnd = wakeEnd + nremFraction;
+        double depth;
+        if (progress < wakeEnd) {
+            phase = SleepPhase.WAKE;
+            depth = 0.0;
+        } else if (progress < nremEnd) {
+            double relative = (progress - wakeEnd) / Math.max(1e-9, nremFraction);
+            if (relative < 0.5) {
+                phase = SleepPhase.NREM2;
+                depth = 0.5 * (relative / 0.5);
+            } else {
+                phase = SleepPhase.NREM3;
+                depth = 0.5 + 0.5 * ((relative - 0.5) / 0.5);
+            }
+        } else {
+            phase = SleepPhase.REM;
+            depth = 0.7;
+        }
+        SleepStateSignal s = new SleepStateSignal(phase, depth);
+        s.setSourceNeuronId(this.getId());
+        return s;
+    }
+
+    /**
+     * Force-set the phase. Exposed for tests and for externally-driven
+     * sleep scheduling (e.g. circadian override).
+     */
+    public void setPhase(SleepPhase phase) {
+        this.phase = phase == null ? SleepPhase.WAKE : phase;
+    }
+
+    public SleepPhase currentPhase() { return phase; }
+    public long getTick() { return tick; }
+    public int getCycleTicks() { return cycleTicks; }
+    public void setCycleTicks(int v) { this.cycleTicks = Math.max(2, v); }
+    public double getNremFraction() { return nremFraction; }
+    public void setNremFraction(double v) { this.nremFraction = clamp01(v); }
+    public double getRemFraction() { return remFraction; }
+    public void setRemFraction(double v) { this.remFraction = clamp01(v); }
+
+    private static double clamp01(double v) { return Math.max(0.0, Math.min(1.0, v)); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/SleepPhase.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/SleepPhase.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.sleep;
+
+/**
+ * Coarse sleep-wake phase. WAKE is the normal operating state; NREM2 and
+ * NREM3 are deepening stages of non-REM sleep (with sharp-wave ripples
+ * predominating in NREM3); REM is rapid-eye-movement sleep where
+ * dreaming (recombination) occurs (Diekelmann &amp; Born 2010).
+ */
+public enum SleepPhase {
+    WAKE,
+    NREM2,
+    NREM3,
+    REM
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * Sleep / replay / offline-consolidation subsystem.
+ *
+ * <p>Biological analogues and citations:
+ * <ul>
+ *   <li>Hippocampal replay (NREM): Wilson &amp; McNaughton 1994;
+ *       Foster &amp; Wilson 2006.</li>
+ *   <li>Sharp-wave ripples: Buzsáki 2015.</li>
+ *   <li>REM dreaming / recombination: Wamsley &amp; Stickgold 2011.</li>
+ *   <li>Sleep-dependent memory consolidation: Diekelmann &amp; Born 2010.</li>
+ * </ul>
+ *
+ * <p>Key classes:
+ * <ul>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.sleep.SleepControllerNeuron}
+ *       — orchestrates sleep phases.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.sleep.HippocampalReplayNeuron}
+ *       — top-K salience-ordered episode replay.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.sleep.SharpWaveRippleNeuron}
+ *       — NREM3 burst compression targeting LTM.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.sleep.REMDreamingNeuron}
+ *       — REM recombination for hypothetical planning.</li>
+ * </ul>
+ *
+ * <p>Safety invariant: REM-generated plans are forwarded only as
+ * candidates; the harm discriminator still gates motor execution.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.sleep;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/affect/AffectStateSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/affect/AffectStateSignal.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.affect;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Broadcast summary of the agent's affective state.
+ * Biological analogue: limbic output (amygdala + anterior insula integration)
+ * modulating cortical and subcortical targets.
+ * <p>ProcessingFrequency: loop=2 (slow), epoch=1.
+ */
+public class AffectStateSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 2);
+
+    private double valence;
+    private double arousal;
+    private String contextId;
+
+    public AffectStateSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 1L;
+        this.timeAlive = 100;
+    }
+
+    public AffectStateSignal(double valence, double arousal, String contextId) {
+        this();
+        this.valence = clamp(valence, -1.0, 1.0);
+        this.arousal = clamp(arousal, 0.0, 1.0);
+        this.contextId = contextId;
+    }
+
+    private static double clamp(double v, double lo, double hi) {
+        return Math.max(lo, Math.min(hi, v));
+    }
+
+    public double getValence() { return valence; }
+    public void setValence(double valence) { this.valence = clamp(valence, -1.0, 1.0); }
+
+    public double getArousal() { return arousal; }
+    public void setArousal(double arousal) { this.arousal = clamp(arousal, 0.0, 1.0); }
+
+    public String getContextId() { return contextId; }
+    public void setContextId(String contextId) { this.contextId = contextId; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return AffectStateSignal.class; }
+    @Override public String getDescription() { return "AffectStateSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        AffectStateSignal c = new AffectStateSignal(valence, arousal, contextId);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/affect/AppraisalSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/affect/AppraisalSignal.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.affect;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Cognitive appraisal of a situation: goal progress, novelty, controllability.
+ * Biological analogue: medial prefrontal cortex + orbitofrontal cortex
+ * appraisal outputs feeding the limbic integrator.
+ * <p>ProcessingFrequency: loop=1 (fast), epoch=2.
+ */
+public class AppraisalSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
+
+    private double goalDelta;
+    private double novelty;
+    private double controllability;
+
+    public AppraisalSignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 2L;
+        this.timeAlive = 100;
+    }
+
+    public AppraisalSignal(double goalDelta, double novelty, double controllability) {
+        this();
+        this.goalDelta = goalDelta;
+        this.novelty = novelty;
+        this.controllability = controllability;
+    }
+
+    public double getGoalDelta() { return goalDelta; }
+    public void setGoalDelta(double goalDelta) { this.goalDelta = goalDelta; }
+
+    public double getNovelty() { return novelty; }
+    public void setNovelty(double novelty) { this.novelty = novelty; }
+
+    public double getControllability() { return controllability; }
+    public void setControllability(double controllability) { this.controllability = controllability; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return AppraisalSignal.class; }
+    @Override public String getDescription() { return "AppraisalSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        AppraisalSignal c = new AppraisalSignal(goalDelta, novelty, controllability);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/affect/InteroceptiveSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/affect/InteroceptiveSignal.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.affect;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Carries body-state telemetry into the affective subsystem.
+ * Biological analogue: ascending interoceptive pathways (vagal, spinothalamic)
+ * feeding the anterior insula.
+ * <p>ProcessingFrequency: loop=1 (fast), epoch=2.
+ */
+public class InteroceptiveSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
+
+    private double energyBudget;
+    private double homeostaticError;
+    private double painMagnitude;
+    private String source;
+
+    public InteroceptiveSignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 2L;
+        this.timeAlive = 100;
+    }
+
+    public InteroceptiveSignal(double energyBudget, double homeostaticError,
+                               double painMagnitude, String source) {
+        this();
+        this.energyBudget = energyBudget;
+        this.homeostaticError = homeostaticError;
+        this.painMagnitude = painMagnitude;
+        this.source = source;
+    }
+
+    public double getEnergyBudget() { return energyBudget; }
+    public void setEnergyBudget(double energyBudget) { this.energyBudget = energyBudget; }
+
+    public double getHomeostaticError() { return homeostaticError; }
+    public void setHomeostaticError(double homeostaticError) { this.homeostaticError = homeostaticError; }
+
+    public double getPainMagnitude() { return painMagnitude; }
+    public void setPainMagnitude(double painMagnitude) { this.painMagnitude = painMagnitude; }
+
+    public String getSource() { return source; }
+    public void setSource(String source) { this.source = source; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return InteroceptiveSignal.class; }
+    @Override public String getDescription() { return "InteroceptiveSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        InteroceptiveSignal c = new InteroceptiveSignal(energyBudget, homeostaticError, painMagnitude, source);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/curiosity/BoredomSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/curiosity/BoredomSignal.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.curiosity;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * High familiarity / low learning progress marker. Drives inhibition-of-return
+ * on over-familiar contexts to force exploration.
+ * <p>ProcessingFrequency: loop=2, epoch=2.
+ */
+public class BoredomSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 2);
+
+    private String contextHash;
+    private double familiarity;
+
+    public BoredomSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 2L;
+        this.timeAlive = 100;
+    }
+
+    public BoredomSignal(String contextHash, double familiarity) {
+        this();
+        this.contextHash = contextHash;
+        this.familiarity = clamp01(familiarity);
+    }
+
+    private static double clamp01(double v) { return Math.max(0.0, Math.min(1.0, v)); }
+
+    public String getContextHash() { return contextHash; }
+    public void setContextHash(String contextHash) { this.contextHash = contextHash; }
+
+    public double getFamiliarity() { return familiarity; }
+    public void setFamiliarity(double familiarity) { this.familiarity = clamp01(familiarity); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return BoredomSignal.class; }
+    @Override public String getDescription() { return "BoredomSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        BoredomSignal c = new BoredomSignal(contextHash, familiarity);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/curiosity/EmpowermentSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/curiosity/EmpowermentSignal.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.curiosity;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Estimate of mutual information between action choice and future state
+ * (empowerment, Klyubin et al. 2005) — an agent-centric measure of
+ * how much control the agent retains from a given state.
+ * <p>ProcessingFrequency: loop=2, epoch=3.
+ */
+public class EmpowermentSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(3L, 2);
+
+    private int stateId;
+    private double mutualInformation;
+
+    public EmpowermentSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 3L;
+        this.timeAlive = 100;
+    }
+
+    public EmpowermentSignal(int stateId, double mutualInformation) {
+        this();
+        this.stateId = stateId;
+        this.mutualInformation = Math.max(0.0, mutualInformation);
+    }
+
+    public int getStateId() { return stateId; }
+    public void setStateId(int stateId) { this.stateId = stateId; }
+
+    public double getMutualInformation() { return mutualInformation; }
+    public void setMutualInformation(double mutualInformation) { this.mutualInformation = Math.max(0.0, mutualInformation); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return EmpowermentSignal.class; }
+    @Override public String getDescription() { return "EmpowermentSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        EmpowermentSignal c = new EmpowermentSignal(stateId, mutualInformation);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/curiosity/LearningProgressSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/curiosity/LearningProgressSignal.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.curiosity;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Rate of change of prediction error in a given domain. A decreasing
+ * error trajectory (negative derivative) indicates ongoing learning
+ * progress and yields intrinsic reward (Oudeyer &amp; Kaplan 2007).
+ * <p>ProcessingFrequency: loop=2, epoch=2.
+ */
+public class LearningProgressSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 2);
+
+    private String domain;
+    private double errorDerivative;
+
+    public LearningProgressSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 2L;
+        this.timeAlive = 100;
+    }
+
+    public LearningProgressSignal(String domain, double errorDerivative) {
+        this();
+        this.domain = domain;
+        this.errorDerivative = errorDerivative;
+    }
+
+    public String getDomain() { return domain; }
+    public void setDomain(String domain) { this.domain = domain; }
+
+    public double getErrorDerivative() { return errorDerivative; }
+    public void setErrorDerivative(double errorDerivative) { this.errorDerivative = errorDerivative; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return LearningProgressSignal.class; }
+    @Override public String getDescription() { return "LearningProgressSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        LearningProgressSignal c = new LearningProgressSignal(domain, errorDerivative);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/curiosity/NoveltySignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/curiosity/NoveltySignal.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.curiosity;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Signals how novel a given context is.
+ * Biological analogue: hippocampal novelty detection (CA1/dentate) that
+ * gates dopaminergic bursts from VTA during new-environment exploration.
+ * <p>ProcessingFrequency: loop=1, epoch=2.
+ */
+public class NoveltySignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
+
+    private double noveltyScore;
+    private String contextHash;
+
+    public NoveltySignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 2L;
+        this.timeAlive = 100;
+    }
+
+    public NoveltySignal(double noveltyScore, String contextHash) {
+        this();
+        this.noveltyScore = clamp01(noveltyScore);
+        this.contextHash = contextHash;
+    }
+
+    private static double clamp01(double v) { return Math.max(0.0, Math.min(1.0, v)); }
+
+    public double getNoveltyScore() { return noveltyScore; }
+    public void setNoveltyScore(double noveltyScore) { this.noveltyScore = clamp01(noveltyScore); }
+
+    public String getContextHash() { return contextHash; }
+    public void setContextHash(String contextHash) { this.contextHash = contextHash; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return NoveltySignal.class; }
+    @Override public String getDescription() { return "NoveltySignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        NoveltySignal c = new NoveltySignal(noveltyScore, contextHash);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/embodiment/BodySchemaUpdateSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/embodiment/BodySchemaUpdateSignal.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.embodiment.EffectorCapability;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Update to the agent's body schema.
+ * Biological analogue: slow plasticity of the posterior parietal body map
+ * following injury or tool use.
+ * <p>ProcessingFrequency: loop=2, epoch=3.
+ */
+public class BodySchemaUpdateSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(3L, 2);
+
+    private int effectorId;
+    private EffectorCapability capability;
+    private boolean damaged;
+    private boolean tool;
+
+    public BodySchemaUpdateSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 3L;
+        this.timeAlive = 100;
+    }
+
+    public BodySchemaUpdateSignal(int effectorId, EffectorCapability capability, boolean damaged) {
+        this();
+        this.effectorId = effectorId;
+        this.capability = capability;
+        this.damaged = damaged;
+    }
+
+    public int getEffectorId() { return effectorId; }
+    public void setEffectorId(int effectorId) { this.effectorId = effectorId; }
+
+    public EffectorCapability getCapability() { return capability; }
+    public void setCapability(EffectorCapability capability) { this.capability = capability; }
+
+    public boolean isDamaged() { return damaged; }
+    public void setDamaged(boolean damaged) { this.damaged = damaged; }
+
+    public boolean isTool() { return tool; }
+    public void setTool(boolean tool) { this.tool = tool; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return BodySchemaUpdateSignal.class; }
+    @Override public String getDescription() { return "BodySchemaUpdateSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        BodySchemaUpdateSignal c = new BodySchemaUpdateSignal(effectorId, capability, damaged);
+        c.tool = this.tool;
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/embodiment/EfferenceCopySignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/embodiment/EfferenceCopySignal.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Efference copy of a motor command.
+ * Biological analogue: cerebellar/parietal internal forward model
+ * (Wolpert, Miall &amp; Kawato 1998).
+ * <p>ProcessingFrequency: loop=1, epoch=1.
+ */
+public class EfferenceCopySignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private long originalMotorCommandId;
+    private double[] predictedOutcome;
+    private int effectorId;
+
+    public EfferenceCopySignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 1L;
+        this.timeAlive = 100;
+    }
+
+    public EfferenceCopySignal(long originalMotorCommandId, double[] predictedOutcome, int effectorId) {
+        this();
+        this.originalMotorCommandId = originalMotorCommandId;
+        this.predictedOutcome = predictedOutcome == null ? new double[0] : predictedOutcome.clone();
+        this.effectorId = effectorId;
+    }
+
+    public long getOriginalMotorCommandId() { return originalMotorCommandId; }
+    public void setOriginalMotorCommandId(long originalMotorCommandId) { this.originalMotorCommandId = originalMotorCommandId; }
+
+    public double[] getPredictedOutcome() { return predictedOutcome == null ? new double[0] : predictedOutcome.clone(); }
+    public void setPredictedOutcome(double[] predictedOutcome) { this.predictedOutcome = predictedOutcome == null ? new double[0] : predictedOutcome.clone(); }
+
+    public int getEffectorId() { return effectorId; }
+    public void setEffectorId(int effectorId) { this.effectorId = effectorId; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return EfferenceCopySignal.class; }
+    @Override public String getDescription() { return "EfferenceCopySignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        EfferenceCopySignal c = new EfferenceCopySignal(originalMotorCommandId, predictedOutcome, effectorId);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/embodiment/ProprioceptiveSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/embodiment/ProprioceptiveSignal.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Proprioceptive feedback from a single effector.
+ * Biological analogue: muscle spindle, Golgi tendon and joint-receptor
+ * afferents ascending via the dorsal columns.
+ * <p>ProcessingFrequency: loop=1, epoch=1.
+ */
+public class ProprioceptiveSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private int effectorId;
+    private double[] jointStates;
+    private long timestamp;
+
+    public ProprioceptiveSignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 1L;
+        this.timeAlive = 100;
+    }
+
+    public ProprioceptiveSignal(int effectorId, double[] jointStates, long timestamp) {
+        this();
+        this.effectorId = effectorId;
+        this.jointStates = jointStates == null ? new double[0] : jointStates.clone();
+        this.timestamp = timestamp;
+    }
+
+    public int getEffectorId() { return effectorId; }
+    public void setEffectorId(int effectorId) { this.effectorId = effectorId; }
+
+    public double[] getJointStates() { return jointStates == null ? new double[0] : jointStates.clone(); }
+    public void setJointStates(double[] jointStates) { this.jointStates = jointStates == null ? new double[0] : jointStates.clone(); }
+
+    public long getTimestamp() { return timestamp; }
+    public void setTimestamp(long timestamp) { this.timestamp = timestamp; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return ProprioceptiveSignal.class; }
+    @Override public String getDescription() { return "ProprioceptiveSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        ProprioceptiveSignal c = new ProprioceptiveSignal(effectorId, jointStates, timestamp);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/embodiment/SensorimotorContingencySignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/embodiment/SensorimotorContingencySignal.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Learned action-to-sensory-change contingency.
+ * Biological analogue: parieto-frontal forward model mapping (O'Regan &amp; Noe 2001).
+ * <p>ProcessingFrequency: loop=1, epoch=2.
+ */
+public class SensorimotorContingencySignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
+
+    private int actionId;
+    private double[] sensoryDelta;
+    private double confidence;
+
+    public SensorimotorContingencySignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 2L;
+        this.timeAlive = 100;
+    }
+
+    public SensorimotorContingencySignal(int actionId, double[] sensoryDelta, double confidence) {
+        this();
+        this.actionId = actionId;
+        this.sensoryDelta = sensoryDelta == null ? new double[0] : sensoryDelta.clone();
+        this.confidence = Math.max(0.0, Math.min(1.0, confidence));
+    }
+
+    public int getActionId() { return actionId; }
+    public void setActionId(int actionId) { this.actionId = actionId; }
+
+    public double[] getSensoryDelta() { return sensoryDelta == null ? new double[0] : sensoryDelta.clone(); }
+    public void setSensoryDelta(double[] sensoryDelta) { this.sensoryDelta = sensoryDelta == null ? new double[0] : sensoryDelta.clone(); }
+
+    public double getConfidence() { return confidence; }
+    public void setConfidence(double confidence) { this.confidence = Math.max(0.0, Math.min(1.0, confidence)); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return SensorimotorContingencySignal.class; }
+    @Override public String getDescription() { return "SensorimotorContingencySignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        SensorimotorContingencySignal c = new SensorimotorContingencySignal(actionId, sensoryDelta, confidence);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/glia/CalciumWaveSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/glia/CalciumWaveSignal.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.glia;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Astrocytic calcium wave — a slow broadcast of local activity integration
+ * over a neural region. Amplitude and propagation radius come from the
+ * integrating astrocyte.
+ * <p>Biological analogue: astrocytic Ca²⁺ waves (Volterra &amp; Meldolesi 2005).
+ * <p>ProcessingFrequency: loop=2, epoch=1.
+ */
+public class CalciumWaveSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 2);
+
+    private int regionId;
+    private double amplitude;
+    private double propagationRadius;
+
+    public CalciumWaveSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 1L;
+        this.timeAlive = 100;
+    }
+
+    public CalciumWaveSignal(int regionId, double amplitude, double propagationRadius) {
+        this();
+        this.regionId = regionId;
+        this.amplitude = Math.max(0.0, amplitude);
+        this.propagationRadius = Math.max(0.0, propagationRadius);
+    }
+
+    public int getRegionId() { return regionId; }
+    public void setRegionId(int regionId) { this.regionId = regionId; }
+
+    public double getAmplitude() { return amplitude; }
+    public void setAmplitude(double amplitude) { this.amplitude = Math.max(0.0, amplitude); }
+
+    public double getPropagationRadius() { return propagationRadius; }
+    public void setPropagationRadius(double propagationRadius) { this.propagationRadius = Math.max(0.0, propagationRadius); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return CalciumWaveSignal.class; }
+    @Override public String getDescription() { return "CalciumWaveSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        CalciumWaveSignal c = new CalciumWaveSignal(regionId, amplitude, propagationRadius);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/glia/GliotransmitterSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/glia/GliotransmitterSignal.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.glia;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia.GliotransmitterType;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * A regional release of a gliotransmitter (glutamate, ATP, D-serine)
+ * that modulates local neural activity.
+ * <p>Biological analogue: tripartite-synapse gliotransmission
+ * (Araque et al. 2014).
+ * <p>ProcessingFrequency: loop=2, epoch=2.
+ */
+public class GliotransmitterSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 2);
+
+    private GliotransmitterType transmitter;
+    private double concentration;
+    private int regionId;
+
+    public GliotransmitterSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 2L;
+        this.timeAlive = 100;
+    }
+
+    public GliotransmitterSignal(GliotransmitterType transmitter, double concentration, int regionId) {
+        this();
+        this.transmitter = transmitter;
+        this.concentration = Math.max(0.0, concentration);
+        this.regionId = regionId;
+    }
+
+    public GliotransmitterType getTransmitter() { return transmitter; }
+    public void setTransmitter(GliotransmitterType transmitter) { this.transmitter = transmitter; }
+
+    public double getConcentration() { return concentration; }
+    public void setConcentration(double concentration) { this.concentration = Math.max(0.0, concentration); }
+
+    public int getRegionId() { return regionId; }
+    public void setRegionId(int regionId) { this.regionId = regionId; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return GliotransmitterSignal.class; }
+    @Override public String getDescription() { return "GliotransmitterSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        GliotransmitterSignal c = new GliotransmitterSignal(transmitter, concentration, regionId);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/glia/MyelinationSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/glia/MyelinationSignal.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.glia;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * A request to reduce the propagation delay on a specific axonal
+ * connection, reflecting activity-dependent myelination.
+ * <p>Biological analogue: oligodendrocyte-mediated activity-dependent
+ * myelination (Fields 2015; Gibson et al. 2014).
+ * <p>ProcessingFrequency: loop=2, epoch=10.
+ */
+public class MyelinationSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(10L, 2);
+
+    private long axonSourceId;
+    private long axonTargetId;
+    private int newDelayTicks;
+
+    public MyelinationSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 10L;
+        this.timeAlive = 100;
+    }
+
+    public MyelinationSignal(long axonSourceId, long axonTargetId, int newDelayTicks) {
+        this();
+        this.axonSourceId = axonSourceId;
+        this.axonTargetId = axonTargetId;
+        this.newDelayTicks = Math.max(0, newDelayTicks);
+    }
+
+    public long getAxonSourceId() { return axonSourceId; }
+    public void setAxonSourceId(long axonSourceId) { this.axonSourceId = axonSourceId; }
+
+    public long getAxonTargetId() { return axonTargetId; }
+    public void setAxonTargetId(long axonTargetId) { this.axonTargetId = axonTargetId; }
+
+    public int getNewDelayTicks() { return newDelayTicks; }
+    public void setNewDelayTicks(int newDelayTicks) { this.newDelayTicks = Math.max(0, newDelayTicks); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return MyelinationSignal.class; }
+    @Override public String getDescription() { return "MyelinationSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        MyelinationSignal c = new MyelinationSignal(axonSourceId, axonTargetId, newDelayTicks);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/glia/PruningSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/glia/PruningSignal.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.glia;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * A request emitted by {@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia.MicroglialPruningNeuron}
+ * to sever a chronically-inactive or damaged connection.
+ * <p>Biological analogue: microglial synaptic pruning
+ * (Schafer et al. 2012; Paolicelli et al. 2011).
+ * <p>ProcessingFrequency: loop=2, epoch=5.
+ */
+public class PruningSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(5L, 2);
+
+    private long axonSourceId;
+    private long axonTargetId;
+    private String reason;
+
+    public PruningSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 5L;
+        this.timeAlive = 100;
+    }
+
+    public PruningSignal(long axonSourceId, long axonTargetId, String reason) {
+        this();
+        this.axonSourceId = axonSourceId;
+        this.axonTargetId = axonTargetId;
+        this.reason = reason;
+    }
+
+    public long getAxonSourceId() { return axonSourceId; }
+    public void setAxonSourceId(long axonSourceId) { this.axonSourceId = axonSourceId; }
+
+    public long getAxonTargetId() { return axonTargetId; }
+    public void setAxonTargetId(long axonTargetId) { this.axonTargetId = axonTargetId; }
+
+    public String getReason() { return reason; }
+    public void setReason(String reason) { this.reason = reason; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return PruningSignal.class; }
+    @Override public String getDescription() { return "PruningSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        PruningSignal c = new PruningSignal(axonSourceId, axonTargetId, reason);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/sleep/DreamSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/sleep/DreamSignal.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.sleep;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A recombined episode generated during REM sleep. Carries the bindings
+ * it was composed from and a novelty score used to gate whether the
+ * candidate plan is forwarded to {@code PlanningNeuron}.
+ * <p>Biological analogue: REM-sleep dreaming and episode recombination
+ * (Wamsley &amp; Stickgold 2011).
+ * <p>ProcessingFrequency: loop=2, epoch=5.
+ */
+public class DreamSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(5L, 2);
+
+    private List<Long> episodeBindings = new ArrayList<>();
+    private double noveltyScore;
+
+    public DreamSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 5L;
+        this.timeAlive = 100;
+    }
+
+    public DreamSignal(List<Long> episodeBindings, double noveltyScore) {
+        this();
+        this.episodeBindings = (episodeBindings == null) ? new ArrayList<>() : new ArrayList<>(episodeBindings);
+        this.noveltyScore = clamp01(noveltyScore);
+    }
+
+    private static double clamp01(double v) { return Math.max(0.0, Math.min(1.0, v)); }
+
+    public List<Long> getEpisodeBindings() { return Collections.unmodifiableList(episodeBindings); }
+    public void setEpisodeBindings(List<Long> episodeBindings) {
+        this.episodeBindings = (episodeBindings == null) ? new ArrayList<>() : new ArrayList<>(episodeBindings);
+    }
+
+    public double getNoveltyScore() { return noveltyScore; }
+    public void setNoveltyScore(double noveltyScore) { this.noveltyScore = clamp01(noveltyScore); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return DreamSignal.class; }
+    @Override public String getDescription() { return "DreamSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        DreamSignal c = new DreamSignal(episodeBindings, noveltyScore);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/sleep/ReplaySignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/sleep/ReplaySignal.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.sleep;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.sleep.ReplayDirection;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Compressed replay of a recorded episode sequence. A replay carries the
+ * sequence identifier, playback direction, and compression ratio relative
+ * to original wall-clock duration.
+ * <p>Biological analogue: hippocampal replay events (Wilson &amp;
+ * McNaughton 1994; Foster &amp; Wilson 2006).
+ * <p>ProcessingFrequency: loop=2, epoch=3.
+ */
+public class ReplaySignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(3L, 2);
+
+    private String sequenceId;
+    private ReplayDirection direction;
+    private double compressionRatio;
+    private List<Long> neuronSequence = new ArrayList<>();
+
+    public ReplaySignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 3L;
+        this.timeAlive = 100;
+        this.direction = ReplayDirection.REVERSE;
+        this.compressionRatio = 1.0;
+    }
+
+    public ReplaySignal(String sequenceId, ReplayDirection direction, double compressionRatio, List<Long> neuronSequence) {
+        this();
+        this.sequenceId = sequenceId;
+        this.direction = direction == null ? ReplayDirection.REVERSE : direction;
+        this.compressionRatio = Math.max(1.0, compressionRatio);
+        this.neuronSequence = (neuronSequence == null) ? new ArrayList<>() : new ArrayList<>(neuronSequence);
+    }
+
+    public String getSequenceId() { return sequenceId; }
+    public void setSequenceId(String sequenceId) { this.sequenceId = sequenceId; }
+
+    public ReplayDirection getDirection() { return direction; }
+    public void setDirection(ReplayDirection direction) { this.direction = direction == null ? ReplayDirection.REVERSE : direction; }
+
+    public double getCompressionRatio() { return compressionRatio; }
+    public void setCompressionRatio(double compressionRatio) { this.compressionRatio = Math.max(1.0, compressionRatio); }
+
+    public List<Long> getNeuronSequence() { return Collections.unmodifiableList(neuronSequence); }
+    public void setNeuronSequence(List<Long> neuronSequence) {
+        this.neuronSequence = (neuronSequence == null) ? new ArrayList<>() : new ArrayList<>(neuronSequence);
+    }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return ReplaySignal.class; }
+    @Override public String getDescription() { return "ReplaySignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        ReplaySignal c = new ReplaySignal(sequenceId, direction, compressionRatio, neuronSequence);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/sleep/SharpWaveRippleSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/sleep/SharpWaveRippleSignal.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.sleep;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A compressed burst replay (sharp-wave ripple) emitted during NREM3
+ * sleep; targets cortical long-term memory for consolidation.
+ * <p>Biological analogue: hippocampal SWRs (Buzsáki 2015).
+ * <p>ProcessingFrequency: loop=2, epoch=1.
+ */
+public class SharpWaveRippleSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 2);
+
+    private List<Long> neuronSequence = new ArrayList<>();
+    private double power;
+
+    public SharpWaveRippleSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 1L;
+        this.timeAlive = 100;
+    }
+
+    public SharpWaveRippleSignal(List<Long> neuronSequence, double power) {
+        this();
+        this.neuronSequence = (neuronSequence == null) ? new ArrayList<>() : new ArrayList<>(neuronSequence);
+        this.power = Math.max(0.0, power);
+    }
+
+    public List<Long> getNeuronSequence() { return Collections.unmodifiableList(neuronSequence); }
+    public void setNeuronSequence(List<Long> neuronSequence) {
+        this.neuronSequence = (neuronSequence == null) ? new ArrayList<>() : new ArrayList<>(neuronSequence);
+    }
+
+    public double getPower() { return power; }
+    public void setPower(double power) { this.power = Math.max(0.0, power); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return SharpWaveRippleSignal.class; }
+    @Override public String getDescription() { return "SharpWaveRippleSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        SharpWaveRippleSignal c = new SharpWaveRippleSignal(neuronSequence, power);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/sleep/SleepStateSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/sleep/SleepStateSignal.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.sleep;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.sleep.SleepPhase;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Broadcast indicating the current {@link SleepPhase} and sleep depth.
+ * Gates fast-loop activity while active.
+ * <p>Biological analogue: brainstem / thalamic cortical-arousal control
+ * systems (Saper et al. 2005).
+ * <p>ProcessingFrequency: loop=2, epoch=10.
+ */
+public class SleepStateSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(10L, 2);
+
+    private SleepPhase phase;
+    private double depth;
+
+    public SleepStateSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 10L;
+        this.timeAlive = 100;
+        this.phase = SleepPhase.WAKE;
+    }
+
+    public SleepStateSignal(SleepPhase phase, double depth) {
+        this();
+        this.phase = phase == null ? SleepPhase.WAKE : phase;
+        this.depth = clamp01(depth);
+    }
+
+    private static double clamp01(double v) { return Math.max(0.0, Math.min(1.0, v)); }
+
+    public SleepPhase getPhase() { return phase; }
+    public void setPhase(SleepPhase phase) { this.phase = phase == null ? SleepPhase.WAKE : phase; }
+
+    public double getDepth() { return depth; }
+    public void setDepth(double depth) { this.depth = clamp01(depth); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return SleepStateSignal.class; }
+    @Override public String getDescription() { return "SleepStateSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        SleepStateSignal c = new SleepStateSignal(phase, depth);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/affect/AffectIntegrationProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/affect/AffectIntegrationProcessor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.affect;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect.AffectIntegrationNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect.IAffectiveNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.affect.AffectStateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.affect.AppraisalSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor that routes {@link AppraisalSignal}s into an
+ * {@link IAffectiveNeuron}; when the target is an
+ * {@link AffectIntegrationNeuron} the processor also emits a broadcast
+ * {@link AffectStateSignal}.
+ */
+public class AffectIntegrationProcessor implements ISignalProcessor<AppraisalSignal, IAffectiveNeuron> {
+
+    private static final String DESCRIPTION = "Integrates appraisal into affective state; broadcasts AffectStateSignal from integration neurons";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(AppraisalSignal input, IAffectiveNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        neuron.onAppraisal(input);
+        if (neuron instanceof AffectIntegrationNeuron) {
+            AffectIntegrationNeuron in = (AffectIntegrationNeuron) neuron;
+            AffectStateSignal broadcast = in.integrate(
+                    input.getGoalDelta(),
+                    input.getNovelty(),
+                    input.getControllability(),
+                    0.0,
+                    0.0);
+            out.add((I) broadcast);
+        }
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return AffectIntegrationProcessor.class; }
+    @Override public Class<IAffectiveNeuron> getNeuronClass() { return IAffectiveNeuron.class; }
+    @Override public Class<AppraisalSignal> getSignalClass() { return AppraisalSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/affect/InteroceptionProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/affect/InteroceptionProcessor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.affect;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect.AnteriorInsulaNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect.IInteroceptive;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.affect.InteroceptiveSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor that feeds {@link InteroceptiveSignal}s into an
+ * interoceptive neuron (typically {@link AnteriorInsulaNeuron}).
+ */
+public class InteroceptionProcessor implements ISignalProcessor<InteroceptiveSignal, IInteroceptive> {
+
+    private static final String DESCRIPTION = "Integrates interoceptive telemetry into the insula neuron";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(InteroceptiveSignal input, IInteroceptive neuron) {
+        if (input == null || neuron == null) return new LinkedList<>();
+        if (neuron instanceof AnteriorInsulaNeuron) {
+            ((AnteriorInsulaNeuron) neuron).integrate(input);
+        }
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return InteroceptionProcessor.class; }
+    @Override public Class<IInteroceptive> getNeuronClass() { return IInteroceptive.class; }
+    @Override public Class<InteroceptiveSignal> getSignalClass() { return InteroceptiveSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/affect/ValenceTaggingProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/affect/ValenceTaggingProcessor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.affect;
+
+import com.rakovpublic.jneuropallium.ai.signals.fast.SpikeSignal;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect.AmygdalaValenceNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect.IAffectiveNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor that tags incoming {@link SpikeSignal}s with valence
+ * via the {@link AmygdalaValenceNeuron}.
+ */
+public class ValenceTaggingProcessor implements ISignalProcessor<SpikeSignal, IAffectiveNeuron> {
+
+    private static final String DESCRIPTION = "Amygdala-like fast valence tagging of sensory spikes";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(SpikeSignal input, IAffectiveNeuron neuron) {
+        if (input == null || neuron == null) return new LinkedList<>();
+        if (neuron instanceof AmygdalaValenceNeuron) {
+            double threat = input.getBurstCount() > 2 ? Math.min(1.0, 0.3 * input.getBurstCount()) : 0.0;
+            ((AmygdalaValenceNeuron) neuron).tag(input.getMagnitude(), threat);
+        }
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return ValenceTaggingProcessor.class; }
+    @Override public Class<IAffectiveNeuron> getNeuronClass() { return IAffectiveNeuron.class; }
+    @Override public Class<SpikeSignal> getSignalClass() { return SpikeSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/curiosity/LearningProgressProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/curiosity/LearningProgressProcessor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.curiosity;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.curiosity.LearningProgressNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.curiosity.LearningProgressSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor that records an incoming error sample into the
+ * learning-progress neuron's per-domain window.
+ */
+public class LearningProgressProcessor implements ISignalProcessor<LearningProgressSignal, LearningProgressNeuron> {
+
+    private static final String DESCRIPTION = "Oudeyer-Kaplan learning-progress reward update";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(LearningProgressSignal input, LearningProgressNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        LearningProgressSignal emitted = neuron.recordError(input.getDomain(), input.getErrorDerivative());
+        if (emitted != null) out.add((I) emitted);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return LearningProgressProcessor.class; }
+    @Override public Class<LearningProgressNeuron> getNeuronClass() { return LearningProgressNeuron.class; }
+    @Override public Class<LearningProgressSignal> getSignalClass() { return LearningProgressSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/curiosity/NoveltyDetectionProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/curiosity/NoveltyDetectionProcessor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.curiosity;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.curiosity.NoveltyDetectorNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.curiosity.NoveltySignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor that passes a {@link NoveltySignal}'s context hash
+ * through the detector; the detector's mutable state records the visit.
+ */
+public class NoveltyDetectionProcessor implements ISignalProcessor<NoveltySignal, NoveltyDetectorNeuron> {
+
+    private static final String DESCRIPTION = "Hippocampal-CA1-like novelty-detection update";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(NoveltySignal input, NoveltyDetectorNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        NoveltySignal emitted = neuron.evaluate(input.getContextHash());
+        if (emitted != null) out.add((I) emitted);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return NoveltyDetectionProcessor.class; }
+    @Override public Class<NoveltyDetectorNeuron> getNeuronClass() { return NoveltyDetectorNeuron.class; }
+    @Override public Class<NoveltySignal> getSignalClass() { return NoveltySignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/glia/PruningProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/glia/PruningProcessor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.glia;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia.MicroglialPruningNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.glia.PruningSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor that, on arrival of a {@link PruningSignal},
+ * records inactivity against a target connection and possibly emits
+ * a follow-up prune request for a sibling connection.
+ */
+public class PruningProcessor implements ISignalProcessor<PruningSignal, MicroglialPruningNeuron> {
+
+    private static final String DESCRIPTION = "Microglial pruning request handling";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(PruningSignal input, MicroglialPruningNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        neuron.tick();
+        PruningSignal emitted = neuron.maybePrune(input.getAxonSourceId(), input.getAxonTargetId(), input.getReason());
+        if (emitted != null) out.add((I) emitted);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return PruningProcessor.class; }
+    @Override public Class<MicroglialPruningNeuron> getNeuronClass() { return MicroglialPruningNeuron.class; }
+    @Override public Class<PruningSignal> getSignalClass() { return PruningSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/sleep/SleepStateGateProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/sleep/SleepStateGateProcessor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.sleep;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.sleep.SleepControllerNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.sleep.SleepStateSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor that propagates the latest {@link SleepStateSignal}
+ * to downstream neurons. The controller uses the arrival to advance one
+ * cycle tick.
+ */
+public class SleepStateGateProcessor implements ISignalProcessor<SleepStateSignal, SleepControllerNeuron> {
+
+    private static final String DESCRIPTION = "Sleep-state gate re-emission";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(SleepStateSignal input, SleepControllerNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        neuron.setPhase(input.getPhase());
+        SleepStateSignal advanced = neuron.advance();
+        if (advanced != null) out.add((I) advanced);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return SleepStateGateProcessor.class; }
+    @Override public Class<SleepControllerNeuron> getNeuronClass() { return SleepControllerNeuron.class; }
+    @Override public Class<SleepStateSignal> getSignalClass() { return SleepStateSignal.class; }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/AffectModuleTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/affect/AffectModuleTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.affect;
+
+import com.rakovpublic.jneuropallium.ai.signals.fast.SpikeSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.affect.AffectStateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.affect.AppraisalSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.affect.InteroceptiveSignal;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.affect.AffectIntegrationProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.affect.InteroceptionProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.affect.ValenceTaggingProcessor;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AffectModuleTest {
+
+    // ---- AffectStateSignal ----
+
+    @Test
+    void affectStateSignal_serializationRoundTripPreservesFields() {
+        AffectStateSignal s = new AffectStateSignal(-0.4, 0.8, "ctx-1");
+        AffectStateSignal copy = (AffectStateSignal) s.copySignal();
+        assertEquals(-0.4, copy.getValence(), 1e-9);
+        assertEquals(0.8, copy.getArousal(), 1e-9);
+        assertEquals("ctx-1", copy.getContextId());
+    }
+
+    @Test
+    void affectStateSignal_processingFrequencyIsLoop2Epoch1() {
+        assertEquals(1L, AffectStateSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(2, AffectStateSignal.PROCESSING_FREQUENCY.getLoop());
+        AffectStateSignal s = new AffectStateSignal(0, 0, "c");
+        assertEquals(2, s.getLoop());
+        assertEquals(1L, s.getEpoch());
+    }
+
+    @Test
+    void affectStateSignal_clampsValenceAndArousalInConstructor() {
+        AffectStateSignal s = new AffectStateSignal(5.0, -2.0, "ctx");
+        assertEquals(1.0, s.getValence(), 1e-9);
+        assertEquals(0.0, s.getArousal(), 1e-9);
+    }
+
+    @Test
+    void interoceptiveSignal_processingFrequencyIsLoop1Epoch2() {
+        assertEquals(2L, InteroceptiveSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(1, InteroceptiveSignal.PROCESSING_FREQUENCY.getLoop());
+    }
+
+    @Test
+    void appraisalSignal_processingFrequencyIsLoop1Epoch2() {
+        assertEquals(2L, AppraisalSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(1, AppraisalSignal.PROCESSING_FREQUENCY.getLoop());
+    }
+
+    // ---- AmygdalaValenceNeuron ----
+
+    @Test
+    void amygdalaValenceNeuron_threatPositiveInputProducesNegativeValence() {
+        AmygdalaValenceNeuron n = new AmygdalaValenceNeuron();
+        double v = n.tag(0.9, 0.9);
+        assertTrue(v < 0, "threat-positive input should yield negative valence, got " + v);
+        assertTrue(n.currentState().getArousal() > 0.5);
+    }
+
+    @Test
+    void amygdalaValenceNeuron_modulateThresholdDecreasesWithArousal() {
+        AmygdalaValenceNeuron n = new AmygdalaValenceNeuron();
+        double base = n.getFiringThreshold();
+        n.modulateThreshold(1.0);
+        assertTrue(n.getFiringThreshold() < base);
+    }
+
+    // ---- ValenceTaggingProcessor ----
+
+    @Test
+    void valenceTaggingProcessor_forwardsSpikeToAmygdala() {
+        AmygdalaValenceNeuron n = new AmygdalaValenceNeuron();
+        ValenceTaggingProcessor p = new ValenceTaggingProcessor();
+        SpikeSignal spike = new SpikeSignal(true, 1.2, 5);
+        List<?> out = p.process(spike, n);
+        assertTrue(out.isEmpty());
+        assertTrue(n.currentState().getArousal() > 0);
+    }
+
+    // ---- AnteriorInsulaNeuron + InteroceptionProcessor ----
+
+    @Test
+    void anteriorInsula_integratesInteroceptiveSignals() {
+        AnteriorInsulaNeuron n = new AnteriorInsulaNeuron();
+        InteroceptionProcessor p = new InteroceptionProcessor();
+        p.process(new InteroceptiveSignal(0.8, 0.5, 0.2, "energy"), n);
+        p.process(new InteroceptiveSignal(0.7, 0.6, 0.3, "energy"), n);
+        assertTrue(n.getSampleCount() >= 2);
+        assertTrue(n.readHomeostaticError() > 0);
+        assertTrue(n.readEnergyBudget() > 0);
+    }
+
+    // ---- AffectIntegrationNeuron + AffectIntegrationProcessor ----
+
+    @Test
+    void affectIntegrationProcessor_emitsAffectStateSignalForIntegrationNeuron() {
+        AffectIntegrationNeuron n = new AffectIntegrationNeuron();
+        n.setId(42L);
+        AffectIntegrationProcessor p = new AffectIntegrationProcessor();
+        List<?> out = p.process(new AppraisalSignal(0.5, 0.7, 0.4), n);
+        assertEquals(1, out.size());
+        assertTrue(out.get(0) instanceof AffectStateSignal);
+        AffectStateSignal emitted = (AffectStateSignal) out.get(0);
+        assertEquals(42L, emitted.getSourceNeuronId());
+    }
+
+    // ---- AffectModulationNeuron: integration test for harm threshold tightening ----
+
+    @Test
+    void affectModulation_negativeValenceTightensHarmThreshold() {
+        AffectModulationNeuron mod = new AffectModulationNeuron();
+        mod.onAffect(new AffectStateSignal(-0.8, 0.7, "ctx"));
+        assertTrue(mod.getHarmThresholdMultiplier() > 1.0,
+                "negative valence should raise harm threshold multiplier above baseline, got "
+                        + mod.getHarmThresholdMultiplier());
+    }
+
+    @Test
+    void affectModulation_scalesLearningRatesWithArousal() {
+        AffectModulationNeuron mod = new AffectModulationNeuron();
+        mod.onAffect(new AffectStateSignal(0.0, 0.6, "ctx"));
+        assertEquals(1.6, mod.getShortTermLearningScale(), 1e-9);
+        assertEquals(0.7, mod.getLongTermConsolidationScale(), 1e-9);
+    }
+
+    @Test
+    void affectModulation_respectsHarmClampRange() {
+        AffectModulationNeuron mod = new AffectModulationNeuron();
+        mod.onAffect(new AffectStateSignal(-1.0, 1.0, "ctx")); // raw = 2.0, within [1,5]
+        assertTrue(mod.getHarmThresholdMultiplier() >= mod.getHarmClampMin());
+        assertTrue(mod.getHarmThresholdMultiplier() <= mod.getHarmClampMax());
+    }
+
+    // ---- AffectConfig backwards-compat property ----
+
+    @Test
+    void affectConfig_defaultsAreDisabled() {
+        AffectConfig cfg = new AffectConfig();
+        assertFalse(cfg.isEnabled(), "affect module must default to disabled");
+        assertEquals(300, cfg.getValenceDecayTicks());
+        assertEquals(150, cfg.getArousalDecayTicks());
+        assertEquals(1.0, cfg.getHarmThresholdClampMin());
+        assertEquals(5.0, cfg.getHarmThresholdClampMax());
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/curiosity/CuriosityModuleTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/curiosity/CuriosityModuleTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.curiosity;
+
+import com.rakovpublic.jneuropallium.ai.signals.fast.AttentionGateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.curiosity.BoredomSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.curiosity.EmpowermentSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.curiosity.LearningProgressSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.curiosity.NoveltySignal;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CuriosityModuleTest {
+
+    // ---- NoveltyDetectorNeuron ----
+
+    @Test
+    void novelty_firstContextIsFullyNovel() {
+        NoveltyDetectorNeuron n = new NoveltyDetectorNeuron();
+        NoveltySignal s = n.evaluate("ctx-new");
+        assertEquals(1.0, s.getNoveltyScore(), 1e-9);
+        assertEquals("ctx-new", s.getContextHash());
+    }
+
+    @Test
+    void novelty_repeatedContextDecreases() {
+        NoveltyDetectorNeuron n = new NoveltyDetectorNeuron();
+        double first = n.evaluate("ctx-A").getNoveltyScore();
+        double second = n.evaluate("ctx-A").getNoveltyScore();
+        assertTrue(second < first, "repeated context should be less novel");
+    }
+
+    // ---- LearningProgressNeuron ----
+
+    @Test
+    void learningProgress_positiveRewardWhenErrorDecreases() {
+        LearningProgressNeuron n = new LearningProgressNeuron();
+        n.setWindowTicks(20);
+        for (double e : new double[]{1.0, 0.9, 0.8, 0.6, 0.3, 0.1}) {
+            n.recordError("nav", e);
+        }
+        assertTrue(n.intrinsicReward("nav") > 0.0, "decreasing error → positive intrinsic reward");
+    }
+
+    @Test
+    void learningProgress_negativeOrZeroWhenFlatOrRising() {
+        LearningProgressNeuron n = new LearningProgressNeuron();
+        for (double e : new double[]{0.1, 0.2, 0.3, 0.4}) {
+            n.recordError("manip", e);
+        }
+        assertTrue(n.intrinsicReward("manip") <= 0.0);
+    }
+
+    @Test
+    void learningProgress_signalCarriesDomainAndDerivative() {
+        LearningProgressNeuron n = new LearningProgressNeuron();
+        n.recordError("d1", 1.0);
+        LearningProgressSignal s = n.recordError("d1", 0.0);
+        assertEquals("d1", s.getDomain());
+        assertTrue(s.getErrorDerivative() < 0, "error went down, derivative is negative");
+    }
+
+    // ---- EmpowermentNeuron ----
+
+    @Test
+    void empowerment_higherForMoreReachableFutures() {
+        EmpowermentNeuron n = new EmpowermentNeuron();
+        List<List<Integer>> few = Arrays.asList(
+                Collections.singletonList(1),
+                Collections.singletonList(1));
+        List<List<Integer>> many = Arrays.asList(
+                Arrays.asList(1, 2, 3),
+                Arrays.asList(4, 5, 6));
+        EmpowermentSignal low = n.estimate(0, few);
+        EmpowermentSignal high = n.estimate(0, many);
+        assertTrue(high.getMutualInformation() > low.getMutualInformation());
+    }
+
+    @Test
+    void empowerment_emptyRolloutsGiveZero() {
+        EmpowermentNeuron n = new EmpowermentNeuron();
+        assertEquals(0.0, n.estimate(0, null).getMutualInformation(), 1e-9);
+        assertEquals(0.0, n.estimate(0, Collections.emptyList()).getMutualInformation(), 1e-9);
+    }
+
+    // ---- BoredomNeuron ----
+
+    @Test
+    void boredom_familiaritySaturates() {
+        BoredomNeuron n = new BoredomNeuron();
+        n.setSaturationVisits(4);
+        BoredomSignal b1 = n.visit("ctx");
+        for (int i = 0; i < 10; i++) n.visit("ctx");
+        BoredomSignal bN = n.visit("ctx");
+        assertTrue(bN.getFamiliarity() >= b1.getFamiliarity());
+        assertEquals(1.0, bN.getFamiliarity(), 1e-9);
+    }
+
+    @Test
+    void boredom_emitsSuppressionWhenOverThreshold() {
+        BoredomNeuron n = new BoredomNeuron();
+        n.setSaturationVisits(4);
+        n.setFamiliarityThreshold(0.5);
+        for (int i = 0; i < 3; i++) n.visit("ctx");
+        AttentionGateSignal gate = n.maybeSuppress("ctx");
+        assertNotNull(gate);
+        assertTrue(gate.isSuppress());
+        assertEquals("ctx", gate.getRegionId());
+    }
+
+    @Test
+    void boredom_noSuppressionBelowThreshold() {
+        BoredomNeuron n = new BoredomNeuron();
+        n.setSaturationVisits(100);
+        n.setFamiliarityThreshold(0.9);
+        n.visit("ctx");
+        assertNull(n.maybeSuppress("ctx"));
+    }
+
+    // ---- Signals ----
+
+    @Test
+    void noveltySignal_copyPreservesFields() {
+        NoveltySignal s = new NoveltySignal(0.7, "ctx");
+        NoveltySignal c = (NoveltySignal) s.copySignal();
+        assertEquals(0.7, c.getNoveltyScore(), 1e-9);
+        assertEquals("ctx", c.getContextHash());
+    }
+
+    @Test
+    void noveltySignal_clampsOutOfRange() {
+        NoveltySignal s = new NoveltySignal(2.0, "x");
+        assertEquals(1.0, s.getNoveltyScore(), 1e-9);
+        s.setNoveltyScore(-0.5);
+        assertEquals(0.0, s.getNoveltyScore(), 1e-9);
+    }
+
+    @Test
+    void empowermentSignal_processingFrequency() {
+        assertEquals(3L, EmpowermentSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(2, EmpowermentSignal.PROCESSING_FREQUENCY.getLoop());
+    }
+
+    @Test
+    void boredomSignal_processingFrequency() {
+        assertEquals(2L, BoredomSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(2, BoredomSignal.PROCESSING_FREQUENCY.getLoop());
+    }
+
+    // ---- Config ----
+
+    @Test
+    void curiosityConfig_defaultsAreDisabled() {
+        CuriosityConfig cfg = new CuriosityConfig();
+        assertFalse(cfg.isEnabled());
+        assertEquals(2048, cfg.getNovelty().getHashBits());
+        assertEquals(1000, cfg.getNovelty().getDecayTicks());
+        assertEquals(200, cfg.getLearningProgress().getWindowTicks());
+        assertEquals(3, cfg.getEmpowerment().getHorizon());
+        assertEquals(8, cfg.getEmpowerment().getNActionSamples());
+        assertEquals(0.2, cfg.getWeights().getBetaNovelty());
+        assertEquals(0.1, cfg.getWeights().getBetaEmpowerment());
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/EmbodimentModuleTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/embodiment/EmbodimentModuleTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.embodiment;
+
+import com.rakovpublic.jneuropallium.ai.signals.fast.MotorCommandSignal;
+import com.rakovpublic.jneuropallium.ai.signals.slow.HarmFeedbackSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.BodySchemaUpdateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.EfferenceCopySignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.ProprioceptiveSignal;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EmbodimentModuleTest {
+
+    // ---- EfferenceCopyNeuron ----
+
+    @Test
+    void efferenceCopyNeuron_producesCopyWithMatchingCommandId() {
+        EfferenceCopyNeuron n = new EfferenceCopyNeuron();
+        n.setId(1L);
+        MotorCommandSignal cmd = new MotorCommandSignal(0, new double[]{0.1, 0.2, 0.3});
+        EfferenceCopySignal copy1 = n.produceCopy(cmd);
+        EfferenceCopySignal copy2 = n.produceCopy(cmd);
+        assertNotNull(copy1);
+        assertNotNull(copy2);
+        assertNotEquals(copy1.getOriginalMotorCommandId(), copy2.getOriginalMotorCommandId());
+        assertArrayEquals(new double[]{0.1, 0.2, 0.3}, copy1.getPredictedOutcome(), 1e-9);
+        assertEquals(0, copy1.getEffectorId());
+    }
+
+    @Test
+    void efferenceCopyNeuron_nullMotorReturnsNull() {
+        EfferenceCopyNeuron n = new EfferenceCopyNeuron();
+        assertNull(n.produceCopy(null));
+    }
+
+    // ---- ReafferenceComparatorNeuron ----
+
+    @Test
+    void reafferenceMismatch_producesHarmFeedbackAboveThreshold() {
+        ReafferenceComparatorNeuron cmp = new ReafferenceComparatorNeuron();
+        cmp.setFailureEmitThreshold(0.1);
+        EfferenceCopySignal expected = new EfferenceCopySignal(1L, new double[]{1.0, 1.0}, 0);
+        cmp.registerEfferenceCopy(expected);
+        cmp.onProprioceptive(new ProprioceptiveSignal(0, new double[]{0.2, 0.2}, 100L));
+        HarmFeedbackSignal fb = cmp.maybeEmitFailure("plan-x");
+        assertNotNull(fb);
+        assertTrue(fb.isActualHarmOccurred());
+        assertEquals("mechanical", fb.getFeedbackSource());
+        assertEquals("plan-x", fb.getActionPlanId());
+    }
+
+    @Test
+    void reafferenceSmallMismatch_doesNotEmit() {
+        ReafferenceComparatorNeuron cmp = new ReafferenceComparatorNeuron();
+        cmp.setFailureEmitThreshold(0.5);
+        cmp.registerEfferenceCopy(new EfferenceCopySignal(2L, new double[]{1.0}, 0));
+        cmp.onProprioceptive(new ProprioceptiveSignal(0, new double[]{0.99}, 1L));
+        assertNull(cmp.maybeEmitFailure("plan-y"));
+    }
+
+    // ---- BodySchemaNeuron + ToolIncorporationNeuron ----
+
+    @Test
+    void toolIncorporation_extendsAndRestoresBodySchema() {
+        BodySchemaNeuron body = new BodySchemaNeuron();
+        EffectorCapability arm = new EffectorCapability(7, new double[7], new double[7], 1.0, false);
+        body.register(0, arm);
+
+        ToolIncorporationNeuron tool = new ToolIncorporationNeuron();
+        EffectorCapability hammer = new EffectorCapability(2, new double[2], new double[]{1, 1}, 1.0, false);
+        BodySchemaUpdateSignal sig = tool.incorporate(body, 99, hammer);
+        assertNotNull(sig);
+        assertTrue(sig.isTool());
+        assertTrue(body.currentSchema().has(99));
+        assertEquals(2, body.currentSchema().get(99).getDof());
+
+        tool.release(body, 99);
+        assertFalse(body.currentSchema().has(99),
+                "releasing a tool that had no prior effector should remove the slot");
+        assertTrue(body.currentSchema().has(0), "arm remains");
+    }
+
+    @Test
+    void bodySchemaNeuron_registersNewEffectorOnProprioception() {
+        BodySchemaNeuron body = new BodySchemaNeuron();
+        body.onProprioceptive(new ProprioceptiveSignal(5, new double[]{0.1, 0.2}, 1L));
+        assertTrue(body.currentSchema().has(5));
+        assertEquals(2, body.currentSchema().get(5).getDof());
+    }
+
+    // ---- Signals ----
+
+    @Test
+    void proprioceptiveSignal_copyPreservesFields() {
+        ProprioceptiveSignal s = new ProprioceptiveSignal(1, new double[]{0.1, 0.2}, 77L);
+        ProprioceptiveSignal c = (ProprioceptiveSignal) s.copySignal();
+        assertEquals(1, c.getEffectorId());
+        assertArrayEquals(new double[]{0.1, 0.2}, c.getJointStates(), 1e-9);
+        assertEquals(77L, c.getTimestamp());
+    }
+
+    @Test
+    void efferenceCopySignal_processingFrequency() {
+        assertEquals(1L, EfferenceCopySignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(1, EfferenceCopySignal.PROCESSING_FREQUENCY.getLoop());
+    }
+
+    @Test
+    void bodySchemaUpdateSignal_processingFrequency() {
+        assertEquals(3L, BodySchemaUpdateSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(2, BodySchemaUpdateSignal.PROCESSING_FREQUENCY.getLoop());
+    }
+
+    // ---- Config ----
+
+    @Test
+    void embodimentConfig_defaultsAreDisabled() {
+        EmbodimentConfig cfg = new EmbodimentConfig();
+        assertFalse(cfg.isEnabled());
+        assertEquals(0.15, cfg.getEfferenceCopyMismatchThreshold());
+        assertEquals(0.4, cfg.getEfferenceCopyFailureEmitThreshold());
+        assertTrue(cfg.isToolIncorporationEnabled());
+        assertEquals(600, cfg.getToolIncorporationTimeoutTicks());
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/GliaModuleTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/glia/GliaModuleTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.glia;
+
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.glia.CalciumWaveSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.glia.GliotransmitterSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.glia.MyelinationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.glia.PruningSignal;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GliaModuleTest {
+
+    // ---- DelayedAxon ----
+
+    @Test
+    void delayedAxon_setDelayClampsToBaselineAndMin() {
+        DelayedAxon a = new DelayedAxon(5, 1);
+        a.setDelay(42L, 99);
+        assertEquals(5, a.getDelay(42L), "clamps above baseline");
+        a.setDelay(42L, -3);
+        assertEquals(1, a.getDelay(42L), "clamps below min");
+    }
+
+    @Test
+    void delayedAxon_accelerateMonotonicallyDecreasesToFloor() {
+        DelayedAxon a = new DelayedAxon(5, 1);
+        a.setDelay(7L, 5);
+        int d1 = a.accelerate(7L, 1);
+        int d2 = a.accelerate(7L, 1);
+        int d3 = a.accelerate(7L, 100);
+        assertEquals(4, d1);
+        assertEquals(3, d2);
+        assertEquals(1, d3, "accelerate cannot go below min");
+    }
+
+    @Test
+    void delayedAxon_demyelinateRestoresBaselineAndNeverAbove() {
+        DelayedAxon a = new DelayedAxon(5, 1);
+        a.setDelay(7L, 1);
+        int restored = a.demyelinate(7L);
+        assertEquals(5, restored);
+        assertEquals(5, a.getDelay(7L));
+    }
+
+    // ---- DelayQueue ----
+
+    @Test
+    void delayQueue_releasesAtExactTick() {
+        DelayQueue q = new DelayQueue();
+        CalciumWaveSignal s = new CalciumWaveSignal(1, 0.5, 1.0);
+        q.enqueue(100L, 7L, s, 3);
+        assertTrue(q.releaseReady(101L).isEmpty(), "not yet");
+        assertTrue(q.releaseReady(102L).isEmpty(), "still not yet");
+        List<DelayQueue.ReleasedSignal> ready = q.releaseReady(103L);
+        assertEquals(1, ready.size());
+        assertEquals(7L, ready.get(0).targetNeuronId);
+        assertSame(s, ready.get(0).signal);
+    }
+
+    @Test
+    void delayQueue_zeroDelayReleasesImmediately() {
+        DelayQueue q = new DelayQueue();
+        q.enqueue(10L, 3L, new CalciumWaveSignal(0, 0.1, 0.1), 0);
+        List<DelayQueue.ReleasedSignal> ready = q.releaseReady(10L);
+        assertEquals(1, ready.size());
+    }
+
+    // ---- AstrocyteNeuron ----
+
+    @Test
+    void astrocyte_emitsCalciumWaveAboveThreshold() {
+        AstrocyteNeuron n = new AstrocyteNeuron(4);
+        n.setCalciumWaveThreshold(1.0);
+        n.accumulate(0.6);
+        assertNull(n.maybeEmitWave(), "below threshold");
+        n.accumulate(0.6);
+        CalciumWaveSignal w = n.maybeEmitWave();
+        assertNotNull(w);
+        assertEquals(4, w.getRegionId());
+        assertEquals(0, n.getIntegratedActivity(), 1e-9, "integrator cleared");
+    }
+
+    @Test
+    void astrocyte_releasesGliotransmitter() {
+        AstrocyteNeuron n = new AstrocyteNeuron(2);
+        GliotransmitterSignal g = n.release(GliotransmitterType.D_SERINE, 0.7);
+        assertEquals(GliotransmitterType.D_SERINE, g.getTransmitter());
+        assertEquals(0.7, g.getConcentration(), 1e-9);
+        assertEquals(2, g.getRegionId());
+    }
+
+    // ---- MicroglialPruningNeuron ----
+
+    @Test
+    void microglia_pruningSafetyRespectsInactivityWindow() {
+        MicroglialPruningNeuron n = new MicroglialPruningNeuron();
+        n.setMinInactivityTicks(100);
+        for (int i = 0; i < 50; i++) n.tick();
+        n.recordActivity(1L, 2L);
+        for (int i = 0; i < 10; i++) n.tick();
+        assertNull(n.maybePrune(1L, 2L, null), "cannot prune recently-active");
+        for (int i = 0; i < 100; i++) n.tick();
+        assertNotNull(n.maybePrune(1L, 2L, null), "allowed after silence");
+    }
+
+    @Test
+    void microglia_honorsEpochCap() {
+        MicroglialPruningNeuron n = new MicroglialPruningNeuron();
+        n.setMinInactivityTicks(1);
+        n.setMaxPruningsPerEpoch(2);
+        for (int i = 0; i < 5; i++) n.tick();
+        assertNotNull(n.maybePrune(1L, 10L, null));
+        assertNotNull(n.maybePrune(1L, 11L, null));
+        assertNull(n.maybePrune(1L, 12L, null), "cap enforced");
+        n.resetEpochCounter();
+        assertNotNull(n.maybePrune(1L, 12L, null), "after reset it emits");
+    }
+
+    // ---- MyelinationNeuron ----
+
+    @Test
+    void myelination_reducesDelayMonotonicallyToFloor() {
+        MyelinationNeuron n = new MyelinationNeuron();
+        n.setBaselineDelayTicks(5);
+        n.setMinDelayTicks(1);
+        n.setUsageThreshold(3);
+
+        DelayedAxon axon = new DelayedAxon(5, 1);
+        axon.setDelay(99L, 5);
+
+        int prev = 5;
+        for (int w = 0; w < 10; w++) {
+            for (int i = 0; i < 5; i++) n.recordUsage(99L);
+            MyelinationSignal sig = n.evaluate(1L, 99L);
+            if (sig != null) {
+                n.applyTo(axon, sig);
+                assertTrue(sig.getNewDelayTicks() <= prev, "monotonic decrease");
+                prev = sig.getNewDelayTicks();
+            }
+        }
+        assertEquals(1, axon.getDelay(99L));
+    }
+
+    @Test
+    void myelination_demyelinationRestoresBaselineNotAbove() {
+        MyelinationNeuron n = new MyelinationNeuron();
+        n.setBaselineDelayTicks(4);
+        n.setMinDelayTicks(1);
+        DelayedAxon axon = new DelayedAxon(4, 1);
+        axon.setDelay(5L, 1);
+        n.demyelinate(axon, 5L);
+        assertEquals(4, axon.getDelay(5L), "restored to baseline, not above");
+    }
+
+    // ---- Signals ----
+
+    @Test
+    void pruningSignal_processingFrequency() {
+        assertEquals(5L, PruningSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(2, PruningSignal.PROCESSING_FREQUENCY.getLoop());
+    }
+
+    @Test
+    void myelinationSignal_processingFrequency() {
+        assertEquals(10L, MyelinationSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(2, MyelinationSignal.PROCESSING_FREQUENCY.getLoop());
+    }
+
+    @Test
+    void calciumWaveSignal_copyPreservesFields() {
+        CalciumWaveSignal s = new CalciumWaveSignal(3, 0.8, 2.0);
+        CalciumWaveSignal c = (CalciumWaveSignal) s.copySignal();
+        assertEquals(3, c.getRegionId());
+        assertEquals(0.8, c.getAmplitude(), 1e-9);
+        assertEquals(2.0, c.getPropagationRadius(), 1e-9);
+    }
+
+    // ---- Config ----
+
+    @Test
+    void gliaConfig_defaultsAreDisabled() {
+        GliaConfig cfg = new GliaConfig();
+        assertFalse(cfg.isEnabled());
+        assertTrue(cfg.getAstrocytes().isPerLayer());
+        assertEquals(0.4, cfg.getAstrocytes().getCalciumWaveThreshold());
+        assertTrue(cfg.getMicroglia().isPruningEnabled());
+        assertEquals(2000, cfg.getMicroglia().getMinInactivityTicks());
+        assertTrue(cfg.getMyelination().isEnabled());
+        assertEquals(5, cfg.getMyelination().getBaselineDelayTicks());
+        assertEquals(1, cfg.getMyelination().getMinDelayTicks());
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/SleepModuleTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/sleep/SleepModuleTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.sleep;
+
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.sleep.DreamSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.sleep.ReplaySignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.sleep.SharpWaveRippleSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.sleep.SleepStateSignal;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SleepModuleTest {
+
+    // ---- SleepControllerNeuron ----
+
+    @Test
+    void sleepPhaseCycle_visitsAllPhasesInOrder() {
+        SleepControllerNeuron ctl = new SleepControllerNeuron();
+        ctl.setCycleTicks(20);
+        ctl.setNremFraction(0.5);
+        ctl.setRemFraction(0.25);
+
+        EnumSet<SleepPhase> seen = EnumSet.noneOf(SleepPhase.class);
+        int firstWake = -1, firstNrem2 = -1, firstNrem3 = -1, firstRem = -1;
+        for (int i = 0; i < 19; i++) {
+            SleepStateSignal s = ctl.advance();
+            seen.add(s.getPhase());
+            if (firstWake < 0 && s.getPhase() == SleepPhase.WAKE) firstWake = i;
+            if (firstNrem2 < 0 && s.getPhase() == SleepPhase.NREM2) firstNrem2 = i;
+            if (firstNrem3 < 0 && s.getPhase() == SleepPhase.NREM3) firstNrem3 = i;
+            if (firstRem < 0 && s.getPhase() == SleepPhase.REM) firstRem = i;
+        }
+        assertTrue(seen.contains(SleepPhase.WAKE));
+        assertTrue(seen.contains(SleepPhase.NREM2));
+        assertTrue(seen.contains(SleepPhase.NREM3));
+        assertTrue(seen.contains(SleepPhase.REM));
+        assertTrue(firstWake < firstNrem2 && firstNrem2 < firstNrem3 && firstNrem3 < firstRem,
+                "within one cycle the order is WAKE → NREM2 → NREM3 → REM");
+    }
+
+    @Test
+    void sleepController_nrem3DeeperThanNrem2() {
+        SleepControllerNeuron ctl = new SleepControllerNeuron();
+        ctl.setCycleTicks(100);
+        ctl.setNremFraction(0.6);
+        ctl.setRemFraction(0.15);
+        double maxN2 = 0, maxN3 = 0;
+        for (int i = 0; i < 100; i++) {
+            SleepStateSignal s = ctl.advance();
+            if (s.getPhase() == SleepPhase.NREM2) maxN2 = Math.max(maxN2, s.getDepth());
+            if (s.getPhase() == SleepPhase.NREM3) maxN3 = Math.max(maxN3, s.getDepth());
+        }
+        assertTrue(maxN3 >= maxN2);
+    }
+
+    // ---- HippocampalReplayNeuron ----
+
+    @Test
+    void replay_reverseInvertsSequence() {
+        HippocampalReplayNeuron rep = new HippocampalReplayNeuron();
+        rep.setDirection(ReplayDirection.REVERSE);
+        rep.setCompressionRatio(8.0);
+        rep.recordEpisode("ep1", Arrays.asList(1L, 2L, 3L, 4L), 0.9);
+        List<ReplaySignal> out = rep.emitTopK();
+        assertEquals(1, out.size());
+        assertEquals(Arrays.asList(4L, 3L, 2L, 1L), out.get(0).getNeuronSequence());
+        assertEquals(ReplayDirection.REVERSE, out.get(0).getDirection());
+        assertEquals(8.0, out.get(0).getCompressionRatio());
+    }
+
+    @Test
+    void replay_forwardPreservesOrder() {
+        HippocampalReplayNeuron rep = new HippocampalReplayNeuron();
+        rep.setDirection(ReplayDirection.FORWARD);
+        rep.recordEpisode("ep", Arrays.asList(1L, 2L, 3L), 0.5);
+        List<ReplaySignal> out = rep.emitTopK();
+        assertEquals(Arrays.asList(1L, 2L, 3L), out.get(0).getNeuronSequence());
+    }
+
+    @Test
+    void replay_topKSalienceOrdering() {
+        HippocampalReplayNeuron rep = new HippocampalReplayNeuron();
+        rep.setTopK(2);
+        rep.recordEpisode("low", Arrays.asList(1L), 0.1);
+        rep.recordEpisode("mid", Arrays.asList(2L), 0.5);
+        rep.recordEpisode("hi",  Arrays.asList(3L), 0.9);
+        List<ReplaySignal> out = rep.emitTopK();
+        assertEquals(2, out.size());
+        assertEquals("hi", out.get(0).getSequenceId());
+        assertEquals("mid", out.get(1).getSequenceId());
+    }
+
+    // ---- SharpWaveRippleNeuron ----
+
+    @Test
+    void swr_onlyEmitsInNREM3WithSufficientDepth() {
+        SharpWaveRippleNeuron swr = new SharpWaveRippleNeuron();
+        List<Long> seq = Arrays.asList(1L, 2L, 3L);
+        assertNull(swr.maybeEmit(SleepPhase.WAKE, 1.0, seq, 0.8), "no emit in WAKE");
+        assertNull(swr.maybeEmit(SleepPhase.NREM2, 1.0, seq, 0.8), "no emit in NREM2");
+        assertNull(swr.maybeEmit(SleepPhase.NREM3, 0.3, seq, 0.8), "too shallow");
+        SharpWaveRippleSignal s = swr.maybeEmit(SleepPhase.NREM3, 0.9, seq, 0.8);
+        assertNotNull(s);
+        assertEquals(seq, s.getNeuronSequence());
+    }
+
+    // ---- REMDreamingNeuron ----
+
+    @Test
+    void dream_onlyDuringREM() {
+        REMDreamingNeuron d = new REMDreamingNeuron();
+        List<List<Long>> eps = Arrays.asList(Arrays.asList(1L, 2L), Arrays.asList(3L, 4L));
+        assertTrue(d.recombine(SleepPhase.WAKE, eps).isEmpty());
+        assertTrue(d.recombine(SleepPhase.NREM3, eps).isEmpty());
+        assertFalse(d.recombine(SleepPhase.REM, eps).isEmpty());
+    }
+
+    @Test
+    void dream_safetyGateRejectsHighNovelty() {
+        REMDreamingNeuron d = new REMDreamingNeuron();
+        d.setMaxNoveltyForPlanning(0.5);
+        DreamSignal safe = new DreamSignal(new ArrayList<>(), 0.2);
+        DreamSignal unsafe = new DreamSignal(new ArrayList<>(), 0.9);
+        assertTrue(d.isPlanningCandidate(safe));
+        assertFalse(d.isPlanningCandidate(unsafe));
+    }
+
+    // ---- Signals ----
+
+    @Test
+    void replaySignal_processingFrequency() {
+        assertEquals(3L, ReplaySignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(2, ReplaySignal.PROCESSING_FREQUENCY.getLoop());
+    }
+
+    @Test
+    void sleepStateSignal_copyPreservesFields() {
+        SleepStateSignal s = new SleepStateSignal(SleepPhase.NREM3, 0.9);
+        SleepStateSignal c = (SleepStateSignal) s.copySignal();
+        assertEquals(SleepPhase.NREM3, c.getPhase());
+        assertEquals(0.9, c.getDepth(), 1e-9);
+    }
+
+    @Test
+    void dreamSignal_clampsNovelty() {
+        DreamSignal d = new DreamSignal(Arrays.asList(1L), 2.0);
+        assertEquals(1.0, d.getNoveltyScore(), 1e-9);
+        d.setNoveltyScore(-0.5);
+        assertEquals(0.0, d.getNoveltyScore(), 1e-9);
+    }
+
+    @Test
+    void sharpWaveRippleSignal_processingFrequency() {
+        assertEquals(1L, SharpWaveRippleSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(2, SharpWaveRippleSignal.PROCESSING_FREQUENCY.getLoop());
+    }
+
+    // ---- Config ----
+
+    @Test
+    void sleepConfig_defaultsAreDisabled() {
+        SleepConfig cfg = new SleepConfig();
+        assertFalse(cfg.isEnabled());
+        assertEquals(10000, cfg.getCircadian().getCycleTicks());
+        assertEquals(0.6, cfg.getCircadian().getNremFraction());
+        assertEquals(0.15, cfg.getCircadian().getRemFraction());
+        assertEquals(ReplayDirection.REVERSE, cfg.getReplay().getDirection());
+        assertEquals(10.0, cfg.getReplay().getCompressionRatio());
+        assertEquals(20, cfg.getReplay().getTopKEpisodes());
+        assertEquals(5, cfg.getDreaming().getRecombinationCount());
+        assertEquals(0.7, cfg.getDreaming().getMaxNoveltyForPlanning());
+        assertEquals(3.0, cfg.getConsolidationBoost());
+    }
+}


### PR DESCRIPTION
… sleep)

Adds five biologically-inspired subsystems per the repository spec, each opt-in via top-level config section, no changes to core abstractions.

Module A - Affect: AmygdalaValenceNeuron, AnteriorInsulaNeuron, AffectIntegrationNeuron, AffectModulationNeuron. Signals: AffectStateSignal, InteroceptiveSignal, AppraisalSignal. Processors under signalprocessor.impl.affect. 14 tests.

Module B - Embodiment: EfferenceCopyNeuron, BodySchemaNeuron, ToolIncorporationNeuron, ReafferenceComparatorNeuron. Signals: Proprioceptive, EfferenceCopy, BodySchemaUpdate, SensorimotorContingency. Mismatch emits HarmFeedbackSignal(source="mechanical"). 10 tests.

Module C - Curiosity: NoveltyDetectorNeuron (decaying Bloom filter), LearningProgressNeuron (Oudeyer-Kaplan), EmpowermentNeuron (Klyubin MI estimator), BoredomNeuron (habituation + inhibition-of-return). 15 tests.

Module D - Glia: DelayedAxon extends Axon with per-connection delay map (myelination can only decrease delay toward min, demyelination restores baseline). DelayQueue for dispatcher-side delayed delivery. AstrocyteNeuron, MicroglialPruningNeuron (inactivity window + epoch cap), MyelinationNeuron. 15 tests.

Module E - Sleep: SleepControllerNeuron (WAKE -> NREM2 -> NREM3 -> REM), HippocampalReplayNeuron (top-K salience-ordered replay, reverse default), SharpWaveRippleNeuron (NREM3-only burst), REMDreamingNeuron (recombination with planner-safety gate - dreams above max-novelty-for-planning are filtered before planning). 13 tests.

All modules: config class with enabled=false default, package-info.java with biological citations, Javadoc referencing layer/loop/epoch, signal classes declare public static final ProcessingFrequency PROCESSING_FREQUENCY.

Docs: docs/modules/{affect,embodiment,curiosity,glia,sleep}.md.

All 67 new unit tests pass.

https://claude.ai/code/session_018DLgBWsQFe4q32RCbqYsAQ