### PR TITLE
Add stateless processors for clinical signals; processors typed on ne…

### DIFF
--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/ContraindicationProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/ContraindicationProcessor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.IContraindicationNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.ClinicalVetoSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.TreatmentProposalSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: every {@link TreatmentProposalSignal} is run
+ * through the {@link IContraindicationNeuron}. Any non-null
+ * {@link ClinicalVetoSignal} is forwarded immediately so that the
+ * harm-discriminator audit path captures it.
+ */
+public class ContraindicationProcessor implements ISignalProcessor<TreatmentProposalSignal, IContraindicationNeuron> {
+
+    private static final String DESCRIPTION = "Hard contraindication filter for proposed treatments";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(TreatmentProposalSignal input, IContraindicationNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        ClinicalVetoSignal veto = neuron.evaluate(input);
+        if (veto != null) out.add((I) veto);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return ContraindicationProcessor.class; }
+    @Override public Class<IContraindicationNeuron> getNeuronClass() { return IContraindicationNeuron.class; }
+    @Override public Class<TreatmentProposalSignal> getSignalClass() { return TreatmentProposalSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/DemographicContextProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/DemographicContextProcessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.IPatientContextNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.DemographicSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: refreshes the per-patient context snapshot
+ * (allergies, comorbidities, vulnerability factor) on every
+ * {@link DemographicSignal}.
+ */
+public class DemographicContextProcessor implements ISignalProcessor<DemographicSignal, IPatientContextNeuron> {
+
+    private static final String DESCRIPTION = "Patient demographic / context snapshot";
+
+    @Override
+    public <I extends ISignal> List<I> process(DemographicSignal input, IPatientContextNeuron neuron) {
+        if (input != null && neuron != null) neuron.update(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return DemographicContextProcessor.class; }
+    @Override public Class<IPatientContextNeuron> getNeuronClass() { return IPatientContextNeuron.class; }
+    @Override public Class<DemographicSignal> getSignalClass() { return DemographicSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/ImagingEvidenceProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/ImagingEvidenceProcessor.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.FindingCategory;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.IDifferentialDiagnosisNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.ImagingFindingSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: imaging findings update the differential
+ * diagnosis posterior. ABNORMAL/CRITICAL with high confidence yields a
+ * positive likelihood ratio scaled by reported confidence; NORMAL acts
+ * as mildly negative evidence. The ICD-10 hint is encoded in the
+ * region code via the convention {@code "REGION|icd10"}.
+ */
+public class ImagingEvidenceProcessor implements ISignalProcessor<ImagingFindingSignal, IDifferentialDiagnosisNeuron> {
+
+    private static final String DESCRIPTION = "Bayesian update from imaging finding";
+
+    @Override
+    public <I extends ISignal> List<I> process(ImagingFindingSignal input, IDifferentialDiagnosisNeuron neuron) {
+        if (input == null || neuron == null) return new LinkedList<>();
+        String region = input.getRegionCode();
+        if (region == null || !region.contains("|")) return new LinkedList<>();
+        String icd10 = region.substring(region.indexOf('|') + 1);
+        if (icd10.isEmpty()) return new LinkedList<>();
+        double lr;
+        FindingCategory cat = input.getCategory();
+        switch (cat) {
+            case CRITICAL: lr = 1.0 + 4.0 * input.getConfidence(); break;
+            case ABNORMAL: lr = 1.0 + 2.0 * input.getConfidence(); break;
+            case INCIDENTAL: lr = 1.0; break;
+            case NORMAL: lr = 1.0 - 0.5 * input.getConfidence(); break;
+            default: lr = 1.0;
+        }
+        neuron.update(icd10, lr, "img:" + input.getModality() + ":" + region);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return ImagingEvidenceProcessor.class; }
+    @Override public Class<IDifferentialDiagnosisNeuron> getNeuronClass() { return IDifferentialDiagnosisNeuron.class; }
+    @Override public Class<ImagingFindingSignal> getSignalClass() { return ImagingFindingSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/LabEvidenceProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/LabEvidenceProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.IDifferentialDiagnosisNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.LabResultSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: an abnormal {@link LabResultSignal} is treated
+ * as evidence of moderate strength (likelihood ratio 2.0) for any
+ * candidate already seeded in the {@link IDifferentialDiagnosisNeuron}
+ * whose ICD-10 code maps to the analyte. Mapping itself is the
+ * deployment's responsibility — this processor only forwards the LR
+ * for an explicit ICD-10 hint carried in the lab signal's analyte
+ * code via the convention {@code "LOINC:icd10"}; otherwise no update.
+ */
+public class LabEvidenceProcessor implements ISignalProcessor<LabResultSignal, IDifferentialDiagnosisNeuron> {
+
+    private static final String DESCRIPTION = "Bayesian update from abnormal lab result";
+
+    private static final double ABNORMAL_LR = 2.0;
+    private static final double NORMAL_LR = 0.5;
+
+    @Override
+    public <I extends ISignal> List<I> process(LabResultSignal input, IDifferentialDiagnosisNeuron neuron) {
+        if (input == null || neuron == null) return new LinkedList<>();
+        String code = input.getAnalyteCode();
+        if (code == null || !code.contains(":")) return new LinkedList<>();
+        String icd10 = code.substring(code.indexOf(':') + 1);
+        if (icd10.isEmpty()) return new LinkedList<>();
+        double lr = input.isAbnormal() ? ABNORMAL_LR : NORMAL_LR;
+        neuron.update(icd10, lr, "lab:" + input.getAnalyteCode());
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return LabEvidenceProcessor.class; }
+    @Override public Class<IDifferentialDiagnosisNeuron> getNeuronClass() { return IDifferentialDiagnosisNeuron.class; }
+    @Override public Class<LabResultSignal> getSignalClass() { return LabResultSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/MedicationRegimenProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/MedicationRegimenProcessor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.IDrugInteractionMemoryNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.MedicationAdminSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: records every {@link MedicationAdminSignal} in
+ * the active-regimen set held by an {@link IDrugInteractionMemoryNeuron}
+ * so subsequent treatment proposals can be checked for DDI hazards.
+ */
+public class MedicationRegimenProcessor implements ISignalProcessor<MedicationAdminSignal, IDrugInteractionMemoryNeuron> {
+
+    private static final String DESCRIPTION = "Active-medication regimen tracker for DDI lookups";
+
+    @Override
+    public <I extends ISignal> List<I> process(MedicationAdminSignal input, IDrugInteractionMemoryNeuron neuron) {
+        if (input != null && neuron != null && input.getRxNormCode() != null) {
+            neuron.addActive(input.getRxNormCode());
+        }
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return MedicationRegimenProcessor.class; }
+    @Override public Class<IDrugInteractionMemoryNeuron> getNeuronClass() { return IDrugInteractionMemoryNeuron.class; }
+    @Override public Class<MedicationAdminSignal> getSignalClass() { return MedicationAdminSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/VitalAcuityProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/VitalAcuityProcessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.IAcuityNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.VitalSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: ingests {@link VitalSignal} samples into the
+ * NEWS2-style {@link IAcuityNeuron}. The acuity score is read on
+ * demand by downstream attention / harm-threshold modulators.
+ */
+public class VitalAcuityProcessor implements ISignalProcessor<VitalSignal, IAcuityNeuron> {
+
+    private static final String DESCRIPTION = "Per-tick acuity score update";
+
+    @Override
+    public <I extends ISignal> List<I> process(VitalSignal input, IAcuityNeuron neuron) {
+        if (input != null && neuron != null) neuron.ingest(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return VitalAcuityProcessor.class; }
+    @Override public Class<IAcuityNeuron> getNeuronClass() { return IAcuityNeuron.class; }
+    @Override public Class<VitalSignal> getSignalClass() { return VitalSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/VitalMonitorProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/VitalMonitorProcessor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.IVitalMonitorNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.AdverseEventAlertSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.VitalSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: feeds {@link VitalSignal} into an
+ * {@link IVitalMonitorNeuron} and forwards any guardrail-excursion alert.
+ */
+public class VitalMonitorProcessor implements ISignalProcessor<VitalSignal, IVitalMonitorNeuron> {
+
+    private static final String DESCRIPTION = "Vital-sign guardrail monitor";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(VitalSignal input, IVitalMonitorNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        AdverseEventAlertSignal alert = neuron.observe(input);
+        if (alert != null) out.add((I) alert);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return VitalMonitorProcessor.class; }
+    @Override public Class<IVitalMonitorNeuron> getNeuronClass() { return IVitalMonitorNeuron.class; }
+    @Override public Class<VitalSignal> getSignalClass() { return VitalSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/VitalTrendProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/VitalTrendProcessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.ITrendDetectorNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.VitalSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: pushes {@link VitalSignal} samples into an
+ * {@link ITrendDetectorNeuron}'s rolling-window slope estimator.
+ * Emits no follow-up signals — the trend is read on demand.
+ */
+public class VitalTrendProcessor implements ISignalProcessor<VitalSignal, ITrendDetectorNeuron> {
+
+    private static final String DESCRIPTION = "Per-vital trend detector";
+
+    @Override
+    public <I extends ISignal> List<I> process(VitalSignal input, ITrendDetectorNeuron neuron) {
+        if (input != null && neuron != null) neuron.observe(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return VitalTrendProcessor.class; }
+    @Override public Class<ITrendDetectorNeuron> getNeuronClass() { return ITrendDetectorNeuron.class; }
+    @Override public Class<VitalSignal> getSignalClass() { return VitalSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/WaveformAnalysisProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/WaveformAnalysisProcessor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.IWaveformAnalysisNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.AdverseEventAlertSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.WaveformSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: hands a {@link WaveformSignal} buffer to an
+ * {@link IWaveformAnalysisNeuron} for ECG/PPG/EEG feature extraction
+ * and forwards any pathological alert it produces.
+ */
+public class WaveformAnalysisProcessor implements ISignalProcessor<WaveformSignal, IWaveformAnalysisNeuron> {
+
+    private static final String DESCRIPTION = "Real-time waveform classifier";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(WaveformSignal input, IWaveformAnalysisNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        AdverseEventAlertSignal alert = neuron.analyse(input);
+        if (alert != null) out.add((I) alert);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return WaveformAnalysisProcessor.class; }
+    @Override public Class<IWaveformAnalysisNeuron> getNeuronClass() { return IWaveformAnalysisNeuron.class; }
+    @Override public Class<WaveformSignal> getSignalClass() { return WaveformSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/package-info.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * Stateless signal processors for the clinical decision-support module.
+ * Per the framework rule "stateless processors, stateful neurons", each
+ * processor holds no mutable state and is parameterised by an
+ * {@code I<Neuron>} interface — concrete neuron implementations are
+ * dependency-injected at network-construction time so processors remain
+ * decoupled from any particular implementation.
+ *
+ * <ul>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical.VitalMonitorProcessor}
+ *       — guardrail check, may emit {@code AdverseEventAlertSignal}.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical.VitalTrendProcessor}
+ *       — feeds the per-vital trend detector.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical.VitalAcuityProcessor}
+ *       — updates NEWS2-style acuity score.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical.WaveformAnalysisProcessor}
+ *       — ECG/PPG/EEG classification, may emit alerts.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical.DemographicContextProcessor}
+ *       — patient context refresh.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical.MedicationRegimenProcessor}
+ *       — keeps the active-drug list in sync for DDI lookups.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical.LabEvidenceProcessor}
+ *       — Bayesian update from abnormal lab.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical.ImagingEvidenceProcessor}
+ *       — Bayesian update from imaging.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical.ContraindicationProcessor}
+ *       — runs every proposed treatment through the contraindication
+ *         filter and forwards any {@code ClinicalVetoSignal}.</li>
+ * </ul>
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical;

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/ClinicalProcessorsTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/clinical/ClinicalProcessorsTest.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.clinical;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.AcuityNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.AlertSeverity;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.ClinicalConsequenceModelNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.ContraindicationNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.DifferentialDiagnosisNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.DrugInteractionMemoryNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.FindingCategory;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.IAcuityNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.IClinicalConsequenceModelNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.IContraindicationNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.IDifferentialDiagnosisNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.IDrugInteractionMemoryNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.IPatientContextNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.ITrendDetectorNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.IVitalMonitorNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.IWaveformAnalysisNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.PatientContextNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.Sex;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.TrendDetectorNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.VitalMonitorNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.VitalType;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.WaveformAnalysisNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.WaveformType;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.AdverseEventAlertSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.ClinicalVetoSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.DemographicSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.ImagingFindingSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.LabResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.MedicationAdminSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.TreatmentProposalSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.VitalSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.WaveformSignal;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClinicalProcessorsTest {
+
+    // ---------- VitalMonitorProcessor ----------
+
+    @Test
+    void vitalMonitorProcessor_emitsAlertOnExcursion() {
+        VitalMonitorProcessor p = new VitalMonitorProcessor();
+        IVitalMonitorNeuron n = new VitalMonitorNeuron();
+        List<ISignal> out = p.process(new VitalSignal(VitalType.HR, 250, 0L, "p"), n);
+        assertEquals(1, out.size());
+        assertTrue(out.get(0) instanceof AdverseEventAlertSignal);
+        assertEquals(AlertSeverity.CRITICAL, ((AdverseEventAlertSignal) out.get(0)).getSeverity());
+    }
+
+    @Test
+    void vitalMonitorProcessor_silentOnNormal() {
+        VitalMonitorProcessor p = new VitalMonitorProcessor();
+        IVitalMonitorNeuron n = new VitalMonitorNeuron();
+        List<ISignal> out = p.process(new VitalSignal(VitalType.HR, 80, 0L, "p"), n);
+        assertTrue(out.isEmpty());
+    }
+
+    @Test
+    void vitalMonitorProcessor_metadata() {
+        VitalMonitorProcessor p = new VitalMonitorProcessor();
+        assertEquals(IVitalMonitorNeuron.class, p.getNeuronClass());
+        assertEquals(VitalSignal.class, p.getSignalClass());
+        assertFalse(p.hasMerger());
+        assertNotNull(p.getDescription());
+    }
+
+    @Test
+    void vitalMonitorProcessor_nullSafe() {
+        VitalMonitorProcessor p = new VitalMonitorProcessor();
+        assertTrue(p.process(null, new VitalMonitorNeuron()).isEmpty());
+        assertTrue(p.process(new VitalSignal(VitalType.HR, 80, 0L, "p"), null).isEmpty());
+    }
+
+    // ---------- VitalTrendProcessor ----------
+
+    @Test
+    void vitalTrendProcessor_feedsWindow() {
+        VitalTrendProcessor p = new VitalTrendProcessor();
+        ITrendDetectorNeuron n = new TrendDetectorNeuron();
+        for (int i = 0; i < 5; i++) {
+            assertTrue(p.process(new VitalSignal(VitalType.HR, 60 + i, i, "p"), n).isEmpty());
+        }
+        assertEquals(5, n.samplesFor(VitalType.HR));
+    }
+
+    @Test
+    void vitalTrendProcessor_metadata() {
+        VitalTrendProcessor p = new VitalTrendProcessor();
+        assertEquals(ITrendDetectorNeuron.class, p.getNeuronClass());
+        assertEquals(VitalSignal.class, p.getSignalClass());
+    }
+
+    // ---------- VitalAcuityProcessor ----------
+
+    @Test
+    void vitalAcuityProcessor_updatesScore() {
+        VitalAcuityProcessor p = new VitalAcuityProcessor();
+        IAcuityNeuron n = new AcuityNeuron();
+        p.process(new VitalSignal(VitalType.HR, 35, 0L, "p"), n);
+        p.process(new VitalSignal(VitalType.SPO2, 80, 0L, "p"), n);
+        assertTrue(n.rawScore() > 0);
+    }
+
+    @Test
+    void vitalAcuityProcessor_metadata() {
+        VitalAcuityProcessor p = new VitalAcuityProcessor();
+        assertEquals(IAcuityNeuron.class, p.getNeuronClass());
+        assertEquals(VitalSignal.class, p.getSignalClass());
+    }
+
+    // ---------- WaveformAnalysisProcessor ----------
+
+    @Test
+    void waveformAnalysisProcessor_emitsAsystoleAlert() {
+        WaveformAnalysisProcessor p = new WaveformAnalysisProcessor();
+        IWaveformAnalysisNeuron n = new WaveformAnalysisNeuron();
+        WaveformSignal w = new WaveformSignal(WaveformType.ECG, new double[100], 250.0, "p");
+        List<ISignal> out = p.process(w, n);
+        assertEquals(1, out.size());
+        assertEquals("ECG_ASYSTOLE_LIKELY", ((AdverseEventAlertSignal) out.get(0)).getEventCode());
+    }
+
+    @Test
+    void waveformAnalysisProcessor_metadata() {
+        WaveformAnalysisProcessor p = new WaveformAnalysisProcessor();
+        assertEquals(IWaveformAnalysisNeuron.class, p.getNeuronClass());
+        assertEquals(WaveformSignal.class, p.getSignalClass());
+    }
+
+    // ---------- DemographicContextProcessor ----------
+
+    @Test
+    void demographicContextProcessor_updatesContext() {
+        DemographicContextProcessor p = new DemographicContextProcessor();
+        IPatientContextNeuron n = new PatientContextNeuron();
+        p.process(new DemographicSignal(80, Sex.FEMALE,
+                Arrays.asList("N18.6"), Arrays.asList("BETA_LACTAM_ANAPHYLAXIS"), "p1"), n);
+        assertEquals(80, n.getAgeYears());
+        assertTrue(n.hasComorbidity("N18.6"));
+        assertTrue(n.hasAllergy("BETA_LACTAM_ANAPHYLAXIS"));
+        assertTrue(n.getVulnerabilityFactor() > 1.0);
+    }
+
+    @Test
+    void demographicContextProcessor_metadata() {
+        DemographicContextProcessor p = new DemographicContextProcessor();
+        assertEquals(IPatientContextNeuron.class, p.getNeuronClass());
+        assertEquals(DemographicSignal.class, p.getSignalClass());
+    }
+
+    // ---------- MedicationRegimenProcessor ----------
+
+    @Test
+    void medicationRegimenProcessor_addsActiveDrug() {
+        MedicationRegimenProcessor p = new MedicationRegimenProcessor();
+        IDrugInteractionMemoryNeuron n = new DrugInteractionMemoryNeuron();
+        p.process(new MedicationAdminSignal("WARFARIN", 5, "mg", "po", 0L, "p1"), n);
+        assertTrue(n.getActive().contains("WARFARIN"));
+    }
+
+    @Test
+    void medicationRegimenProcessor_skipsNullCode() {
+        MedicationRegimenProcessor p = new MedicationRegimenProcessor();
+        IDrugInteractionMemoryNeuron n = new DrugInteractionMemoryNeuron();
+        p.process(new MedicationAdminSignal(null, 5, "mg", "po", 0L, "p1"), n);
+        assertTrue(n.getActive().isEmpty());
+    }
+
+    @Test
+    void medicationRegimenProcessor_metadata() {
+        MedicationRegimenProcessor p = new MedicationRegimenProcessor();
+        assertEquals(IDrugInteractionMemoryNeuron.class, p.getNeuronClass());
+        assertEquals(MedicationAdminSignal.class, p.getSignalClass());
+    }
+
+    // ---------- LabEvidenceProcessor ----------
+
+    @Test
+    void labEvidenceProcessor_updatesPosteriorOnAbnormal() {
+        LabEvidenceProcessor p = new LabEvidenceProcessor();
+        IDifferentialDiagnosisNeuron n = new DifferentialDiagnosisNeuron();
+        n.seed("J18.9");
+        n.seed("I21.9");
+        // analyteCode "WBC:J18.9" routes the LR to the pneumonia candidate
+        p.process(new LabResultSignal("WBC:J18.9", 18.0, "10^9/L",
+                new double[]{4, 11}, 0L, "p1"), n);
+        assertTrue(n.posteriorOf("J18.9") > n.posteriorOf("I21.9"));
+    }
+
+    @Test
+    void labEvidenceProcessor_skipsWhenNoIcdHint() {
+        LabEvidenceProcessor p = new LabEvidenceProcessor();
+        IDifferentialDiagnosisNeuron n = new DifferentialDiagnosisNeuron();
+        n.seed("J18.9");
+        double before = n.posteriorOf("J18.9");
+        p.process(new LabResultSignal("WBC", 18.0, "10^9/L",
+                new double[]{4, 11}, 0L, "p1"), n);
+        assertEquals(before, n.posteriorOf("J18.9"), 1e-9);
+    }
+
+    @Test
+    void labEvidenceProcessor_metadata() {
+        LabEvidenceProcessor p = new LabEvidenceProcessor();
+        assertEquals(IDifferentialDiagnosisNeuron.class, p.getNeuronClass());
+        assertEquals(LabResultSignal.class, p.getSignalClass());
+    }
+
+    // ---------- ImagingEvidenceProcessor ----------
+
+    @Test
+    void imagingEvidenceProcessor_criticalRaisesPosterior() {
+        ImagingEvidenceProcessor p = new ImagingEvidenceProcessor();
+        IDifferentialDiagnosisNeuron n = new DifferentialDiagnosisNeuron();
+        n.seed("J93.9");   // pneumothorax
+        n.seed("J18.9");
+        p.process(new ImagingFindingSignal("X-RAY", "CHEST|J93.9",
+                FindingCategory.CRITICAL, 0.9, "p1"), n);
+        assertTrue(n.posteriorOf("J93.9") > n.posteriorOf("J18.9"));
+    }
+
+    @Test
+    void imagingEvidenceProcessor_normalReducesPosterior() {
+        ImagingEvidenceProcessor p = new ImagingEvidenceProcessor();
+        IDifferentialDiagnosisNeuron n = new DifferentialDiagnosisNeuron();
+        n.seed("J93.9");
+        n.seed("J18.9");
+        double before = n.posteriorOf("J93.9");
+        p.process(new ImagingFindingSignal("X-RAY", "CHEST|J93.9",
+                FindingCategory.NORMAL, 0.9, "p1"), n);
+        assertTrue(n.posteriorOf("J93.9") < before);
+    }
+
+    @Test
+    void imagingEvidenceProcessor_metadata() {
+        ImagingEvidenceProcessor p = new ImagingEvidenceProcessor();
+        assertEquals(IDifferentialDiagnosisNeuron.class, p.getNeuronClass());
+        assertEquals(ImagingFindingSignal.class, p.getSignalClass());
+    }
+
+    // ---------- ContraindicationProcessor ----------
+
+    @Test
+    void contraindicationProcessor_emitsVetoOnAllergyMatch() {
+        IPatientContextNeuron ctx = new PatientContextNeuron();
+        ctx.update(new DemographicSignal(40, Sex.MALE, null,
+                Arrays.asList("BETA_LACTAM_ANAPHYLAXIS"), "p1"));
+        IContraindicationNeuron filter = new ContraindicationNeuron();
+        filter.setContext(ctx);
+
+        ContraindicationProcessor p = new ContraindicationProcessor();
+        List<ISignal> out = p.process(new TreatmentProposalSignal("AMOXICILLIN",
+                0.7, 0.2, "advisory", "p1"), filter);
+        assertEquals(1, out.size());
+        assertTrue(out.get(0) instanceof ClinicalVetoSignal);
+    }
+
+    @Test
+    void contraindicationProcessor_silentOnSafeProposal() {
+        IPatientContextNeuron ctx = new PatientContextNeuron();
+        ctx.update(new DemographicSignal(40, Sex.MALE, null, null, "p1"));
+        IContraindicationNeuron filter = new ContraindicationNeuron();
+        filter.setContext(ctx);
+
+        ContraindicationProcessor p = new ContraindicationProcessor();
+        List<ISignal> out = p.process(new TreatmentProposalSignal("ACETAMINOPHEN",
+                0.5, 0.1, "advisory", "p1"), filter);
+        assertTrue(out.isEmpty());
+    }
+
+    @Test
+    void contraindicationProcessor_metadata() {
+        ContraindicationProcessor p = new ContraindicationProcessor();
+        assertEquals(IContraindicationNeuron.class, p.getNeuronClass());
+        assertEquals(TreatmentProposalSignal.class, p.getSignalClass());
+    }
+
+    // ---------- consequence-model neuron is interface-typed in collaborators ----------
+
+    @Test
+    void treatmentPlanning_acceptsInterfaceTypedConsequenceModel() {
+        IClinicalConsequenceModelNeuron model = new ClinicalConsequenceModelNeuron();
+        com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.TreatmentPlanningNeuron planner =
+                new com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.TreatmentPlanningNeuron(model);
+        assertNotNull(planner);
+    }
+}


### PR DESCRIPTION
…uron interfaces

Adds 9 stateless ISignalProcessor implementations under worker/signalprocessor/impl/clinical, each parameterised by an I<Neuron> interface so processors are decoupled from concrete neuron classes:

* VitalMonitorProcessor (VitalSignal -> IVitalMonitorNeuron) — emits AdverseEventAlertSignal on guardrail excursion.
* VitalTrendProcessor (VitalSignal -> ITrendDetectorNeuron) — feeds rolling slope window.
* VitalAcuityProcessor (VitalSignal -> IAcuityNeuron) — updates NEWS2-style score.
* WaveformAnalysisProcessor (WaveformSignal -> IWaveformAnalysisNeuron) — emits ECG/PPG/EEG alerts.
* DemographicContextProcessor (DemographicSignal -> IPatientContextNeuron) — refreshes per-patient snapshot and vulnerability factor.
* MedicationRegimenProcessor (MedicationAdminSignal -> IDrugInteractionMemoryNeuron) — keeps active-drug list in sync for DDI lookups.
* LabEvidenceProcessor (LabResultSignal -> IDifferentialDiagnosisNeuron) — Bayesian update from abnormal/normal lab; ICD-10 hint encoded in analyte code as "LOINC:icd10".
* ImagingEvidenceProcessor (ImagingFindingSignal -> IDifferentialDiagnosisNeuron) — likelihood ratio scaled by CRITICAL/ABNORMAL/NORMAL category and confidence; ICD-10 hint encoded in region code as "REGION|icd10".
* ContraindicationProcessor (TreatmentProposalSignal -> IContraindicationNeuron) — forwards any ClinicalVetoSignal so it flows through the existing harm-veto audit path.

Also adds ClinicalProcessorsTest with 25 tests covering the alert emission, evidence updates, regimen tracking, veto forwarding, and ISignalProcessor metadata (neuron-class, signal-class, hasMerger). The tests confirm IClinicalConsequenceModelNeuron can be passed into TreatmentPlanningNeuron's interface-typed constructor, demonstrating the abstraction reaches all collaborator wiring.

Full worker suite: 364/364 pass (339 prior + 25 new), no regressions.

https://claude.ai/code/session_018DLgBWsQFe4q32RCbqYsAQ