### PR TITLE
Implement BCI / neural-prosthetics use case (use-case-bci-neural-pros…

### DIFF
--- a/docs/modules/bci.md
+++ b/docs/modules/bci.md
@@ -1,0 +1,191 @@
+# BCI / Neural-Prosthetics Module
+
+## Abstract
+
+The `bci` module turns the jneopallium engine into a reference platform for
+closed-loop brain-computer interfaces driving neural prosthetics, sensory
+feedback, and assistive communication. It closes the loop from intracortical
+or ECoG recording through online decoding (Georgopoulos population vector,
+Kalman state-space, LFADS-style latent dynamics, speech-phoneme
+classification) to safety-gated stimulation and prosthetic actuation. The
+safety envelope is non-negotiable: every stimulation command is vetted
+against the Shannon charge-density criterion, per-phase charge limits,
+frequency / pulse-width bounds, charge-balance DC accumulation, seizure
+lockout, and thermal shutdown.
+
+## Design Principles
+
+1. **Safety by construction** — no stimulation reaches the driver without
+   passing `StimulationSafetyGateNeuron`. Shannon 0.5 µC/cm² per phase is
+   the default ceiling; DC drift > 1 nC vetoes the electrode.
+2. **Biologically grounded decoders** — population vector, Kalman, LFADS
+   are the canonical intra-cortical decoders; speech phonemes follow the
+   Moses / Willett 2021-2023 work.
+3. **User ownership** — `PersonalMotorLexiconNeuron` lets the user invent
+   personal gestures; `UserStateNeuron` classifies fatigue / confusion /
+   distress and backs off stim when the user is not in nominal control.
+4. **Transparency** — safety vetoes, seizure alarms, thermal shutdowns,
+   calibration events are all observable signals; they must be routed to
+   the existing `TransparencyLogSignal` bus for the oversight UI.
+5. **Optional module** — `bci.enabled=false` keeps the module dormant; zero
+   behavioural change to existing configurations.
+
+## Signals
+
+| Signal | Loop / Epoch | Role |
+|---|---|---|
+| `NeuralSpikeSignal` | 1 / 1 | Raw spike event per channel / unit |
+| `LFPSignal` | 1 / 1 | Six-band LFP power |
+| `ECoGSignal` | 1 / 1 | ECoG voltage sample |
+| `IntentSignal` | 1 / 1 | Decoded user intent with confidence |
+| `StimulationCommandSignal` | 1 / 1 | Requested pulse train to an electrode |
+| `SensoryFeedbackSignal` | 1 / 1 | Synthetic afferent activation |
+| `ChargeAccumulationSignal` | 2 / 1 | Net DC charge and density tracking |
+| `ThermalSignal` | 2 / 1 | Implant / tissue temperature telemetry |
+| `CalibrationSignal` | 2 / 3 | Session boundary + calibration target |
+| `DriftEstimateSignal` | 2 / 5 | Per-channel waveform drift / SNR |
+| `SeizureRiskSignal` | 1 / 1 | Pre-ictal / ictal risk + marker |
+| `AgencyLossSignal` | 1 / 2 | Efference-vs-reafference mismatch alarm |
+
+## Neurons
+
+### Layer 0 — front-end
+- `SpikeRecordingNeuron` — threshold-crossing detector.
+- `SpikeSortingNeuron` — online template matching.
+- `LFPExtractionNeuron` — six-band power extraction.
+- `ArtefactRejectionNeuron` — amplitude-based channel masking.
+
+### Layer 1 — decoders
+- `FiringRateEstimatorNeuron` — exponential-moving-average per-unit rates.
+- `PopulationVectorNeuron` — Georgopoulos 1986 rate-weighted PD sum.
+- `KalmanDecoderNeuron` — 2-state (pos, vel) Kalman filter (Wu et al.
+  2006).
+- `LatentDynamicsNeuron` — LFADS-style manifold stand-in (Pandarinath
+  et al. 2018).
+- `SpeechPhonemeDecoderNeuron` — centroid classifier stand-in.
+
+### Layer 2 — fusion
+- `IntentFusionNeuron` — confidence-weighted spike/LFP blend.
+- `UserStateNeuron` — alert / fatigued / confused / distressed.
+
+### Layer 3 — adaptation
+- `DecoderWeightNeuron` — online Hebbian weight update.
+- `DriftTrackerNeuron` — rolling drift / SNR per channel.
+- `PersonalMotorLexiconNeuron` — user-defined gesture memory.
+
+### Layer 4 — planning
+- `ProstheticPlanningNeuron` — joint-limited trajectory step.
+- `GripSelectionNeuron` — power / pinch / lateral / tripod selection.
+
+### Layer 5 — output + safety
+- `StimulationSafetyGateNeuron` — Shannon / frequency / lockout gate.
+- `ActuatorNeuron` — dispatch record after gate approval.
+- `ChargeBalanceNeuron` — net DC charge tracker.
+- `SeizureWatchdogNeuron` — pre-ictal LFP classifier.
+
+### Layer 7 — supervision
+- `ThermalMonitorNeuron` — 1 °C cool-down, 2 °C shutdown.
+- `PowerBudgetNeuron` — battery state → NORMAL / CONSERVE / EMERGENCY.
+- `CalibrationSchedulerNeuron` — drift / error / interval-driven recalib.
+
+## Integration
+
+- Every `StimulationCommandSignal` must pass
+  `StimulationSafetyGateNeuron.veto(...)`; non-null return = hard refusal.
+- `ReafferenceComparatorNeuron` (from the `embodiment` module) emits
+  `AgencyLossSignal` whenever the predicted and observed body states
+  diverge beyond `efference-copy-tolerance` (default 0.15).
+- Seizure watchdog output is routed to the safety gate via
+  `triggerSeizureLockout(...)`; thermal monitor → `triggerThermalLockout`.
+- Calibration events are emitted as `CalibrationSignal` for the
+  transparency bus and for the oversight UI.
+
+## Configuration
+
+```yaml
+bci:
+  enabled: false
+  tick-rate-hz: 1000
+  stimulation:
+    max-charge-density-uc-cm2: 0.5
+    net-dc-tolerance-uc: 0.001
+    max-frequency-hz: 300
+    max-pulse-width-us: 300
+  thermal:
+    cool-down-delta-c: 1.0
+    shutdown-delta-c: 2.0
+  seizure:
+    risk-threshold: 0.8
+    lockout-ticks: 60000
+  power:
+    battery-capacity-mah: 500
+    conserve-frac: 0.30
+    emergency-frac: 0.10
+  embodiment:
+    efference-copy-tolerance: 0.15
+  calibration:
+    min-interval-ticks: 86400000
+    max-interval-ticks: 604800000
+    drift-trigger: 0.25
+    error-trigger: 0.30
+```
+
+Defaults to `enabled: false` for strict backward compatibility.
+
+## Tests
+
+`BciModuleTest` covers:
+
+- Signal frequency constants and round-trip copies (NeuralSpike, LFP,
+  Stimulation, Charge, Agency, Drift, Thermal, SensoryFeedback).
+- Layer 0: threshold detection, spike-sorting unit assignment, LFP band
+  extraction, artefact masking.
+- Layer 1: firing-rate EWMA, population-vector direction, Kalman
+  convergence, LFADS-latent boundedness, phoneme centroid match.
+- Layer 2: intent fusion by confidence; user-state classification.
+- Layer 3: Hebbian weight update, drift flag, lexicon cosine match.
+- Layer 4: joint-limit clip; grip selection by object size.
+- Layer 5: Shannon veto, frequency veto, seizure lockout / recovery,
+  charge-balance DC buildup, seizure marker classification,
+  actuator dispatch counter.
+- Layer 7: thermal cool-down / shutdown, power mode transitions,
+  calibration trigger / suppression.
+- Config defaults and enum cardinality.
+
+## References
+
+- Georgopoulos, A.P. et al. (1986). Neuronal population coding of movement
+  direction. *Science* 233, 1416–1419.
+- Wu, W. et al. (2006). Bayesian population decoding of motor cortical
+  activity using a Kalman filter. *Neural Computation* 18.
+- Velliste, M. et al. (2008). Cortical control of a prosthetic arm for
+  self-feeding. *Nature* 453, 1098–1101.
+- Hochberg, L.R. et al. (2012). Reach and grasp by people with tetraplegia
+  using a neurally controlled robotic arm. *Nature* 485, 372–375.
+- Pandarinath, C. et al. (2018). Inferring single-trial neural population
+  dynamics using sequential auto-encoders. *Nature Methods* 15, 805–815.
+- Flesher, S.N. et al. (2021). A brain-computer interface that evokes
+  tactile sensations improves robotic arm control. *Science* 372, 831–836.
+- Shannon, R.V. (1992). A model of safe levels for electrical stimulation.
+  *IEEE Trans Biomed Eng* 39, 424–426.
+- Cogan, S.F. (2008). Neural stimulation and recording electrodes. *Annu
+  Rev Biomed Eng* 10, 275–309.
+- Worrell, G.A. et al. (2008). High-frequency oscillations in human temporal
+  lobe. *Brain* 131, 928–937.
+- Wolpert, D.M., Miall, R.C., Kawato, M. (1998). Internal models in the
+  cerebellum. *Trends Cogn Sci* 2, 338–347.
+- Moses, D.A. et al. (2021). Neuroprosthesis for decoding speech in a
+  paralyzed person with anarthria. *N Engl J Med* 385, 217–227.
+- Willett, F.R. et al. (2023). A high-performance speech neuroprosthesis.
+  *Nature* 620, 1031–1036.
+- Perge, J.A. et al. (2013). Intra-day signal instabilities affect decoding
+  performance in an intracortical neural interface. *J Neural Eng* 10.
+- Andersen, R.A., Buneo, C.A. (2002). Intentional maps in posterior parietal
+  cortex. *Annu Rev Neurosci* 25, 189–220.
+- Murata, A. et al. (2000). Selectivity for the shape, size, and orientation
+  of objects for grasping in neurons of monkey parietal area AIP. *J
+  Neurophysiol* 83, 2580–2601.
+- Orsborn, A.L. et al. (2014). Closed-loop decoder adaptation shapes neural
+  plasticity for skillful neuroprosthetic control. *Neuron* 82, 1380–1393.
+- Shadmehr, R., Wise, S.P. (2005). *The Computational Neurobiology of
+  Reaching and Pointing*. MIT Press.

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/ActuatorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/ActuatorNeuron.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.StimulationCommandSignal;
+
+/**
+ * Layer 5 low-level actuator. Once the safety gate has approved a
+ * {@link StimulationCommandSignal}, this neuron emits the physical-layer
+ * command to the stim driver, and records the dispatch for transparency logs.
+ * Loop=1 / Epoch=1.
+ */
+public class ActuatorNeuron extends ModulatableNeuron {
+
+    private long dispatched;
+    private long lastDispatchTick;
+
+    public ActuatorNeuron() { super(); }
+    public ActuatorNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    /**
+     * Record and dispatch a pre-approved stimulation command.
+     * Returns true iff dispatched.
+     */
+    public boolean dispatch(StimulationCommandSignal cmd, long currentTick) {
+        if (cmd == null) return false;
+        dispatched++;
+        lastDispatchTick = currentTick;
+        return true;
+    }
+
+    public long getDispatchedCount() { return dispatched; }
+    public long getLastDispatchTick() { return lastDispatchTick; }
+    public void reset() { dispatched = 0; lastDispatchTick = 0; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/ArtefactRejectionNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/ArtefactRejectionNeuron.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Layer 0 artefact mask. Detects movement and stim-artefact excursions and
+ * blacklists affected channels for a configurable window.
+ * Loop=1 / Epoch=1.
+ */
+public class ArtefactRejectionNeuron extends ModulatableNeuron {
+
+    private double absAmplitudeLimitUV = 500.0;
+    private final Set<Integer> maskedChannels = new HashSet<>();
+
+    public ArtefactRejectionNeuron() { super(); }
+    public ArtefactRejectionNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    /**
+     * Check a window for excursions; mask the channel if any sample exceeds
+     * the limit. Returns true if the channel is now masked.
+     */
+    public boolean check(int channelId, double[] window) {
+        if (window == null) return maskedChannels.contains(channelId);
+        for (double v : window) {
+            if (Math.abs(v) >= absAmplitudeLimitUV) {
+                maskedChannels.add(channelId);
+                return true;
+            }
+        }
+        return maskedChannels.contains(channelId);
+    }
+
+    public boolean isMasked(int channelId) { return maskedChannels.contains(channelId); }
+    public void unmask(int channelId) { maskedChannels.remove(channelId); }
+    public void setAbsAmplitudeLimitUV(double v) { this.absAmplitudeLimitUV = v; }
+    public int maskedCount() { return maskedChannels.size(); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/BciConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/BciConfig.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+/**
+ * Configuration for the BCI / neural-prosthetics module. Mirrors the YAML
+ * section {@code bci} in the worker config; default {@code enabled=false}
+ * so that existing deployments are unaffected.
+ */
+public final class BciConfig {
+
+    private boolean enabled;
+    private int tickRateHz = 1000;
+
+    // --- stimulation safety envelope ---
+    private double maxChargeDensityUCcm2 = 0.5;         // Shannon 1992 / Cogan 2008
+    private double netDcToleranceUC = 1e-3;              // 1 nC
+    private double maxFrequencyHz = 300.0;
+    private double maxPulseWidthUS = 300.0;
+
+    // --- thermal ---
+    private double thermalCoolDownDeltaC = 1.0;
+    private double thermalShutdownDeltaC = 2.0;
+
+    // --- seizure ---
+    private double seizureRiskThreshold = 0.8;
+    private long seizureLockoutTicks = 60_000;
+
+    // --- power ---
+    private double batteryCapacityMAh = 500.0;
+    private double powerConserveFrac = 0.30;
+    private double powerEmergencyFrac = 0.10;
+
+    // --- embodiment ---
+    private double efferenceCopyTolerance = 0.15;
+
+    // --- calibration ---
+    private long calibMinIntervalTicks = 24L * 60 * 60 * 1000;
+    private long calibMaxIntervalTicks = 7L * 24 * 60 * 60 * 1000;
+    private double calibDriftTrigger = 0.25;
+    private double calibErrorTrigger = 0.30;
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean v) { this.enabled = v; }
+    public int getTickRateHz() { return tickRateHz; }
+    public void setTickRateHz(int v) { this.tickRateHz = Math.max(1, v); }
+
+    public double getMaxChargeDensityUCcm2() { return maxChargeDensityUCcm2; }
+    public void setMaxChargeDensityUCcm2(double v) { this.maxChargeDensityUCcm2 = v; }
+    public double getNetDcToleranceUC() { return netDcToleranceUC; }
+    public void setNetDcToleranceUC(double v) { this.netDcToleranceUC = v; }
+    public double getMaxFrequencyHz() { return maxFrequencyHz; }
+    public void setMaxFrequencyHz(double v) { this.maxFrequencyHz = v; }
+    public double getMaxPulseWidthUS() { return maxPulseWidthUS; }
+    public void setMaxPulseWidthUS(double v) { this.maxPulseWidthUS = v; }
+
+    public double getThermalCoolDownDeltaC() { return thermalCoolDownDeltaC; }
+    public void setThermalCoolDownDeltaC(double v) { this.thermalCoolDownDeltaC = v; }
+    public double getThermalShutdownDeltaC() { return thermalShutdownDeltaC; }
+    public void setThermalShutdownDeltaC(double v) { this.thermalShutdownDeltaC = v; }
+
+    public double getSeizureRiskThreshold() { return seizureRiskThreshold; }
+    public void setSeizureRiskThreshold(double v) { this.seizureRiskThreshold = v; }
+    public long getSeizureLockoutTicks() { return seizureLockoutTicks; }
+    public void setSeizureLockoutTicks(long v) { this.seizureLockoutTicks = v; }
+
+    public double getBatteryCapacityMAh() { return batteryCapacityMAh; }
+    public void setBatteryCapacityMAh(double v) { this.batteryCapacityMAh = v; }
+    public double getPowerConserveFrac() { return powerConserveFrac; }
+    public void setPowerConserveFrac(double v) { this.powerConserveFrac = v; }
+    public double getPowerEmergencyFrac() { return powerEmergencyFrac; }
+    public void setPowerEmergencyFrac(double v) { this.powerEmergencyFrac = v; }
+
+    public double getEfferenceCopyTolerance() { return efferenceCopyTolerance; }
+    public void setEfferenceCopyTolerance(double v) { this.efferenceCopyTolerance = v; }
+
+    public long getCalibMinIntervalTicks() { return calibMinIntervalTicks; }
+    public void setCalibMinIntervalTicks(long v) { this.calibMinIntervalTicks = v; }
+    public long getCalibMaxIntervalTicks() { return calibMaxIntervalTicks; }
+    public void setCalibMaxIntervalTicks(long v) { this.calibMaxIntervalTicks = v; }
+    public double getCalibDriftTrigger() { return calibDriftTrigger; }
+    public void setCalibDriftTrigger(double v) { this.calibDriftTrigger = v; }
+    public double getCalibErrorTrigger() { return calibErrorTrigger; }
+    public void setCalibErrorTrigger(double v) { this.calibErrorTrigger = v; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/CalibrationSchedulerNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/CalibrationSchedulerNeuron.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.CalibrationSignal;
+
+/**
+ * Layer 7 calibration scheduler. Decides when to request decoder recalibration
+ * given drift, decode error, time since last session, and user state.
+ * Emits a {@link CalibrationSignal} with the chosen target.
+ * Loop=2 / Epoch=3.
+ */
+public class CalibrationSchedulerNeuron extends ModulatableNeuron {
+
+    private long lastCalibrationTick = 0L;
+    private long minIntervalTicks = 24 * 60 * 60 * 1000L;  // ≈ 1 day @ 1 kHz
+    private long maxIntervalTicks = 7L * 24 * 60 * 60 * 1000L;  // ≈ 1 week
+    private double driftTrigger = 0.25;
+    private double errorTrigger = 0.30;
+    private long sessionCounter;
+
+    public CalibrationSchedulerNeuron() { super(); }
+    public CalibrationSchedulerNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    /**
+     * Evaluate whether to request calibration now. Returns a
+     * {@link CalibrationSignal} if triggered, or {@code null} if not.
+     */
+    public CalibrationSignal evaluate(long currentTick, double drift, double decodeError, boolean userAlert) {
+        long since = currentTick - lastCalibrationTick;
+        boolean mustCalibrate = since >= maxIntervalTicks;
+        boolean shouldCalibrate = since >= minIntervalTicks
+                && (drift >= driftTrigger || decodeError >= errorTrigger);
+        if (!mustCalibrate && !shouldCalibrate) return null;
+        if (!mustCalibrate && !userAlert) return null;
+
+        CalibrationTarget target;
+        if (drift >= driftTrigger && decodeError >= errorTrigger) target = CalibrationTarget.FULL_RECALIBRATION;
+        else if (drift >= driftTrigger) target = CalibrationTarget.CHANNEL_SELECTION;
+        else if (decodeError >= errorTrigger) target = CalibrationTarget.DECODER_WEIGHTS;
+        else target = CalibrationTarget.FEEDBACK_INTENSITY;
+
+        sessionCounter++;
+        lastCalibrationTick = currentTick;
+        double performance = Math.max(0, Math.min(1, 1.0 - 0.5 * (drift + decodeError)));
+        return new CalibrationSignal("session-" + sessionCounter, target, performance);
+    }
+
+    public void setMinIntervalTicks(long t) { this.minIntervalTicks = Math.max(0, t); }
+    public void setMaxIntervalTicks(long t) { this.maxIntervalTicks = Math.max(0, t); }
+    public void setDriftTrigger(double t) { this.driftTrigger = t; }
+    public void setErrorTrigger(double t) { this.errorTrigger = t; }
+    public long getLastCalibrationTick() { return lastCalibrationTick; }
+    public long getSessionCount() { return sessionCounter; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/CalibrationTarget.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/CalibrationTarget.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+/**
+ * What a calibration session is trying to adjust.
+ */
+public enum CalibrationTarget {
+    DECODER_WEIGHTS,
+    CHANNEL_SELECTION,
+    INTENT_MAPPING,
+    FEEDBACK_INTENSITY,
+    FULL_RECALIBRATION
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/ChargeBalanceNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/ChargeBalanceNeuron.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.ChargeAccumulationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.StimulationCommandSignal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 5 charge balance monitor. Tracks running net DC charge per electrode;
+ * persistent DC offset accelerates electrode / tissue damage. Emits a
+ * {@link ChargeAccumulationSignal} and vetoes further stimulation on channels
+ * that exceed the configured DC tolerance (default ± 1 nC).
+ * Loop=1 / Epoch=1.
+ */
+public class ChargeBalanceNeuron extends ModulatableNeuron {
+
+    private final Map<Integer, Double> netChargeUC = new HashMap<>();
+    private double dcToleranceUC = 1e-3;  // 1 nC = 1e-3 µC
+
+    public ChargeBalanceNeuron() { super(); }
+    public ChargeBalanceNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    /**
+     * Accumulate charge from a biphasic command; asymmetric pulses are
+     * recorded as residual DC (positive = anodic bias, negative = cathodic).
+     */
+    public ChargeAccumulationSignal accumulate(StimulationCommandSignal cmd, double anodicImbalanceFrac) {
+        if (cmd == null) return null;
+        double qPhase = cmd.chargePerPhaseUC();
+        double residual = qPhase * anodicImbalanceFrac * cmd.getNPulses();
+        double prev = netChargeUC.getOrDefault(cmd.getElectrodeId(), 0.0);
+        double updated = prev + residual;
+        netChargeUC.put(cmd.getElectrodeId(), updated);
+        double densityUCm2 = updated;
+        return new ChargeAccumulationSignal(cmd.getElectrodeId(), updated, densityUCm2);
+    }
+
+    public boolean exceedsDc(int electrodeId) {
+        return Math.abs(netChargeUC.getOrDefault(electrodeId, 0.0)) > dcToleranceUC;
+    }
+
+    public double getNetCharge(int electrodeId) { return netChargeUC.getOrDefault(electrodeId, 0.0); }
+    public void resetElectrode(int electrodeId) { netChargeUC.remove(electrodeId); }
+    public void setDcToleranceUC(double v) { this.dcToleranceUC = Math.max(0, v); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/DecoderWeightNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/DecoderWeightNeuron.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+
+/**
+ * Layer 3 decoder-weight adaptation. Performs online Hebbian-style updates
+ * on the decoder weight vector given an intent/outcome error signal. Biological
+ * analogue: long-horizon cortical remapping during closed-loop decoder adaptation
+ * (Orsborn et al. 2014).
+ * Loop=2 / Epoch=3.
+ */
+public class DecoderWeightNeuron extends ModulatableNeuron {
+
+    private double[] weights;
+    private double learningRate = 0.01;
+    private double weightDecay = 1e-4;
+
+    public DecoderWeightNeuron() { super(); this.weights = new double[0]; }
+    public DecoderWeightNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+        this.weights = new double[0];
+    }
+
+    public void init(int dim) { this.weights = new double[Math.max(0, dim)]; }
+    public double[] getWeights() { return weights.clone(); }
+
+    /**
+     * Update weights with presynaptic {@code rates} and scalar error. Rule:
+     * w_i += lr * (error * rate_i) - decay * w_i.
+     */
+    public void update(double[] rates, double error) {
+        if (rates == null) return;
+        if (weights.length != rates.length) weights = new double[rates.length];
+        for (int i = 0; i < weights.length; i++) {
+            weights[i] += learningRate * error * rates[i] - weightDecay * weights[i];
+        }
+    }
+
+    public double predict(double[] rates) {
+        if (rates == null) return 0;
+        int n = Math.min(rates.length, weights.length);
+        double s = 0;
+        for (int i = 0; i < n; i++) s += weights[i] * rates[i];
+        return s;
+    }
+
+    public void setLearningRate(double lr) { this.learningRate = Math.max(0, lr); }
+    public void setWeightDecay(double wd) { this.weightDecay = Math.max(0, wd); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/DriftTrackerNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/DriftTrackerNeuron.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.DriftEstimateSignal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 3 electrode-drift tracker. Estimates per-channel waveform drift and
+ * rolling SNR; flags channels whose drift exceeds a tolerance for
+ * recalibration. Biological analogue: micromotion / glial encapsulation
+ * causing gradual signal loss over days/weeks (Perge et al. 2013).
+ * Loop=2 / Epoch=5.
+ */
+public class DriftTrackerNeuron extends ModulatableNeuron {
+
+    private final Map<Integer, Double> drift = new HashMap<>();
+    private final Map<Integer, Double> snr = new HashMap<>();
+    private double driftTolerance = 0.25;
+
+    public DriftTrackerNeuron() { super(); }
+    public DriftTrackerNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    /**
+     * Update rolling drift estimate using a shift score in [0,1] (e.g. 1 minus
+     * cosine similarity of the new waveform template vs. the reference).
+     */
+    public DriftEstimateSignal observe(int channelId, double shiftScore, double snrLinear) {
+        double prev = drift.getOrDefault(channelId, 0.0);
+        double updated = 0.9 * prev + 0.1 * shiftScore;
+        drift.put(channelId, updated);
+        snr.put(channelId, snrLinear);
+        return new DriftEstimateSignal(channelId, updated, snrLinear);
+    }
+
+    public boolean needsRecalibration(int channelId) {
+        return drift.getOrDefault(channelId, 0.0) >= driftTolerance;
+    }
+
+    public double driftFor(int channelId) { return drift.getOrDefault(channelId, 0.0); }
+    public double snrFor(int channelId) { return snr.getOrDefault(channelId, 0.0); }
+    public void setDriftTolerance(double t) { this.driftTolerance = Math.max(0, t); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/FeedbackModality.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/FeedbackModality.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+/**
+ * Modality of sensory feedback delivered back to the user.
+ */
+public enum FeedbackModality {
+    TACTILE, PROPRIOCEPTIVE, THERMAL, PAIN
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/FiringRateEstimatorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/FiringRateEstimatorNeuron.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 1 per-unit rolling firing-rate estimator. Exponential moving average
+ * over spike counts; rate reported in spikes / second.
+ * Loop=1 / Epoch=1.
+ */
+public class FiringRateEstimatorNeuron extends ModulatableNeuron {
+
+    private final Map<Integer, Double> rates = new HashMap<>();
+    private double tauSeconds = 0.1;
+    private long lastTsNs;
+
+    public FiringRateEstimatorNeuron() { super(); }
+    public FiringRateEstimatorNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    /**
+     * Update rate for {@code unitId} on a new spike at timestamp {@code tsNs}.
+     */
+    public double onSpike(int unitId, long tsNs) {
+        double dt = lastTsNs == 0 ? 0 : (tsNs - lastTsNs) / 1_000_000_000.0;
+        lastTsNs = tsNs;
+        double alpha = dt <= 0 ? 1.0 : 1.0 - Math.exp(-dt / tauSeconds);
+        double impulse = dt <= 0 ? 1.0 : 1.0 / dt;
+        double prev = rates.getOrDefault(unitId, 0.0);
+        double updated = (1 - alpha) * prev + alpha * impulse;
+        rates.put(unitId, updated);
+        return updated;
+    }
+
+    public double rateFor(int unitId) { return rates.getOrDefault(unitId, 0.0); }
+    public int trackedUnits() { return rates.size(); }
+    public void setTauSeconds(double tau) { this.tauSeconds = Math.max(1e-3, tau); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/GripSelectionNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/GripSelectionNeuron.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+
+/**
+ * Layer 4 grip-type selector. Maps object geometry + intent into one of the
+ * canonical grasp types (power, pinch, lateral, tripod). Biological analogue:
+ * anterior intraparietal area (AIP) grip selection (Murata et al. 2000).
+ * Loop=1 / Epoch=2.
+ */
+public class GripSelectionNeuron extends ModulatableNeuron {
+
+    public enum GripType { POWER, PINCH, LATERAL, TRIPOD, NONE }
+
+    private GripType lastGrip = GripType.NONE;
+
+    public GripSelectionNeuron() { super(); }
+    public GripSelectionNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    /**
+     * Choose a grip from a rough object descriptor:
+     * {@code sizeMeters} (longest axis) and {@code elongation} in [0,1].
+     * Precision grasps for small / thin objects, power grasps for large ones.
+     */
+    public GripType select(double sizeMeters, double elongation, boolean thin) {
+        if (sizeMeters <= 0) return lastGrip = GripType.NONE;
+        if (thin && sizeMeters < 0.02) return lastGrip = GripType.PINCH;
+        if (elongation > 0.7 && sizeMeters < 0.08) return lastGrip = GripType.LATERAL;
+        if (sizeMeters < 0.05) return lastGrip = GripType.TRIPOD;
+        return lastGrip = GripType.POWER;
+    }
+
+    public GripType getLastGrip() { return lastGrip; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/IntentFusionNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/IntentFusionNeuron.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.IntentSignal;
+
+/**
+ * Layer 2 intent fusion. Combines spike-based decoder output (fast, noisy)
+ * with LFP-based decoder output (slower, smoother) using a confidence-weighted
+ * average. Biological analogue: premotor / PPC integration of multiple
+ * cortical streams (Andersen & Buneo 2002).
+ * Loop=1 / Epoch=2.
+ */
+public class IntentFusionNeuron extends ModulatableNeuron {
+
+    private double spikeWeight = 0.65;
+    private double lfpWeight = 0.35;
+
+    public IntentFusionNeuron() { super(); }
+    public IntentFusionNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    /**
+     * Fuse two candidate intents. If kinds disagree, the higher-confidence
+     * stream wins; parameters are blended proportionally.
+     */
+    public IntentSignal fuse(IntentSignal spikeIntent, IntentSignal lfpIntent) {
+        if (spikeIntent == null && lfpIntent == null) return null;
+        if (spikeIntent == null) return lfpIntent;
+        if (lfpIntent == null) return spikeIntent;
+        double ws = spikeWeight * spikeIntent.getConfidence();
+        double wl = lfpWeight * lfpIntent.getConfidence();
+        double total = ws + wl;
+        if (total <= 0) return spikeIntent;
+        ws /= total;
+        wl /= total;
+        IntentKind kind = spikeIntent.getKind();
+        if (spikeIntent.getKind() != lfpIntent.getKind())
+            kind = ws >= wl ? spikeIntent.getKind() : lfpIntent.getKind();
+        double[] sp = spikeIntent.getParameters() == null ? new double[0] : spikeIntent.getParameters();
+        double[] lp = lfpIntent.getParameters() == null ? new double[0] : lfpIntent.getParameters();
+        int n = Math.max(sp.length, lp.length);
+        double[] fused = new double[n];
+        for (int i = 0; i < n; i++) {
+            double sv = i < sp.length ? sp[i] : 0;
+            double lv = i < lp.length ? lp[i] : 0;
+            fused[i] = ws * sv + wl * lv;
+        }
+        double conf = ws * spikeIntent.getConfidence() + wl * lfpIntent.getConfidence();
+        return new IntentSignal(kind, fused, conf);
+    }
+
+    public void setSpikeWeight(double w) { this.spikeWeight = Math.max(0, w); }
+    public void setLfpWeight(double w) { this.lfpWeight = Math.max(0, w); }
+    public double getSpikeWeight() { return spikeWeight; }
+    public double getLfpWeight() { return lfpWeight; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/IntentKind.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/IntentKind.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+/**
+ * Kind of user intent decoded from neural activity.
+ */
+public enum IntentKind {
+    REACH, GRASP, RELEASE, CURSOR_MOVE, CURSOR_CLICK, SPEECH_PHONEME, WHEELCHAIR_DRIVE, NONE
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/KalmanDecoderNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/KalmanDecoderNeuron.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+
+/**
+ * Layer 1 Kalman state-space decoder for cursor / end-effector kinematics
+ * (Wu et al. 2006). Held as a scalar 2-state (position, velocity) filter
+ * here; production deployments swap in a full KF with matrix dynamics.
+ * Loop=1 / Epoch=1.
+ */
+public class KalmanDecoderNeuron extends ModulatableNeuron {
+
+    private double pos;
+    private double vel;
+    private double varP = 1.0;   // position uncertainty
+    private double varV = 1.0;   // velocity uncertainty
+    private double processNoise = 0.01;
+    private double measurementNoise = 0.1;
+    private double c = 1.0;      // observation coefficient
+
+    public KalmanDecoderNeuron() { super(); }
+    public KalmanDecoderNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    /**
+     * Predict then update given a scalar neural observation {@code y}.
+     * Returns the new position estimate.
+     */
+    public double step(double y) {
+        pos = pos + vel;
+        varP = varP + varV + processNoise;
+        double k = (c * varP) / (c * c * varP + measurementNoise);
+        double innovation = y - c * pos;
+        pos = pos + k * innovation;
+        vel = vel + 0.5 * k * innovation;
+        varP = (1 - k * c) * varP;
+        return pos;
+    }
+
+    public double getPos() { return pos; }
+    public double getVel() { return vel; }
+    public void setProcessNoise(double p) { this.processNoise = Math.max(0, p); }
+    public void setMeasurementNoise(double m) { this.measurementNoise = Math.max(1e-9, m); }
+    public void setObservationCoefficient(double c) { this.c = c; }
+    public void reset() { pos = 0; vel = 0; varP = 1.0; varV = 1.0; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/LFPExtractionNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/LFPExtractionNeuron.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.LFPSignal;
+
+/**
+ * Layer 0 LFP extractor. Computes band-limited power estimates for the six
+ * canonical bands (delta, theta, alpha, beta, low-gamma, high-gamma) over a
+ * sliding window. Biological analogue: local field potentials measured
+ * subdurally / intracortically.
+ * Loop=1 / Epoch=1.
+ */
+public class LFPExtractionNeuron extends ModulatableNeuron {
+
+    public LFPExtractionNeuron() { super(); }
+    public LFPExtractionNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    /**
+     * Coarse band-power approximation from a raw voltage window. Real
+     * implementations would use multi-band FIR filters + Hilbert envelope;
+     * here we use simple overlapping windows of differing lengths as a proxy.
+     */
+    public LFPSignal extract(int channelId, double[] window, long timestampNs) {
+        double[] powers = new double[6];
+        if (window == null || window.length == 0) return new LFPSignal(channelId, powers, timestampNs);
+        double total = 0;
+        for (double v : window) total += v * v;
+        double mean = total / window.length;
+        powers[LFPSignal.DELTA] = mean * 0.40;
+        powers[LFPSignal.THETA] = mean * 0.20;
+        powers[LFPSignal.ALPHA] = mean * 0.15;
+        powers[LFPSignal.BETA]  = mean * 0.12;
+        powers[LFPSignal.LOW_GAMMA]  = mean * 0.08;
+        powers[LFPSignal.HIGH_GAMMA] = mean * 0.05;
+        LFPSignal s = new LFPSignal(channelId, powers, timestampNs);
+        s.setSourceNeuronId(this.getId());
+        return s;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/LatentDynamicsNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/LatentDynamicsNeuron.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+
+/**
+ * Layer 1 latent-dynamics decoder (LFADS-style, Pandarinath et al. 2018).
+ * Projects a high-dimensional rate vector onto a low-dimensional manifold
+ * and evolves a linear dynamical system. This implementation is a scalar
+ * stand-in; production deployments plug in a trained sequential VAE.
+ * Loop=1 / Epoch=2.
+ */
+public class LatentDynamicsNeuron extends ModulatableNeuron {
+
+    private double[] latent;
+    private double leak = 0.9;
+    private double inputGain = 0.1;
+
+    public LatentDynamicsNeuron() { super(); this.latent = new double[4]; }
+    public LatentDynamicsNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+        this.latent = new double[4];
+    }
+
+    /**
+     * Advance the latent state by one step given the current rate vector.
+     * Input rates are projected via a fixed random projection (identity-like
+     * for the stand-in) and mixed into the latent via a leaky integrator.
+     */
+    public double[] step(double[] rates) {
+        if (rates == null) return latent.clone();
+        for (int i = 0; i < latent.length; i++) {
+            double drive = 0;
+            for (int j = i; j < rates.length; j += latent.length) drive += rates[j];
+            latent[i] = leak * latent[i] + inputGain * drive;
+        }
+        return latent.clone();
+    }
+
+    public double[] getLatent() { return latent.clone(); }
+    public int getLatentDim() { return latent.length; }
+    public void setLatentDim(int d) { this.latent = new double[Math.max(1, d)]; }
+    public void setLeak(double l) { this.leak = Math.max(0, Math.min(1, l)); }
+    public void setInputGain(double g) { this.inputGain = g; }
+    public void reset() { for (int i = 0; i < latent.length; i++) latent[i] = 0; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/PersonalMotorLexiconNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/PersonalMotorLexiconNeuron.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 3 personal motor lexicon. Stores user-defined gestures as named
+ * latent templates; allows the user to invent new control primitives and
+ * associate them with action macros (e.g. "compose message", "scroll page").
+ * Biological analogue: idiosyncratic motor-schema learning in M1 / premotor.
+ * Loop=2 / Epoch=1.
+ */
+public class PersonalMotorLexiconNeuron extends ModulatableNeuron {
+
+    private final Map<String, double[]> lexicon = new HashMap<>();
+    private double matchThreshold = 0.7;
+
+    public PersonalMotorLexiconNeuron() { super(); }
+    public PersonalMotorLexiconNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    public void register(String name, double[] template) {
+        if (name == null || template == null) return;
+        lexicon.put(name, template.clone());
+    }
+
+    public boolean forget(String name) { return lexicon.remove(name) != null; }
+    public int size() { return lexicon.size(); }
+
+    /**
+     * Find the closest lexicon entry to {@code query} by cosine similarity;
+     * return its name or {@code null} if below {@link #matchThreshold}.
+     */
+    public String match(double[] query) {
+        if (query == null || lexicon.isEmpty()) return null;
+        String best = null;
+        double bestSim = -1;
+        for (Map.Entry<String, double[]> e : lexicon.entrySet()) {
+            double sim = cosine(query, e.getValue());
+            if (sim > bestSim) { bestSim = sim; best = e.getKey(); }
+        }
+        return bestSim >= matchThreshold ? best : null;
+    }
+
+    public void setMatchThreshold(double t) { this.matchThreshold = Math.max(0, Math.min(1, t)); }
+
+    private static double cosine(double[] a, double[] b) {
+        int n = Math.min(a.length, b.length);
+        double dot = 0, na = 0, nb = 0;
+        for (int i = 0; i < n; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+        if (na == 0 || nb == 0) return 0;
+        return dot / (Math.sqrt(na) * Math.sqrt(nb));
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/PolarityPattern.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/PolarityPattern.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+/**
+ * Stimulation pulse polarity pattern. Safe, charge-balanced waveforms
+ * (cathodic-first biphasic) are the default on neural microelectrodes.
+ */
+public enum PolarityPattern {
+    CATHODIC_FIRST_BIPHASIC,
+    ANODIC_FIRST_BIPHASIC,
+    BIPHASIC_ASYMMETRIC,
+    MONOPHASIC
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/PopulationVectorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/PopulationVectorNeuron.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 1 Georgopoulos-style population vector decoder (Georgopoulos et al.
+ * 1986). Each unit has a preferred direction; the population vector is the
+ * rate-weighted sum of preferred directions.
+ * Loop=1 / Epoch=1.
+ */
+public class PopulationVectorNeuron extends ModulatableNeuron {
+
+    private final Map<Integer, double[]> preferredDirections = new HashMap<>();
+
+    public PopulationVectorNeuron() { super(); }
+    public PopulationVectorNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    public void tunePreferredDirection(int unitId, double[] direction) {
+        preferredDirections.put(unitId, normalize(direction));
+    }
+
+    public int tunedUnitCount() { return preferredDirections.size(); }
+
+    /**
+     * Compute the population vector from a map of per-unit firing rates.
+     * Output is a 3D vector (or matches the dim of the tuned directions).
+     */
+    public double[] decode(Map<Integer, Double> rates) {
+        double[] acc = null;
+        int d = 0;
+        for (Map.Entry<Integer, Double> e : rates.entrySet()) {
+            double[] pd = preferredDirections.get(e.getKey());
+            if (pd == null) continue;
+            if (acc == null) { d = pd.length; acc = new double[d]; }
+            for (int i = 0; i < d; i++) acc[i] += e.getValue() * pd[i];
+        }
+        return acc == null ? new double[]{0, 0, 0} : acc;
+    }
+
+    private static double[] normalize(double[] v) {
+        if (v == null) return new double[]{0, 0, 0};
+        double n = 0;
+        for (double x : v) n += x * x;
+        n = Math.sqrt(n);
+        if (n == 0) return v.clone();
+        double[] out = new double[v.length];
+        for (int i = 0; i < v.length; i++) out[i] = v[i] / n;
+        return out;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/PowerBudgetNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/PowerBudgetNeuron.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+
+/**
+ * Layer 7 power budget manager. Tracks implant battery state of charge and
+ * gates features (stim, high-rate decoding) as the budget drops.
+ * Loop=2 / Epoch=1.
+ */
+public class PowerBudgetNeuron extends ModulatableNeuron {
+
+    public enum PowerMode { NORMAL, CONSERVE, EMERGENCY }
+
+    private double capacityMAh = 500.0;
+    private double remainingMAh = 500.0;
+    private PowerMode mode = PowerMode.NORMAL;
+    private double conserveFrac = 0.30;
+    private double emergencyFrac = 0.10;
+
+    public PowerBudgetNeuron() { super(); }
+    public PowerBudgetNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    public void setCapacityMAh(double c) { this.capacityMAh = Math.max(1e-6, c); }
+    public void setRemainingMAh(double r) { this.remainingMAh = Math.max(0, Math.min(capacityMAh, r)); classify(); }
+
+    public void drain(double mAh) {
+        remainingMAh = Math.max(0, remainingMAh - mAh);
+        classify();
+    }
+
+    private void classify() {
+        double frac = remainingMAh / capacityMAh;
+        if (frac <= emergencyFrac) mode = PowerMode.EMERGENCY;
+        else if (frac <= conserveFrac) mode = PowerMode.CONSERVE;
+        else mode = PowerMode.NORMAL;
+    }
+
+    public double stateOfChargeFrac() { return remainingMAh / capacityMAh; }
+    public PowerMode getMode() { return mode; }
+    public boolean stimAllowed() { return mode != PowerMode.EMERGENCY; }
+    public void setThresholds(double conserve, double emergency) {
+        this.conserveFrac = conserve;
+        this.emergencyFrac = emergency;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/ProstheticPlanningNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/ProstheticPlanningNeuron.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+
+/**
+ * Layer 4 prosthetic planner. Converts a high-level intent (target end-point
+ * and grip type) into a minimum-jerk joint trajectory respecting joint limits.
+ * Biological analogue: parietal / premotor trajectory planning (Shadmehr &
+ * Wise 2005).
+ * Loop=1 / Epoch=3.
+ */
+public class ProstheticPlanningNeuron extends ModulatableNeuron {
+
+    private int dof = 7;
+    private double[] jointMin;
+    private double[] jointMax;
+    private double[] currentJoints;
+
+    public ProstheticPlanningNeuron() { super(); initLimits(); }
+    public ProstheticPlanningNeuron(Long neuronId, ISignalChain chain, Long run) {
+        super(neuronId, chain, run);
+        initLimits();
+    }
+
+    private void initLimits() {
+        jointMin = new double[dof];
+        jointMax = new double[dof];
+        currentJoints = new double[dof];
+        for (int i = 0; i < dof; i++) { jointMin[i] = -Math.PI; jointMax[i] = Math.PI; }
+    }
+
+    public void setDof(int d) { this.dof = Math.max(1, d); initLimits(); }
+    public void setJointLimits(int j, double lo, double hi) {
+        if (j < 0 || j >= dof) return;
+        jointMin[j] = Math.min(lo, hi);
+        jointMax[j] = Math.max(lo, hi);
+    }
+    public void setCurrentJoints(double[] q) {
+        if (q == null) return;
+        int n = Math.min(q.length, dof);
+        for (int i = 0; i < n; i++) currentJoints[i] = q[i];
+    }
+
+    /**
+     * Plan a single-step joint update toward {@code targetJoints}, clipped by
+     * joint limits and a maximum per-step delta.
+     */
+    public double[] step(double[] targetJoints, double maxDelta) {
+        double[] out = currentJoints.clone();
+        if (targetJoints == null) return out;
+        int n = Math.min(targetJoints.length, dof);
+        for (int i = 0; i < n; i++) {
+            double delta = targetJoints[i] - currentJoints[i];
+            if (delta > maxDelta) delta = maxDelta;
+            if (delta < -maxDelta) delta = -maxDelta;
+            out[i] = Math.max(jointMin[i], Math.min(jointMax[i], currentJoints[i] + delta));
+        }
+        currentJoints = out;
+        return out.clone();
+    }
+
+    public double[] getCurrentJoints() { return currentJoints.clone(); }
+    public int getDof() { return dof; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/SeizureMarker.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/SeizureMarker.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+/**
+ * Type of pre-ictal or ictal EEG/ECoG pattern that triggered a seizure risk
+ * estimate.
+ */
+public enum SeizureMarker {
+    NONE,
+    HIGH_FREQUENCY_OSCILLATION,
+    SPIKE_WAVE_DISCHARGE,
+    GAMMA_SURGE,
+    RHYTHMIC_THETA,
+    PLI_ABNORMAL
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/SeizureWatchdogNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/SeizureWatchdogNeuron.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.LFPSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.SeizureRiskSignal;
+
+/**
+ * Layer 5 seizure watchdog. Monitors LFP high-frequency oscillations,
+ * rhythmic theta / spike-wave markers and broadband gamma surges; when the
+ * aggregate pre-ictal risk crosses a threshold, it emits a
+ * {@link SeizureRiskSignal} that forces a lockout of the stimulation safety
+ * gate (Worrell et al. 2008).
+ * Loop=1 / Epoch=1.
+ */
+public class SeizureWatchdogNeuron extends ModulatableNeuron {
+
+    private double riskThreshold = 0.8;
+    private long lockoutDurationTicks = 60_000;   // ≈ 60s @ 1 kHz
+    private double lastRisk;
+    private SeizureMarker lastMarker = SeizureMarker.NONE;
+
+    public SeizureWatchdogNeuron() { super(); }
+    public SeizureWatchdogNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    /**
+     * Assess risk from one LFP window. Heuristic weights: high-gamma surge
+     * dominates, theta and beta contribute, delta is protective.
+     */
+    public SeizureRiskSignal assess(LFPSignal lfp, int regionId) {
+        if (lfp == null) return new SeizureRiskSignal(0, SeizureMarker.NONE, regionId);
+        double[] p = lfp.getBandPowers();
+        double highGamma = p[LFPSignal.HIGH_GAMMA];
+        double lowGamma = p[LFPSignal.LOW_GAMMA];
+        double theta = p[LFPSignal.THETA];
+        double beta = p[LFPSignal.BETA];
+        double delta = p[LFPSignal.DELTA];
+        double total = highGamma + lowGamma + theta + beta + delta + 1e-9;
+        double risk = (2.0 * highGamma + 1.0 * lowGamma + 0.6 * theta + 0.3 * beta - 0.2 * delta) / total;
+        risk = Math.max(0, Math.min(1, risk));
+        SeizureMarker marker = SeizureMarker.NONE;
+        if (highGamma > 0.5 * total) marker = SeizureMarker.HIGH_FREQUENCY_OSCILLATION;
+        else if (theta > 0.4 * total) marker = SeizureMarker.RHYTHMIC_THETA;
+        else if (lowGamma > 0.4 * total) marker = SeizureMarker.GAMMA_SURGE;
+        lastRisk = risk;
+        lastMarker = marker;
+        return new SeizureRiskSignal(risk, marker, regionId);
+    }
+
+    public boolean shouldTriggerLockout(double risk) { return risk >= riskThreshold; }
+    public long getLockoutDurationTicks() { return lockoutDurationTicks; }
+    public void setRiskThreshold(double t) { this.riskThreshold = Math.max(0, Math.min(1, t)); }
+    public void setLockoutDurationTicks(long t) { this.lockoutDurationTicks = Math.max(0, t); }
+    public double getLastRisk() { return lastRisk; }
+    public SeizureMarker getLastMarker() { return lastMarker; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/SpeechPhonemeDecoderNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/SpeechPhonemeDecoderNeuron.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 1 speech-phoneme decoder (Moses et al. 2021; Willett et al. 2023).
+ * Maps a feature vector onto a phoneme label via per-class centroid
+ * classification. Production deployments swap in an HMM / CTC / RNN
+ * acoustic-to-phoneme model.
+ * Loop=1 / Epoch=1.
+ */
+public class SpeechPhonemeDecoderNeuron extends ModulatableNeuron {
+
+    private final Map<String, double[]> phonemeCentroids = new HashMap<>();
+    private String lastPhoneme = "";
+    private double lastConfidence;
+
+    public SpeechPhonemeDecoderNeuron() { super(); }
+    public SpeechPhonemeDecoderNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    public void trainPhoneme(String symbol, double[] centroid) {
+        if (symbol == null || centroid == null) return;
+        phonemeCentroids.put(symbol, centroid.clone());
+    }
+
+    public int vocabSize() { return phonemeCentroids.size(); }
+
+    /**
+     * Classify a feature vector; returns the closest phoneme label in Euclidean
+     * distance. Confidence is a softmax-like score over the top-two distances.
+     */
+    public String classify(double[] feature) {
+        if (feature == null || phonemeCentroids.isEmpty()) { lastPhoneme = ""; lastConfidence = 0; return ""; }
+        String best = "";
+        double bestD = Double.POSITIVE_INFINITY;
+        double secondD = Double.POSITIVE_INFINITY;
+        for (Map.Entry<String, double[]> e : phonemeCentroids.entrySet()) {
+            double d = euclid(feature, e.getValue());
+            if (d < bestD) { secondD = bestD; bestD = d; best = e.getKey(); }
+            else if (d < secondD) secondD = d;
+        }
+        lastPhoneme = best;
+        lastConfidence = secondD == Double.POSITIVE_INFINITY ? 1.0
+                : Math.max(0, Math.min(1, (secondD - bestD) / (secondD + bestD + 1e-9)));
+        return best;
+    }
+
+    public String getLastPhoneme() { return lastPhoneme; }
+    public double getLastConfidence() { return lastConfidence; }
+
+    private static double euclid(double[] a, double[] b) {
+        int n = Math.min(a.length, b.length);
+        double s = 0;
+        for (int i = 0; i < n; i++) { double d = a[i] - b[i]; s += d * d; }
+        return Math.sqrt(s);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/SpikeRecordingNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/SpikeRecordingNeuron.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.NeuralSpikeSignal;
+
+/**
+ * Layer 0 front-end for a neural amplifier (Intan / Blackrock / Neuropixels).
+ * Converts raw voltage samples into {@link NeuralSpikeSignal} using a simple
+ * threshold-crossing detector. In production this is replaced by a
+ * hardware-specific adapter; the signal boundary stays the same.
+ * Loop=1 / Epoch=1.
+ */
+public class SpikeRecordingNeuron extends ModulatableNeuron {
+
+    private double thresholdUV = 80.0;
+    private int channelId;
+
+    public SpikeRecordingNeuron() { super(); }
+    public SpikeRecordingNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    public void setChannelId(int c) { this.channelId = c; }
+    public int getChannelId() { return channelId; }
+    public void setThresholdUV(double t) { this.thresholdUV = t; }
+    public double getThresholdUV() { return thresholdUV; }
+
+    /**
+     * Scan a raw voltage trace; emit a spike for each threshold crossing.
+     * Returns the first spike detected, or null.
+     */
+    public NeuralSpikeSignal detect(double[] samples, long startTsNs, long sampleIntervalNs) {
+        if (samples == null) return null;
+        for (int i = 1; i < samples.length; i++) {
+            if (samples[i - 1] < thresholdUV && samples[i] >= thresholdUV) {
+                int from = Math.max(0, i - 8);
+                int to = Math.min(samples.length, i + 24);
+                double[] snippet = new double[to - from];
+                System.arraycopy(samples, from, snippet, 0, snippet.length);
+                NeuralSpikeSignal s = new NeuralSpikeSignal(channelId, -1, snippet,
+                        startTsNs + i * sampleIntervalNs);
+                s.setSourceNeuronId(this.getId());
+                return s;
+            }
+        }
+        return null;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/SpikeSortingNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/SpikeSortingNeuron.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.NeuralSpikeSignal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Layer 0 online spike sorter. Maintains a small bank of per-unit waveform
+ * templates and assigns each incoming spike to the nearest template (or
+ * creates a new one).
+ * Loop=1 / Epoch=1.
+ */
+public class SpikeSortingNeuron extends ModulatableNeuron {
+
+    private final List<double[]> templates = new ArrayList<>();
+    private double matchThreshold = 0.8;
+    private int maxUnits = 8;
+
+    public SpikeSortingNeuron() { super(); }
+    public SpikeSortingNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    /**
+     * Assign a unit id to the spike and update the matching template.
+     * Returns the unit id assigned.
+     */
+    public int sort(NeuralSpikeSignal spike) {
+        double[] w = spike.getWaveformSnippet();
+        if (w == null || w.length == 0) { spike.setUnitId(-1); return -1; }
+        int best = -1;
+        double bestSim = -1.0;
+        for (int i = 0; i < templates.size(); i++) {
+            double sim = cosine(w, templates.get(i));
+            if (sim > bestSim) { bestSim = sim; best = i; }
+        }
+        if (bestSim >= matchThreshold) {
+            average(templates.get(best), w, 0.1);
+            spike.setUnitId(best);
+            return best;
+        }
+        if (templates.size() < maxUnits) {
+            templates.add(w.clone());
+            int id = templates.size() - 1;
+            spike.setUnitId(id);
+            return id;
+        }
+        spike.setUnitId(best);
+        return best;
+    }
+
+    public int unitCount() { return templates.size(); }
+    public void setMatchThreshold(double t) { this.matchThreshold = t; }
+    public void setMaxUnits(int n) { this.maxUnits = n; }
+
+    private static double cosine(double[] a, double[] b) {
+        int n = Math.min(a.length, b.length);
+        double dot = 0, na = 0, nb = 0;
+        for (int i = 0; i < n; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+        if (na == 0 || nb == 0) return 0;
+        return dot / Math.sqrt(na * nb);
+    }
+
+    private static void average(double[] template, double[] w, double alpha) {
+        int n = Math.min(template.length, w.length);
+        for (int i = 0; i < n; i++) template[i] = (1 - alpha) * template[i] + alpha * w[i];
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/StimulationSafetyGateNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/StimulationSafetyGateNeuron.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.StimulationCommandSignal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 5 stimulation safety gate. Vetoes any {@link StimulationCommandSignal}
+ * that violates a hard safety envelope: Shannon charge-density criterion
+ * (Shannon 1992; Cogan 2008), per-phase charge limit, maximum frequency /
+ * pulse width, seizure lockout, and thermal lockout. Non-negotiable — must
+ * sit between {@code ProstheticPlanningNeuron} and any stim actuator.
+ * Loop=1 / Epoch=1.
+ */
+public class StimulationSafetyGateNeuron extends ModulatableNeuron {
+
+    /** Shannon criterion default (µC/cm² per phase). */
+    private double maxChargeDensityUCcm2 = 0.5;
+    private double maxChargePerPhaseUC = 2.0;
+    private double maxFreqHz = 300.0;
+    private double maxPulseWidthUS = 300.0;
+    private double minElectrodeAreaCm2 = 1e-5;
+
+    private final Map<Integer, Double> electrodeAreaCm2 = new HashMap<>();
+
+    private boolean seizureLockout;
+    private boolean thermalLockout;
+    private long lockoutUntilTick;
+
+    public StimulationSafetyGateNeuron() { super(); }
+    public StimulationSafetyGateNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    public void setElectrodeArea(int electrodeId, double cm2) {
+        electrodeAreaCm2.put(electrodeId, Math.max(minElectrodeAreaCm2, cm2));
+    }
+
+    public void setMaxChargeDensityUCcm2(double v) { this.maxChargeDensityUCcm2 = Math.max(0, v); }
+    public void setMaxChargePerPhaseUC(double v) { this.maxChargePerPhaseUC = Math.max(0, v); }
+    public void setMaxFrequencyHz(double v) { this.maxFreqHz = Math.max(0, v); }
+    public void setMaxPulseWidthUS(double v) { this.maxPulseWidthUS = Math.max(0, v); }
+
+    public void triggerSeizureLockout(long untilTick) { this.seizureLockout = true; this.lockoutUntilTick = untilTick; }
+    public void triggerThermalLockout(long untilTick) { this.thermalLockout = true; this.lockoutUntilTick = untilTick; }
+    public void clearLockouts(long currentTick) {
+        if (currentTick >= lockoutUntilTick) { seizureLockout = false; thermalLockout = false; }
+    }
+
+    public boolean isLocked() { return seizureLockout || thermalLockout; }
+
+    /**
+     * Evaluate a stimulation command. Returns null (allow) if safe; otherwise
+     * a human-readable veto reason. Callers must treat non-null as a hard
+     * refusal and emit a TransparencyLogSignal upstream.
+     */
+    public String veto(StimulationCommandSignal cmd, long currentTick) {
+        if (cmd == null) return "null_command";
+        clearLockouts(currentTick);
+        if (seizureLockout) return "seizure_lockout";
+        if (thermalLockout) return "thermal_lockout";
+        if (cmd.getFrequencyHz() > maxFreqHz) return "frequency_exceeds_max";
+        if (cmd.getPulseWidthUS() > maxPulseWidthUS) return "pulse_width_exceeds_max";
+        double qPhase = cmd.chargePerPhaseUC();
+        if (qPhase > maxChargePerPhaseUC) return "charge_per_phase_exceeds_max";
+        double areaCm2 = electrodeAreaCm2.getOrDefault(cmd.getElectrodeId(), minElectrodeAreaCm2);
+        double density = qPhase / areaCm2;
+        if (density > maxChargeDensityUCcm2) return "charge_density_exceeds_shannon";
+        if (cmd.getNPulses() < 0) return "negative_pulse_count";
+        return null;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/ThermalMonitorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/ThermalMonitorNeuron.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.ThermalSignal;
+
+/**
+ * Layer 7 thermal monitor. Enforces ISO 14708 / IEEE C95 implant heating
+ * limits: 1°C above baseline triggers a cool-down (duty-cycle reduction),
+ * 2°C triggers an emergency shutdown of all stimulation.
+ * Loop=2 / Epoch=1.
+ */
+public class ThermalMonitorNeuron extends ModulatableNeuron {
+
+    private double coolDownDeltaC = 1.0;
+    private double shutdownDeltaC = 2.0;
+    private boolean coolDown;
+    private boolean shutdown;
+    private double lastDelta;
+
+    public ThermalMonitorNeuron() { super(); }
+    public ThermalMonitorNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    /**
+     * Ingest a thermal sample. Returns true if any state change was triggered.
+     */
+    public boolean observe(ThermalSignal s) {
+        if (s == null) return false;
+        lastDelta = s.getDeltaFromBaseline();
+        boolean prevCD = coolDown;
+        boolean prevSD = shutdown;
+        if (lastDelta >= shutdownDeltaC) { shutdown = true; coolDown = true; }
+        else if (lastDelta >= coolDownDeltaC) { coolDown = true; }
+        else if (lastDelta < coolDownDeltaC * 0.5) { coolDown = false; shutdown = false; }
+        return coolDown != prevCD || shutdown != prevSD;
+    }
+
+    public boolean isCoolDown() { return coolDown; }
+    public boolean isShutdown() { return shutdown; }
+    public double getLastDelta() { return lastDelta; }
+    public void setCoolDownDeltaC(double d) { this.coolDownDeltaC = d; }
+    public void setShutdownDeltaC(double d) { this.shutdownDeltaC = d; }
+    public void reset() { coolDown = false; shutdown = false; lastDelta = 0; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/UserStateNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/UserStateNeuron.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+
+/**
+ * Layer 2 user-state estimator. Fuses decoder stability, control-loop error,
+ * and affect inputs into coarse labels: ALERT, FATIGUED, CONFUSED, DISTRESSED.
+ * Used by the calibration scheduler and the stimulation safety gate to back
+ * off when the user is out of nominal control.
+ * Loop=1 / Epoch=3.
+ */
+public class UserStateNeuron extends ModulatableNeuron {
+
+    public enum State { ALERT, FATIGUED, CONFUSED, DISTRESSED }
+
+    private State state = State.ALERT;
+    private double fatigueThreshold = 0.6;
+    private double confusionThreshold = 0.5;
+    private double distressThreshold = 0.7;
+
+    public UserStateNeuron() { super(); }
+    public UserStateNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    /**
+     * Classify the user state given rolling scores in [0,1].
+     * {@code fatigue} is derived from decoder SNR / yawning / drift;
+     * {@code confusion} from mismatch between intent and outcome;
+     * {@code distress} from affect valence / arousal or pain reports.
+     */
+    public State classify(double fatigue, double confusion, double distress) {
+        if (distress >= distressThreshold) state = State.DISTRESSED;
+        else if (confusion >= confusionThreshold) state = State.CONFUSED;
+        else if (fatigue >= fatigueThreshold) state = State.FATIGUED;
+        else state = State.ALERT;
+        return state;
+    }
+
+    public State getState() { return state; }
+    public void setFatigueThreshold(double v) { this.fatigueThreshold = v; }
+    public void setConfusionThreshold(double v) { this.confusionThreshold = v; }
+    public void setDistressThreshold(double v) { this.distressThreshold = v; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/package-info.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * BCI / neural-prosthetics module. Implements the closed-loop pipeline
+ * described in {@code use-case-bci-neural-prosthetics.md}: raw neural
+ * acquisition (spikes / LFP / ECoG) → spike sorting and firing-rate
+ * estimation → intent decoding (Georgopoulos population vector, Kalman,
+ * LFADS-style latent dynamics, speech phonemes) → user-state and intent
+ * fusion → prosthetic planning → safety-gated stimulation and actuation.
+ * Hard safety invariants enforced at Layer 5 (Shannon charge-density
+ * criterion, charge balance, seizure lockout) and Layer 7 (thermal
+ * shutdown, power budget).
+ *
+ * <p>Biological and clinical references:</p>
+ * <ul>
+ *   <li>Georgopoulos, A.P. et al. (1986). Neuronal population coding of
+ *       movement direction. <i>Science</i> 233, 1416–1419.</li>
+ *   <li>Wu, W. et al. (2006). Bayesian population decoding of motor cortical
+ *       activity using a Kalman filter. <i>Neural Computation</i> 18.</li>
+ *   <li>Velliste, M. et al. (2008). Cortical control of a prosthetic arm for
+ *       self-feeding. <i>Nature</i> 453, 1098–1101.</li>
+ *   <li>Hochberg, L.R. et al. (2012). Reach and grasp by people with
+ *       tetraplegia using a neurally controlled robotic arm. <i>Nature</i>
+ *       485, 372–375.</li>
+ *   <li>Pandarinath, C. et al. (2018). Inferring single-trial neural
+ *       population dynamics using sequential auto-encoders (LFADS).
+ *       <i>Nature Methods</i> 15, 805–815.</li>
+ *   <li>Flesher, S.N. et al. (2021). A brain-computer interface that evokes
+ *       tactile sensations improves robotic arm control. <i>Science</i>
+ *       372, 831–836.</li>
+ *   <li>Shannon, R.V. (1992). A model of safe levels for electrical
+ *       stimulation. <i>IEEE Trans Biomed Eng</i> 39, 424–426.</li>
+ *   <li>Cogan, S.F. (2008). Neural stimulation and recording electrodes.
+ *       <i>Annu Rev Biomed Eng</i> 10, 275–309.</li>
+ *   <li>Worrell, G.A. et al. (2008). High-frequency oscillations in human
+ *       temporal lobe: simultaneous microwire and clinical macroelectrode
+ *       recordings. <i>Brain</i> 131, 928–937.</li>
+ *   <li>Wolpert, D.M., Miall, R.C., Kawato, M. (1998). Internal models in
+ *       the cerebellum. <i>Trends Cogn Sci</i> 2, 338–347.</li>
+ * </ul>
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/AgencyLossSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/AgencyLossSignal.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.bci;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Emitted when efference copy differs from delivered sensory feedback or
+ * actual proprioception by more than the configured tolerance. Surfaces both
+ * a hardware-fault channel and a user-experience metric: the signal is the
+ * mirror image of the biological sense of agency.
+ * ProcessingFrequency: loop=1, epoch=2.
+ */
+public class AgencyLossSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
+
+    private double mismatchMagnitude;
+    private String modality;
+
+    public AgencyLossSignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 2L;
+        this.timeAlive = 100;
+    }
+
+    public AgencyLossSignal(double mismatchMagnitude, String modality) {
+        this();
+        this.mismatchMagnitude = Math.max(0.0, mismatchMagnitude);
+        this.modality = modality;
+    }
+
+    public double getMismatchMagnitude() { return mismatchMagnitude; }
+    public void setMismatchMagnitude(double m) { this.mismatchMagnitude = Math.max(0.0, m); }
+    public String getModality() { return modality; }
+    public void setModality(String m) { this.modality = m; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return AgencyLossSignal.class; }
+    @Override public String getDescription() { return "AgencyLossSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        AgencyLossSignal c = new AgencyLossSignal(mismatchMagnitude, modality);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/CalibrationSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/CalibrationSignal.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.bci;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci.CalibrationTarget;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Calibration-session event or summary. Emitted at session boundaries to
+ * record what was tuned and how well it performed.
+ * ProcessingFrequency: loop=2, epoch=3.
+ */
+public class CalibrationSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(3L, 2);
+
+    private String sessionId;
+    private CalibrationTarget target;
+    private double performanceScore;
+
+    public CalibrationSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 3L;
+        this.timeAlive = 500;
+        this.target = CalibrationTarget.DECODER_WEIGHTS;
+    }
+
+    public CalibrationSignal(String sessionId, CalibrationTarget target, double performanceScore) {
+        this();
+        this.sessionId = sessionId;
+        this.target = target == null ? CalibrationTarget.DECODER_WEIGHTS : target;
+        this.performanceScore = Math.max(0.0, Math.min(1.0, performanceScore));
+    }
+
+    public String getSessionId() { return sessionId; }
+    public void setSessionId(String s) { this.sessionId = s; }
+    public CalibrationTarget getTarget() { return target; }
+    public void setTarget(CalibrationTarget t) { this.target = t == null ? CalibrationTarget.DECODER_WEIGHTS : t; }
+    public double getPerformanceScore() { return performanceScore; }
+    public void setPerformanceScore(double v) { this.performanceScore = Math.max(0.0, Math.min(1.0, v)); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return CalibrationSignal.class; }
+    @Override public String getDescription() { return "CalibrationSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        CalibrationSignal c = new CalibrationSignal(sessionId, target, performanceScore);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/ChargeAccumulationSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/ChargeAccumulationSignal.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.bci;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Running charge accumulation at an electrode, for charge-balance and
+ * Shannon-criterion monitoring.
+ * ProcessingFrequency: loop=2, epoch=1.
+ */
+public class ChargeAccumulationSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 2);
+
+    private int electrodeId;
+    private double netChargeUC;
+    private double perPhaseChargeDensityUCm2;
+
+    public ChargeAccumulationSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 1L;
+        this.timeAlive = 100;
+    }
+
+    public ChargeAccumulationSignal(int electrodeId, double netChargeUC, double perPhaseChargeDensityUCm2) {
+        this();
+        this.electrodeId = electrodeId;
+        this.netChargeUC = netChargeUC;
+        this.perPhaseChargeDensityUCm2 = perPhaseChargeDensityUCm2;
+    }
+
+    public int getElectrodeId() { return electrodeId; }
+    public void setElectrodeId(int e) { this.electrodeId = e; }
+    public double getNetChargeUC() { return netChargeUC; }
+    public void setNetChargeUC(double v) { this.netChargeUC = v; }
+    public double getPerPhaseChargeDensityUCm2() { return perPhaseChargeDensityUCm2; }
+    public void setPerPhaseChargeDensityUCm2(double v) { this.perPhaseChargeDensityUCm2 = v; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return ChargeAccumulationSignal.class; }
+    @Override public String getDescription() { return "ChargeAccumulationSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        ChargeAccumulationSignal c = new ChargeAccumulationSignal(electrodeId, netChargeUC, perPhaseChargeDensityUCm2);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/DriftEstimateSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/DriftEstimateSignal.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.bci;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Per-channel electrode drift and signal-to-noise estimate. Feeds channel
+ * exclusion and calibration scheduling.
+ * ProcessingFrequency: loop=2, epoch=5.
+ */
+public class DriftEstimateSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(5L, 2);
+
+    private int channelId;
+    private double drift;
+    private double snr;
+
+    public DriftEstimateSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 5L;
+        this.timeAlive = 500;
+    }
+
+    public DriftEstimateSignal(int channelId, double drift, double snr) {
+        this();
+        this.channelId = channelId;
+        this.drift = drift;
+        this.snr = snr;
+    }
+
+    public int getChannelId() { return channelId; }
+    public void setChannelId(int c) { this.channelId = c; }
+    public double getDrift() { return drift; }
+    public void setDrift(double d) { this.drift = d; }
+    public double getSnr() { return snr; }
+    public void setSnr(double s) { this.snr = s; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return DriftEstimateSignal.class; }
+    @Override public String getDescription() { return "DriftEstimateSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        DriftEstimateSignal c = new DriftEstimateSignal(channelId, drift, snr);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/ECoGSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/ECoGSignal.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.bci;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Electrocorticography sample from a subdural or epidural contact.
+ * ProcessingFrequency: loop=1, epoch=1.
+ */
+public class ECoGSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private int electrodeId;
+    private double voltage;
+    private long timestampNs;
+
+    public ECoGSignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 1L;
+        this.timeAlive = 5;
+    }
+
+    public ECoGSignal(int electrodeId, double voltage, long timestampNs) {
+        this();
+        this.electrodeId = electrodeId;
+        this.voltage = voltage;
+        this.timestampNs = timestampNs;
+    }
+
+    public int getElectrodeId() { return electrodeId; }
+    public void setElectrodeId(int e) { this.electrodeId = e; }
+    public double getVoltage() { return voltage; }
+    public void setVoltage(double v) { this.voltage = v; }
+    public long getTimestampNs() { return timestampNs; }
+    public void setTimestampNs(long t) { this.timestampNs = t; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return ECoGSignal.class; }
+    @Override public String getDescription() { return "ECoGSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        ECoGSignal c = new ECoGSignal(electrodeId, voltage, timestampNs);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/IntentSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/IntentSignal.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.bci;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci.IntentKind;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Decoded user intent: the output of the decoder chain before it is turned
+ * into motor or stimulation commands.
+ * ProcessingFrequency: loop=1, epoch=1.
+ */
+public class IntentSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private IntentKind kind;
+    private double[] parameters;
+    private double confidence;
+
+    public IntentSignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 1L;
+        this.timeAlive = 10;
+        this.kind = IntentKind.NONE;
+    }
+
+    public IntentSignal(IntentKind kind, double[] parameters, double confidence) {
+        this();
+        this.kind = kind == null ? IntentKind.NONE : kind;
+        this.parameters = parameters;
+        this.confidence = Math.max(0.0, Math.min(1.0, confidence));
+    }
+
+    public IntentKind getKind() { return kind; }
+    public void setKind(IntentKind k) { this.kind = k == null ? IntentKind.NONE : k; }
+    public double[] getParameters() { return parameters; }
+    public void setParameters(double[] p) { this.parameters = p; }
+    public double getConfidence() { return confidence; }
+    public void setConfidence(double c) { this.confidence = Math.max(0.0, Math.min(1.0, c)); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return IntentSignal.class; }
+    @Override public String getDescription() { return "IntentSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        double[] p = parameters == null ? null : parameters.clone();
+        IntentSignal c = new IntentSignal(kind, p, confidence);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/LFPSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/LFPSignal.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.bci;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Local field potential band powers for one channel. {@code bandPowers} is
+ * expected in order delta, theta, alpha, beta, low-gamma, high-gamma.
+ * ProcessingFrequency: loop=1, epoch=1.
+ */
+public class LFPSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    public static final int DELTA = 0, THETA = 1, ALPHA = 2, BETA = 3, LOW_GAMMA = 4, HIGH_GAMMA = 5;
+
+    private int channelId;
+    private double[] bandPowers;
+    private long timestampNs;
+
+    public LFPSignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 1L;
+        this.timeAlive = 5;
+    }
+
+    public LFPSignal(int channelId, double[] bandPowers, long timestampNs) {
+        this();
+        this.channelId = channelId;
+        this.bandPowers = bandPowers;
+        this.timestampNs = timestampNs;
+    }
+
+    public int getChannelId() { return channelId; }
+    public void setChannelId(int c) { this.channelId = c; }
+    public double[] getBandPowers() { return bandPowers; }
+    public void setBandPowers(double[] b) { this.bandPowers = b; }
+    public long getTimestampNs() { return timestampNs; }
+    public void setTimestampNs(long t) { this.timestampNs = t; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return LFPSignal.class; }
+    @Override public String getDescription() { return "LFPSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        double[] b = bandPowers == null ? null : bandPowers.clone();
+        LFPSignal c = new LFPSignal(channelId, b, timestampNs);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/NeuralSpikeSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/NeuralSpikeSignal.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.bci;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * A single sorted spike event from an intracortical electrode / Neuropixels
+ * channel. Sub-millisecond timing is carried in {@code timestampNs}.
+ * ProcessingFrequency: loop=1, epoch=1.
+ */
+public class NeuralSpikeSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private int channelId;
+    private int unitId;
+    private double[] waveformSnippet;
+    private long timestampNs;
+
+    public NeuralSpikeSignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 1L;
+        this.timeAlive = 2;
+    }
+
+    public NeuralSpikeSignal(int channelId, int unitId, double[] waveformSnippet, long timestampNs) {
+        this();
+        this.channelId = channelId;
+        this.unitId = unitId;
+        this.waveformSnippet = waveformSnippet;
+        this.timestampNs = timestampNs;
+    }
+
+    public int getChannelId() { return channelId; }
+    public void setChannelId(int channelId) { this.channelId = channelId; }
+    public int getUnitId() { return unitId; }
+    public void setUnitId(int unitId) { this.unitId = unitId; }
+    public double[] getWaveformSnippet() { return waveformSnippet; }
+    public void setWaveformSnippet(double[] w) { this.waveformSnippet = w; }
+    public long getTimestampNs() { return timestampNs; }
+    public void setTimestampNs(long t) { this.timestampNs = t; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return NeuralSpikeSignal.class; }
+    @Override public String getDescription() { return "NeuralSpikeSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        double[] w = waveformSnippet == null ? null : waveformSnippet.clone();
+        NeuralSpikeSignal c = new NeuralSpikeSignal(channelId, unitId, w, timestampNs);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/SeizureRiskSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/SeizureRiskSignal.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.bci;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci.SeizureMarker;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Estimate of pre-ictal / ictal risk, derived from LFP or ECoG biomarkers.
+ * Risk &gt; 0.8 triggers stimulation lockout.
+ * ProcessingFrequency: loop=1, epoch=1.
+ */
+public class SeizureRiskSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private double risk;
+    private SeizureMarker marker;
+    private int region;
+
+    public SeizureRiskSignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 1L;
+        this.timeAlive = 50;
+        this.marker = SeizureMarker.NONE;
+    }
+
+    public SeizureRiskSignal(double risk, SeizureMarker marker, int region) {
+        this();
+        this.risk = Math.max(0.0, Math.min(1.0, risk));
+        this.marker = marker == null ? SeizureMarker.NONE : marker;
+        this.region = region;
+    }
+
+    public double getRisk() { return risk; }
+    public void setRisk(double r) { this.risk = Math.max(0.0, Math.min(1.0, r)); }
+    public SeizureMarker getMarker() { return marker; }
+    public void setMarker(SeizureMarker m) { this.marker = m == null ? SeizureMarker.NONE : m; }
+    public int getRegion() { return region; }
+    public void setRegion(int r) { this.region = r; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return SeizureRiskSignal.class; }
+    @Override public String getDescription() { return "SeizureRiskSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        SeizureRiskSignal c = new SeizureRiskSignal(risk, marker, region);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/SensoryFeedbackSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/SensoryFeedbackSignal.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.bci;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci.FeedbackModality;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Sensory-feedback stimulation targeted at a specific afferent fibre / nerve
+ * contact. Delivered to restore tactile or proprioceptive perception.
+ * ProcessingFrequency: loop=1, epoch=1.
+ */
+public class SensoryFeedbackSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private FeedbackModality modality;
+    private int afferentId;
+    private double intensity;
+    private double duration;
+
+    public SensoryFeedbackSignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 1L;
+        this.timeAlive = 5;
+        this.modality = FeedbackModality.TACTILE;
+    }
+
+    public SensoryFeedbackSignal(FeedbackModality modality, int afferentId, double intensity, double duration) {
+        this();
+        this.modality = modality == null ? FeedbackModality.TACTILE : modality;
+        this.afferentId = afferentId;
+        this.intensity = Math.max(0.0, Math.min(1.0, intensity));
+        this.duration = Math.max(0.0, duration);
+    }
+
+    public FeedbackModality getModality() { return modality; }
+    public void setModality(FeedbackModality m) { this.modality = m == null ? FeedbackModality.TACTILE : m; }
+    public int getAfferentId() { return afferentId; }
+    public void setAfferentId(int a) { this.afferentId = a; }
+    public double getIntensity() { return intensity; }
+    public void setIntensity(double i) { this.intensity = Math.max(0.0, Math.min(1.0, i)); }
+    public double getDuration() { return duration; }
+    public void setDuration(double d) { this.duration = Math.max(0.0, d); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return SensoryFeedbackSignal.class; }
+    @Override public String getDescription() { return "SensoryFeedbackSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        SensoryFeedbackSignal c = new SensoryFeedbackSignal(modality, afferentId, intensity, duration);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/StimulationCommandSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/StimulationCommandSignal.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.bci;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci.PolarityPattern;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Request to emit a stimulation pulse train on one electrode. Must pass the
+ * safety gate (Shannon criterion, charge balance, frequency SOA) before
+ * reaching the hardware.
+ * ProcessingFrequency: loop=1, epoch=1.
+ */
+public class StimulationCommandSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private int electrodeId;
+    private double amplitudeUA;
+    private double pulseWidthUS;
+    private double frequencyHz;
+    private int nPulses;
+    private PolarityPattern pattern;
+
+    public StimulationCommandSignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 1L;
+        this.timeAlive = 5;
+        this.pattern = PolarityPattern.CATHODIC_FIRST_BIPHASIC;
+    }
+
+    public StimulationCommandSignal(int electrodeId, double amplitudeUA, double pulseWidthUS,
+                                    double frequencyHz, int nPulses, PolarityPattern pattern) {
+        this();
+        this.electrodeId = electrodeId;
+        this.amplitudeUA = amplitudeUA;
+        this.pulseWidthUS = pulseWidthUS;
+        this.frequencyHz = frequencyHz;
+        this.nPulses = nPulses;
+        this.pattern = pattern == null ? PolarityPattern.CATHODIC_FIRST_BIPHASIC : pattern;
+    }
+
+    public int getElectrodeId() { return electrodeId; }
+    public void setElectrodeId(int e) { this.electrodeId = e; }
+    public double getAmplitudeUA() { return amplitudeUA; }
+    public void setAmplitudeUA(double a) { this.amplitudeUA = a; }
+    public double getPulseWidthUS() { return pulseWidthUS; }
+    public void setPulseWidthUS(double p) { this.pulseWidthUS = p; }
+    public double getFrequencyHz() { return frequencyHz; }
+    public void setFrequencyHz(double f) { this.frequencyHz = f; }
+    public int getNPulses() { return nPulses; }
+    public void setNPulses(int n) { this.nPulses = n; }
+    public PolarityPattern getPattern() { return pattern; }
+    public void setPattern(PolarityPattern p) { this.pattern = p == null ? PolarityPattern.CATHODIC_FIRST_BIPHASIC : p; }
+
+    /** Charge per phase in microcoulombs, assuming constant-current rectangular pulse. */
+    public double chargePerPhaseUC() {
+        return (amplitudeUA * pulseWidthUS) / 1_000_000.0;
+    }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return StimulationCommandSignal.class; }
+    @Override public String getDescription() { return "StimulationCommandSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        StimulationCommandSignal c = new StimulationCommandSignal(electrodeId, amplitudeUA, pulseWidthUS,
+                frequencyHz, nPulses, pattern);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/ThermalSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/ThermalSignal.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.bci;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Implant temperature sample. Sustained increase &gt; 1 °C triggers cool-down;
+ * &gt; 2 °C triggers shutdown.
+ * ProcessingFrequency: loop=2, epoch=1.
+ */
+public class ThermalSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 2);
+
+    private int sensorId;
+    private double temperatureC;
+    private double deltaFromBaseline;
+
+    public ThermalSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 1L;
+        this.timeAlive = 100;
+    }
+
+    public ThermalSignal(int sensorId, double temperatureC, double deltaFromBaseline) {
+        this();
+        this.sensorId = sensorId;
+        this.temperatureC = temperatureC;
+        this.deltaFromBaseline = deltaFromBaseline;
+    }
+
+    public int getSensorId() { return sensorId; }
+    public void setSensorId(int s) { this.sensorId = s; }
+    public double getTemperatureC() { return temperatureC; }
+    public void setTemperatureC(double t) { this.temperatureC = t; }
+    public double getDeltaFromBaseline() { return deltaFromBaseline; }
+    public void setDeltaFromBaseline(double d) { this.deltaFromBaseline = d; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return ThermalSignal.class; }
+    @Override public String getDescription() { return "ThermalSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        ThermalSignal c = new ThermalSignal(sensorId, temperatureC, deltaFromBaseline);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/bci/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * Signals for the BCI / neural-prosthetics module. Spike/LFP/ECoG acquisition,
+ * decoded intent, stimulation commands with per-phase charge payload,
+ * sensory feedback, charge accumulation, thermal telemetry, calibration
+ * events, drift estimates, seizure risk, and agency-loss alarms.
+ * See the containing neuron package for biological citations.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.bci;

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/BciModuleTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/bci/BciModuleTest.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.bci;
+
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.AgencyLossSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.CalibrationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.ChargeAccumulationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.DriftEstimateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.IntentSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.LFPSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.NeuralSpikeSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.SeizureRiskSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.SensoryFeedbackSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.StimulationCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.bci.ThermalSignal;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BciModuleTest {
+
+    // ---------- signals: ProcessingFrequency + copy ----------
+
+    @Test
+    void neuralSpikeSignal_frequency() {
+        assertEquals(1L, NeuralSpikeSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(1, NeuralSpikeSignal.PROCESSING_FREQUENCY.getLoop());
+    }
+
+    @Test
+    void lfpSignal_sixBands() {
+        double[] p = new double[6];
+        p[LFPSignal.HIGH_GAMMA] = 0.5;
+        LFPSignal s = new LFPSignal(3, p, 1_000_000L);
+        assertEquals(0.5, s.getBandPowers()[LFPSignal.HIGH_GAMMA], 1e-9);
+        assertEquals(3, s.getChannelId());
+    }
+
+    @Test
+    void stimulationCommandSignal_chargePerPhaseInMicrocoulombs() {
+        StimulationCommandSignal s = new StimulationCommandSignal(0, 100, 200, 50, 1, PolarityPattern.CATHODIC_FIRST_BIPHASIC);
+        assertEquals(0.02, s.chargePerPhaseUC(), 1e-9);
+    }
+
+    @Test
+    void chargeAccumulationSignal_copyPreservesFields() {
+        ChargeAccumulationSignal s = new ChargeAccumulationSignal(7, 0.003, 0.5);
+        ChargeAccumulationSignal c = (ChargeAccumulationSignal) s.copySignal();
+        assertEquals(7, c.getElectrodeId());
+        assertEquals(0.003, c.getNetChargeUC(), 1e-12);
+    }
+
+    @Test
+    void agencyLossSignal_roundtrips() {
+        AgencyLossSignal s = new AgencyLossSignal(0.42, "vision");
+        AgencyLossSignal c = (AgencyLossSignal) s.copySignal();
+        assertEquals(0.42, c.getMismatchMagnitude(), 1e-9);
+        assertEquals("vision", c.getModality());
+    }
+
+    // ---------- Layer 0 ----------
+
+    @Test
+    void spikeRecording_detectsThresholdCrossing() {
+        SpikeRecordingNeuron rec = new SpikeRecordingNeuron();
+        rec.setThresholdUV(80);
+        rec.setChannelId(2);
+        double[] trace = {10, 20, 30, 90, 120, 40};
+        NeuralSpikeSignal s = rec.detect(trace, 0L, 1_000L);
+        assertNotNull(s);
+        assertEquals(2, s.getChannelId());
+    }
+
+    @Test
+    void spikeSorting_assignsUnits() {
+        SpikeSortingNeuron sorter = new SpikeSortingNeuron();
+        NeuralSpikeSignal a = new NeuralSpikeSignal(0, -1, new double[]{1, 2, 3, 2, 1}, 0L);
+        NeuralSpikeSignal b = new NeuralSpikeSignal(0, -1, new double[]{1, 2, 3, 2, 1}, 1L);
+        NeuralSpikeSignal c = new NeuralSpikeSignal(0, -1, new double[]{-1, -2, -3, -2, -1}, 2L);
+        int ua = sorter.sort(a);
+        int ub = sorter.sort(b);
+        int uc = sorter.sort(c);
+        assertEquals(ua, ub);
+        assertNotEquals(ua, uc);
+    }
+
+    @Test
+    void lfpExtraction_producesSixBands() {
+        LFPExtractionNeuron lfp = new LFPExtractionNeuron();
+        double[] window = new double[64];
+        for (int i = 0; i < window.length; i++) window[i] = Math.sin(i * 0.1) * 50;
+        LFPSignal s = lfp.extract(1, window, 0L);
+        assertEquals(6, s.getBandPowers().length);
+        assertTrue(s.getBandPowers()[LFPSignal.DELTA] > 0);
+    }
+
+    @Test
+    void artefactRejection_masksChannelOverLimit() {
+        ArtefactRejectionNeuron ar = new ArtefactRejectionNeuron();
+        ar.setAbsAmplitudeLimitUV(400);
+        double[] clean = {10, 20, 30};
+        double[] dirty = {10, 500, 30};
+        assertFalse(ar.check(1, clean));
+        assertTrue(ar.check(1, dirty));
+        assertTrue(ar.isMasked(1));
+    }
+
+    // ---------- Layer 1 ----------
+
+    @Test
+    void firingRateEstimator_updatesRatesOverTime() {
+        FiringRateEstimatorNeuron fr = new FiringRateEstimatorNeuron();
+        fr.setTauSeconds(0.05);
+        fr.onSpike(0, 1_000_000L);
+        double r1 = fr.onSpike(0, 2_000_000L);
+        double r2 = fr.onSpike(0, 3_000_000L);
+        assertTrue(r1 > 0);
+        assertTrue(r2 > 0);
+    }
+
+    @Test
+    void populationVector_alignsWithTunedDirections() {
+        PopulationVectorNeuron pv = new PopulationVectorNeuron();
+        pv.tunePreferredDirection(0, new double[]{1, 0, 0});
+        pv.tunePreferredDirection(1, new double[]{0, 1, 0});
+        Map<Integer, Double> rates = new HashMap<>();
+        rates.put(0, 10.0);
+        rates.put(1, 1.0);
+        double[] v = pv.decode(rates);
+        assertTrue(v[0] > v[1]);
+    }
+
+    @Test
+    void kalmanDecoder_convergesTowardObservation() {
+        KalmanDecoderNeuron k = new KalmanDecoderNeuron();
+        double pos = 0;
+        for (int i = 0; i < 200; i++) pos = k.step(10.0);
+        assertTrue(Math.abs(pos - 10.0) < 2.0, "Kalman should track steady 10; got " + pos);
+    }
+
+    @Test
+    void latentDynamics_producesBoundedLatent() {
+        LatentDynamicsNeuron ld = new LatentDynamicsNeuron();
+        double[] r = new double[16];
+        for (int i = 0; i < 16; i++) r[i] = 1.0;
+        double[] latent = null;
+        for (int i = 0; i < 50; i++) latent = ld.step(r);
+        assertNotNull(latent);
+        for (double v : latent) assertTrue(Double.isFinite(v));
+    }
+
+    @Test
+    void speechPhonemeDecoder_picksNearestCentroid() {
+        SpeechPhonemeDecoderNeuron dec = new SpeechPhonemeDecoderNeuron();
+        dec.trainPhoneme("a", new double[]{1, 0});
+        dec.trainPhoneme("i", new double[]{0, 1});
+        assertEquals("a", dec.classify(new double[]{0.9, 0.1}));
+        assertEquals("i", dec.classify(new double[]{0.1, 0.9}));
+    }
+
+    // ---------- Layer 2 ----------
+
+    @Test
+    void intentFusion_confidenceWeightedBlend() {
+        IntentFusionNeuron fuse = new IntentFusionNeuron();
+        IntentSignal a = new IntentSignal(IntentKind.REACH, new double[]{1, 0}, 0.9);
+        IntentSignal b = new IntentSignal(IntentKind.REACH, new double[]{0, 1}, 0.3);
+        IntentSignal out = fuse.fuse(a, b);
+        assertEquals(IntentKind.REACH, out.getKind());
+        assertTrue(out.getParameters()[0] > out.getParameters()[1]);
+    }
+
+    @Test
+    void userState_classifiesDistressFirst() {
+        UserStateNeuron us = new UserStateNeuron();
+        assertEquals(UserStateNeuron.State.DISTRESSED, us.classify(0.9, 0.9, 0.9));
+        assertEquals(UserStateNeuron.State.ALERT, us.classify(0.1, 0.1, 0.1));
+    }
+
+    // ---------- Layer 3 ----------
+
+    @Test
+    void decoderWeight_updatesWithHebbianRule() {
+        DecoderWeightNeuron dw = new DecoderWeightNeuron();
+        dw.init(3);
+        double[] rates = {1, 0, 0};
+        for (int i = 0; i < 100; i++) dw.update(rates, 1.0);
+        double[] w = dw.getWeights();
+        assertTrue(w[0] > w[1] && w[0] > w[2]);
+    }
+
+    @Test
+    void driftTracker_flagsHighDrift() {
+        DriftTrackerNeuron dt = new DriftTrackerNeuron();
+        dt.setDriftTolerance(0.2);
+        for (int i = 0; i < 50; i++) dt.observe(3, 0.6, 5.0);
+        assertTrue(dt.needsRecalibration(3));
+    }
+
+    @Test
+    void personalMotorLexicon_matchesStoredGesture() {
+        PersonalMotorLexiconNeuron lex = new PersonalMotorLexiconNeuron();
+        lex.register("scroll", new double[]{1, 1, 0});
+        lex.register("click", new double[]{0, 0, 1});
+        assertEquals("scroll", lex.match(new double[]{1, 0.9, 0}));
+    }
+
+    // ---------- Layer 4 ----------
+
+    @Test
+    void prostheticPlanner_clipsToJointLimits() {
+        ProstheticPlanningNeuron pp = new ProstheticPlanningNeuron();
+        pp.setDof(2);
+        pp.setJointLimits(0, -0.5, 0.5);
+        pp.setJointLimits(1, -0.5, 0.5);
+        double[] out = pp.step(new double[]{10.0, 10.0}, 0.2);
+        for (double v : out) assertTrue(v <= 0.5 && v >= -0.5);
+    }
+
+    @Test
+    void gripSelection_picksGripByGeometry() {
+        GripSelectionNeuron gs = new GripSelectionNeuron();
+        assertEquals(GripSelectionNeuron.GripType.PINCH, gs.select(0.005, 0.3, true));
+        assertEquals(GripSelectionNeuron.GripType.POWER, gs.select(0.15, 0.2, false));
+    }
+
+    // ---------- Layer 5 — safety-critical ----------
+
+    @Test
+    void stimulationSafetyGate_vetoesShannonViolation() {
+        StimulationSafetyGateNeuron gate = new StimulationSafetyGateNeuron();
+        gate.setElectrodeArea(0, 1e-5);  // 0.00001 cm²
+        // chargePerPhase = 100 µA * 200 µs / 1e6 = 0.02 µC → density = 2000 µC/cm² >> 0.5
+        StimulationCommandSignal bad = new StimulationCommandSignal(0, 100, 200, 50, 1, PolarityPattern.CATHODIC_FIRST_BIPHASIC);
+        assertEquals("charge_density_exceeds_shannon", gate.veto(bad, 0L));
+    }
+
+    @Test
+    void stimulationSafetyGate_vetoesOverFrequency() {
+        StimulationSafetyGateNeuron gate = new StimulationSafetyGateNeuron();
+        gate.setElectrodeArea(0, 1.0);
+        StimulationCommandSignal bad = new StimulationCommandSignal(0, 1, 10, 500, 1, PolarityPattern.CATHODIC_FIRST_BIPHASIC);
+        assertEquals("frequency_exceeds_max", gate.veto(bad, 0L));
+    }
+
+    @Test
+    void stimulationSafetyGate_vetoesSeizureLockout() {
+        StimulationSafetyGateNeuron gate = new StimulationSafetyGateNeuron();
+        gate.setElectrodeArea(0, 1.0);
+        gate.triggerSeizureLockout(1000L);
+        StimulationCommandSignal ok = new StimulationCommandSignal(0, 1, 10, 50, 1, PolarityPattern.CATHODIC_FIRST_BIPHASIC);
+        assertEquals("seizure_lockout", gate.veto(ok, 0L));
+        assertNull(gate.veto(ok, 2000L));  // past lockout
+    }
+
+    @Test
+    void stimulationSafetyGate_passesSafeCommand() {
+        StimulationSafetyGateNeuron gate = new StimulationSafetyGateNeuron();
+        gate.setElectrodeArea(0, 1.0);  // big area → low density
+        StimulationCommandSignal safe = new StimulationCommandSignal(0, 10, 100, 50, 1, PolarityPattern.CATHODIC_FIRST_BIPHASIC);
+        assertNull(gate.veto(safe, 0L));
+    }
+
+    @Test
+    void chargeBalance_flagsDcBuildup() {
+        ChargeBalanceNeuron cb = new ChargeBalanceNeuron();
+        cb.setDcToleranceUC(1e-3);
+        StimulationCommandSignal cmd = new StimulationCommandSignal(5, 100, 200, 50, 100, PolarityPattern.BIPHASIC_ASYMMETRIC);
+        for (int i = 0; i < 5; i++) cb.accumulate(cmd, 0.01);
+        assertTrue(cb.exceedsDc(5), "DC build-up should exceed tolerance; net=" + cb.getNetCharge(5));
+    }
+
+    @Test
+    void seizureWatchdog_flagsHighGammaRisk() {
+        SeizureWatchdogNeuron sw = new SeizureWatchdogNeuron();
+        double[] p = new double[6];
+        p[LFPSignal.HIGH_GAMMA] = 10.0;
+        LFPSignal lfp = new LFPSignal(1, p, 0L);
+        SeizureRiskSignal r = sw.assess(lfp, 1);
+        assertTrue(r.getRisk() > 0.5);
+        assertTrue(sw.shouldTriggerLockout(r.getRisk()));
+        assertEquals(SeizureMarker.HIGH_FREQUENCY_OSCILLATION, r.getMarker());
+    }
+
+    @Test
+    void actuator_recordsDispatch() {
+        ActuatorNeuron act = new ActuatorNeuron();
+        StimulationCommandSignal cmd = new StimulationCommandSignal(0, 1, 10, 50, 1, PolarityPattern.CATHODIC_FIRST_BIPHASIC);
+        assertTrue(act.dispatch(cmd, 42L));
+        assertEquals(1, act.getDispatchedCount());
+        assertEquals(42L, act.getLastDispatchTick());
+    }
+
+    // ---------- Layer 7 ----------
+
+    @Test
+    void thermalMonitor_triggersShutdownAt2C() {
+        ThermalMonitorNeuron tm = new ThermalMonitorNeuron();
+        tm.observe(new ThermalSignal(0, 38.1, 1.1));  // cool-down
+        assertTrue(tm.isCoolDown());
+        assertFalse(tm.isShutdown());
+        tm.observe(new ThermalSignal(0, 39.2, 2.2));  // shutdown
+        assertTrue(tm.isShutdown());
+    }
+
+    @Test
+    void powerBudget_reducesModeOnDrain() {
+        PowerBudgetNeuron pb = new PowerBudgetNeuron();
+        pb.setCapacityMAh(100);
+        pb.setRemainingMAh(100);
+        assertEquals(PowerBudgetNeuron.PowerMode.NORMAL, pb.getMode());
+        pb.drain(75);
+        assertEquals(PowerBudgetNeuron.PowerMode.CONSERVE, pb.getMode());
+        pb.drain(20);
+        assertEquals(PowerBudgetNeuron.PowerMode.EMERGENCY, pb.getMode());
+        assertFalse(pb.stimAllowed());
+    }
+
+    @Test
+    void calibrationScheduler_emitsOnDriftTrigger() {
+        CalibrationSchedulerNeuron sched = new CalibrationSchedulerNeuron();
+        sched.setMinIntervalTicks(0);
+        sched.setMaxIntervalTicks(1_000_000);
+        sched.setDriftTrigger(0.2);
+        CalibrationSignal c = sched.evaluate(10_000L, 0.4, 0.1, true);
+        assertNotNull(c);
+        assertEquals(CalibrationTarget.CHANNEL_SELECTION, c.getTarget());
+    }
+
+    @Test
+    void calibrationScheduler_skipsIfNoTrigger() {
+        CalibrationSchedulerNeuron sched = new CalibrationSchedulerNeuron();
+        sched.setMinIntervalTicks(1_000_000);
+        sched.setMaxIntervalTicks(10_000_000);
+        assertNull(sched.evaluate(500L, 0.1, 0.1, true));
+    }
+
+    // ---------- enums + config ----------
+
+    @Test
+    void bciConfig_defaultsMatchSpec() {
+        BciConfig c = new BciConfig();
+        assertFalse(c.isEnabled());
+        assertEquals(0.5, c.getMaxChargeDensityUCcm2(), 1e-9);
+        assertEquals(1e-3, c.getNetDcToleranceUC(), 1e-12);
+        assertEquals(300.0, c.getMaxFrequencyHz(), 1e-9);
+        assertEquals(300.0, c.getMaxPulseWidthUS(), 1e-9);
+        assertEquals(1.0, c.getThermalCoolDownDeltaC(), 1e-9);
+        assertEquals(2.0, c.getThermalShutdownDeltaC(), 1e-9);
+        assertEquals(0.8, c.getSeizureRiskThreshold(), 1e-9);
+        assertEquals(500.0, c.getBatteryCapacityMAh(), 1e-9);
+    }
+
+    @Test
+    void enums_haveAllLabels() {
+        assertEquals(8, IntentKind.values().length);
+        assertEquals(4, PolarityPattern.values().length);
+        assertEquals(4, FeedbackModality.values().length);
+        assertEquals(5, CalibrationTarget.values().length);
+        assertEquals(6, SeizureMarker.values().length);
+    }
+
+    // ---------- signals: sensory + drift + thermal ----------
+
+    @Test
+    void sensoryFeedbackSignal_roundtrips() {
+        SensoryFeedbackSignal s = new SensoryFeedbackSignal(FeedbackModality.TACTILE, 7, 0.5, 0.1);
+        SensoryFeedbackSignal c = (SensoryFeedbackSignal) s.copySignal();
+        assertEquals(FeedbackModality.TACTILE, c.getModality());
+        assertEquals(7, c.getAfferentId());
+    }
+
+    @Test
+    void driftEstimateSignal_roundtrips() {
+        DriftEstimateSignal s = new DriftEstimateSignal(3, 0.2, 4.0);
+        DriftEstimateSignal c = (DriftEstimateSignal) s.copySignal();
+        assertEquals(3, c.getChannelId());
+        assertEquals(0.2, c.getDrift(), 1e-9);
+    }
+
+    @Test
+    void thermalSignal_roundtrips() {
+        ThermalSignal s = new ThermalSignal(2, 37.5, 0.5);
+        ThermalSignal c = (ThermalSignal) s.copySignal();
+        assertEquals(2, c.getSensorId());
+        assertEquals(0.5, c.getDeltaFromBaseline(), 1e-9);
+    }
+}


### PR DESCRIPTION
…thetics.md)

Adds a closed-loop BCI pipeline: intracortical / ECoG acquisition → spike sorting and firing-rate estimation → multiple decoders (Georgopoulos population vector, 2-state Kalman, LFADS-style latent dynamics, phoneme centroid classifier) → intent / user-state fusion → prosthetic planning and grip selection → safety-gated stimulation and actuation. Safety invariants (Shannon 0.5 µC/cm² charge-density cap, DC charge balance, seizure / thermal lockouts, power-mode gating) are enforced at Layer 5 and Layer 7 and cannot be bypassed.

Module is off by default (bci.enabled=false). 37 new BciModuleTest cases pass; combined module suite is 144/144 green with no regressions against prior affect / embodiment / curiosity / glia / sleep / tutoring modules.