### PR TITLE
Implement industrial process control & digital twins use case (use-ca…

### DIFF
--- a/docs/modules/industrial.md
+++ b/docs/modules/industrial.md
@@ -1,0 +1,228 @@
+# Industrial Process Control & Digital Twins
+
+> Status: implementation of [`use-case-industrial-process-control.md`](../../use-case-industrial-process-control.md) for [jneopallium](https://github.com/rakovpublic/jneopallium).
+> License: BSD 3-Clause.
+
+---
+
+## Abstract
+
+The industrial module unifies regulatory control, supervisory
+optimisation, planning, maintenance, and safety in a single
+signal-flow network. Every layer is structurally separate from the
+safety layer — the interlock neuron is frozen at construction time,
+operator override always wins for regulatory control, and every
+per-loop deployment mode (SHADOW / ADVISORY / AUTONOMOUS) is enforced
+at a dedicated safety gate. The headline operational contribution is
+automated, reversible oscillation management: the
+`OscillationMonitorNeuron` maps each tagged loop's autocorrelation to
+a graduated `OscillationIntervention` band (`SCALE_WEIGHTS /
+INJECT_INHIBITION / BREAK_CONNECTION / QUARANTINE_NEURON`) so the
+network can unilaterally damp a misbehaving cascade without permanent
+reconfiguration.
+
+## Design Principles
+
+1. **Typed timescales.** Measurements and actuator commands run on
+   loop 1 / epoch 1; setpoints on 1/2; alarms and interlocks on 1/1;
+   supervisory efficiency and batch-state on 2; degradation on 2/3;
+   maintenance windows on 2/10. Regulatory latency stays bounded as
+   slower layers evolve.
+2. **Processors parameterised by interfaces.** Every
+   `ISignalProcessor` under
+   `worker/signalprocessor/impl/industrial` targets an `I<Neuron>`
+   interface from `worker/net/neuron/impl/industrial`. A deployment
+   can swap PID, MPC, or sensor implementations without touching any
+   processor.
+3. **Safety is asymmetric.** An interlock can drive a process to
+   safe state but never start one; `InterlockNeuron.seal()` freezes
+   the rule set, after which additions throw `IllegalStateException`.
+   The SRS is compiled once.
+4. **Operator override always wins for regulatory control.**
+   `ActuatorNeuron` honours the most-recent `OperatorOverrideSignal`;
+   MANUAL freezes the tag at the manual value, BYPASS drops
+   subsequent commands. `IndustrialConfig.setOverrideAlwaysHonoured(false)`
+   throws.
+5. **Per-loop deployment mode.** `SafetyGateNeuron` maps SHADOW →
+   `execute=false`, ADVISORY → pass through, AUTONOMOUS → force
+   `execute=true`. Plants can run 90% autonomous, 9% advisory, 1%
+   shadow simultaneously.
+6. **Oscillation management is automatic and reversible.** ACF-at-
+   lag-1 drives the intervention band; both PID gain scaling and
+   cascade break are reversible at the next scheduler tick.
+
+## Signals
+
+Package: `com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial`.
+
+| Signal | Loop/Epoch | Notes |
+|---|---|---|
+| `MeasurementSignal` | 1/1 | ISA-95 tag, value, `Quality`, wall-clock ms |
+| `SetpointSignal` | 1/2 | tag, setpoint, ramp rate, source |
+| `ActuatorCommandSignal` | 1/1 | tag, target / current, `execute` |
+| `AlarmSignal` | 1/1 | `AlarmPriority`, tag, condition, ts |
+| `InterlockSignal` | 1/1 | id, `tripped`, causes |
+| `DegradationSignal` | 2/3 | asset id, RUL hours, confidence |
+| `EfficiencySignal` | 2/1 | unit id, efficiency, baseline |
+| `BatchStateSignal` | 2/2 | batch id, `BatchPhase`, key metrics |
+| `OperatorOverrideSignal` | 1/1 | tag, `OverrideKind`, operator, reason, manual value |
+| `MaintenanceWindowSignal` | 2/10 | asset id, scheduled tick, duration |
+
+## Neurons
+
+Every concrete neuron implements a matching `I<Neuron>` interface so
+processors never depend on the concrete type.
+
+### Layer 0 — field I/O
+- `SensorNeuron` / `ISensorNeuron` — reads field values.
+- `MeasurementValidatorNeuron` / `IMeasurementValidatorNeuron` —
+  range + rate-of-change; downgrades quality but never drops.
+
+### Layer 1 — regulatory
+- `PIDNeuron` / `IPIDNeuron` — velocity-form with anti-windup,
+  runtime-scalable gains.
+- `CascadeNeuron` / `ICascadeNeuron` — routes outer output as inner
+  setpoint; `setBroken(true)` freezes on last-good setpoint.
+- `FeedForwardNeuron` / `IFeedForwardNeuron` — proportional disturbance
+  compensation.
+
+### Layer 2 — supervisory
+- `SetpointOptimiserNeuron` / `ISetpointOptimiserNeuron` — efficiency-
+  driven setpoint nudges under constraints.
+- `AlarmAggregationNeuron` / `IAlarmAggregationNeuron` — ISA-18.2
+  suppression + per-minute rate.
+- `ModeControllerNeuron` / `IModeControllerNeuron` — STARTUP /
+  NORMAL / SHUTDOWN / EMERGENCY; interlock trip always forces
+  EMERGENCY, only `resetFromEmergency()` exits.
+
+### Layer 3 — model and memory
+- `ProcessModelNeuron` / `IProcessModelNeuron` — first-order plus
+  dead time.
+- `DegradationModelNeuron` / `IDegradationModelNeuron` — per-asset RUL.
+- `ProductQualityModelNeuron` / `IProductQualityModelNeuron` — target
+  / tolerance compliance.
+
+### Layer 4 — planning
+- `MPCPlanningNeuron` / `IMPCPlanningNeuron` — discrete candidate-move
+  search against a `IProcessModelNeuron` forecast.
+- `CampaignPlanningNeuron` / `ICampaignPlanningNeuron` — FIFO batch-
+  state queue.
+- `MaintenanceSchedulingNeuron` / `IMaintenanceSchedulingNeuron` —
+  proposes a window leading the predicted end-of-life.
+
+### Layer 5 — action
+- `SafetyGateNeuron` / `ISafetyGateNeuron` — per-tag SHADOW /
+  ADVISORY / AUTONOMOUS mode.
+- `ActuatorNeuron` / `IActuatorNeuron` — dispatcher with operator-
+  override authority.
+- `InterlockNeuron` / `IInterlockNeuron` — SRS rules sealed at
+  construction; `addInterlock` after `seal()` throws.
+
+### Layer 7 — homeostasis
+- `OscillationMonitorNeuron` / `IOscillationMonitorNeuron` — ACF-at-
+  lag-1 severity, mapped to `OscillationIntervention` bands.
+- `EnergyAccountingNeuron` / `IEnergyAccountingNeuron` — production-
+  per-kWh efficiency with baseline anchoring.
+
+## Processors
+
+Package: `com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial`.
+
+| Signal | Processor(s) |
+|---|---|
+| `MeasurementSignal` | `MeasurementValidationProcessor`, `MeasurementPIDProcessor`, `MeasurementOscillationProcessor`, `MeasurementInterlockProcessor` |
+| `SetpointSignal` | `SetpointPIDProcessor` |
+| `ActuatorCommandSignal` | `ActuatorSafetyGateProcessor`, `ActuatorDispatchProcessor` |
+| `AlarmSignal` | `AlarmAggregationProcessor` |
+| `InterlockSignal` | `InterlockModeProcessor` |
+| `DegradationSignal` | `DegradationSchedulingProcessor` |
+| `EfficiencySignal` | `EfficiencyOptimiserProcessor` |
+| `BatchStateSignal` | `BatchModeProcessor` |
+| `OperatorOverrideSignal` | `OperatorOverrideProcessor` |
+| `MaintenanceWindowSignal` | `MaintenanceWindowSchedulingProcessor` |
+
+Every processor's `getNeuronClass()` returns an interface —
+`IndustrialModuleTest::processors_allInterfaceTyped` asserts this.
+
+## Configuration
+
+`IndustrialConfig` mirrors spec §9 with strongly-typed setters.
+`setSafetyMode(null)` throws; `setOverrideAlwaysHonoured(false)`
+throws — override authority cannot be disabled at runtime.
+
+```yaml
+industrial:
+  enabled: true
+  tick-rate-hz: 100
+  isa-95-level: 2
+  safety:
+    mode: advisory
+    interlocks-source: "srs.yaml"
+    interlock-test-interval-ticks: 864000
+  oscillation:
+    detection-enabled: true
+    acf-window-ticks: 200
+    circuit-breaker-max-duration-ticks: 6000
+  mpc:
+    horizon-ticks: 60
+    control-horizon-ticks: 10
+  maintenance:
+    rul-refresh-ticks: 100000
+    scheduling-horizon-days: 90
+  audit:
+    log-every-decision: true
+    hash-chain-enabled: true
+    retention-days: 2555
+  operator-override:
+    always-honoured: true            # setter throws on false
+    lockout-during-emergency-only: true
+```
+
+## Tests
+
+`IndustrialModuleTest` covers 33 cases including:
+enum cardinalities, every signal's `ProcessingFrequency`, measurement
+validator range + rate-of-change flagging, PID steering + gain
+scaling, cascade break-and-hold, feed-forward bias, setpoint
+optimiser constraint clamping, alarm suppression, mode-machine
+EMERGENCY lockout, process-model response dynamics, degradation RUL
+reduction, product-quality compliance, MPC move selection, campaign
+FIFO, maintenance window scheduling, safety-gate shadow /
+autonomous, operator override (MANUAL + BYPASS), sealed-interlock
+immutability, interlock trip + fail-safe command, oscillation
+severity detection & intervention band, energy-accounting efficiency,
+config validation, and one smoke test per processor plus
+`processors_allInterfaceTyped` invariant.
+
+Full worker suite: 445/445 pass (412 prior + 33 new), no regressions.
+
+## Regulatory posture
+
+Aligns with IEC 61508 (functional safety, SIL 2 / SIL 3 subsystems
+via physical / network segregation from certified SIS), IEC 62443
+(OT cybersecurity — reuse the security module on the boundary),
+ISA-95 level 2, ISA-18.2 alarm management, 21 CFR Part 11 (hash-
+chained audit trail via the existing `TransparencyLogSignal`).
+
+## Out of scope
+
+Per spec §13:
+- Replacement of certified safety PLCs.
+- Cloud-round-trip control.
+- Affect, curiosity, or in-loop LLM.
+- Uncontrolled model updates.
+
+## References
+
+- Rakovskyi, D. (2024). *Framework for Natural Neuron Network
+  Modeling: The Jneopallium Approach.* IJSR 13(7).
+- IEC 61508:2010 — Functional safety of E/E/PE safety-related systems.
+- IEC 62443 — Industrial communication networks — IT security.
+- ISA-95 / IEC 62264 — Enterprise-control integration.
+- ISA-18.2-2016 — Alarm systems management.
+- Seborg, D.E., Edgar, T.F., Mellichamp, D.A., Doyle, F.J. (2016).
+  *Process Dynamics and Control.* Wiley.
+- Ziegler, J.G., Nichols, N.B. (1942). Optimum Settings for
+  Automatic Controllers. *Trans. ASME.*
+- Grieves, M., Vickers, J. (2017). Digital Twin. *Transdisciplinary
+  Perspectives on Complex Systems.*

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ActuatorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ActuatorNeuron.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.OperatorOverrideSignal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 5 actuator writer. Per spec §5 "operator override always wins"
+ * for regulatory control — a MANUAL override freezes the tag at the
+ * operator's manual value and a BYPASS override disables the loop
+ * entirely. Loop=1 / Epoch=1.
+ */
+public class ActuatorNeuron extends ModulatableNeuron implements IActuatorNeuron {
+
+    private final Map<String, OperatorOverrideSignal> overrides = new HashMap<>();
+    private final Map<String, Double> lastDispatched = new HashMap<>();
+    private long dispatched;
+    private long blocked;
+
+    public ActuatorNeuron() { super(); }
+    public ActuatorNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void onOverride(OperatorOverrideSignal o) {
+        if (o == null || o.getTag() == null) return;
+        overrides.put(o.getTag(), o);
+    }
+
+    @Override public void clearOverride(String tag) { if (tag != null) overrides.remove(tag); }
+    @Override public boolean isOverridden(String tag) { return overrides.containsKey(tag); }
+    @Override public OverrideKind overrideKind(String tag) {
+        OperatorOverrideSignal o = overrides.get(tag);
+        return o == null ? null : o.getKind();
+    }
+
+    @Override
+    public boolean dispatch(ActuatorCommandSignal cmd) {
+        if (cmd == null || cmd.getTag() == null) return false;
+        OperatorOverrideSignal o = overrides.get(cmd.getTag());
+        if (o != null) {
+            if (o.getKind() == OverrideKind.BYPASS) { blocked++; return false; }
+            // MANUAL: freeze at the operator's value
+            if (!cmd.isExecute()) return false;
+            lastDispatched.put(cmd.getTag(), o.getManualValue());
+            dispatched++;
+            return true;
+        }
+        if (!cmd.isExecute()) { blocked++; return false; }
+        lastDispatched.put(cmd.getTag(), cmd.getTargetValue());
+        dispatched++;
+        return true;
+    }
+
+    @Override public long getDispatched() { return dispatched; }
+    @Override public long getBlocked() { return blocked; }
+    @Override public Double lastDispatchedValue(String tag) { return lastDispatched.get(tag); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/AlarmAggregationNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/AlarmAggregationNeuron.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 2 ISA-18.2 alarm aggregator. Suppresses standing alarms (same
+ * tag + code within the suppression window) and tracks the global
+ * alarm rate. Loop=1 / Epoch=2.
+ */
+public class AlarmAggregationNeuron extends ModulatableNeuron implements IAlarmAggregationNeuron {
+
+    private final Map<String, Long> lastSeen = new HashMap<>();
+    private final Deque<Long> recent = new ArrayDeque<>();
+    private long suppressionWindowTicks = 600;
+    private int forwarded;
+
+    public AlarmAggregationNeuron() { super(); }
+    public AlarmAggregationNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void setSuppressionWindowTicks(long t) { this.suppressionWindowTicks = Math.max(0L, t); }
+
+    @Override
+    public AlarmSignal observe(AlarmSignal a) {
+        if (a == null) return null;
+        String key = (a.getTag() == null ? "" : a.getTag()) + '|'
+                + (a.getConditionCode() == null ? "" : a.getConditionCode());
+        long now = a.getTimestamp();
+        Long last = lastSeen.get(key);
+        if (last != null && now - last < suppressionWindowTicks) {
+            return null; // standing alarm suppression
+        }
+        lastSeen.put(key, now);
+        recent.addLast(now);
+        while (!recent.isEmpty() && now - recent.peekFirst() > 60_000L) recent.removeFirst();
+        forwarded++;
+        return a;
+    }
+
+    @Override public int standingAlarmCount() { return lastSeen.size(); }
+    @Override public double alarmRatePerMin() { return recent.size(); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/AlarmPriority.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/AlarmPriority.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+/** ISA-18.2 alarm-priority classes. */
+public enum AlarmPriority { JOURNAL, LOW, HIGH, URGENT }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/BatchPhase.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/BatchPhase.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+/** ISA-88 batch phase enumeration. */
+public enum BatchPhase { IDLE, RUNNING, HELD, PAUSED, COMPLETE, ABORTED, STOPPED }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/CampaignPlanningNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/CampaignPlanningNeuron.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.BatchStateSignal;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Layer 4 campaign planner. Queues target batch-state transitions and
+ * emits the next one on demand. Loop=2 / Epoch=5.
+ */
+public class CampaignPlanningNeuron extends ModulatableNeuron implements ICampaignPlanningNeuron {
+
+    private static final class Entry { String id; BatchStateSignal target; }
+
+    private final Deque<Entry> queue = new ArrayDeque<>();
+
+    public CampaignPlanningNeuron() { super(); }
+    public CampaignPlanningNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override
+    public void enqueueCampaign(String campaignId, BatchStateSignal target) {
+        if (campaignId == null || target == null) return;
+        Entry e = new Entry(); e.id = campaignId; e.target = target;
+        queue.addLast(e);
+    }
+
+    @Override public String currentCampaign() {
+        Entry e = queue.peekFirst();
+        return e == null ? null : e.id;
+    }
+
+    @Override public BatchStateSignal nextPhase() {
+        Entry e = queue.pollFirst();
+        return e == null ? null : e.target;
+    }
+
+    @Override public int queuedCampaigns() { return queue.size(); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/CascadeNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/CascadeNeuron.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+
+/**
+ * Layer 1 cascade router. Passes the outer-PID output as a fresh
+ * setpoint to the inner loop. When {@link #setBroken(boolean) broken},
+ * the cascade emits the last-good setpoint — implementation of the
+ * spec §6 {@link OscillationIntervention#BREAK_CONNECTION} intervention.
+ * Loop=1 / Epoch=1.
+ */
+public class CascadeNeuron extends ModulatableNeuron implements ICascadeNeuron {
+
+    private SetpointSignal lastInner;
+    private boolean broken;
+
+    public CascadeNeuron() { super(); }
+    public CascadeNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override
+    public SetpointSignal forward(ActuatorCommandSignal outerOutput, String innerTag) {
+        if (broken) return lastInner;
+        if (outerOutput == null) return null;
+        SetpointSignal sp = new SetpointSignal(innerTag, outerOutput.getTargetValue(), 0.0, "cascade");
+        lastInner = sp;
+        return sp;
+    }
+
+    @Override public void setBroken(boolean broken) { this.broken = broken; }
+    @Override public boolean isBroken() { return broken; }
+    @Override public SetpointSignal lastInnerSetpoint() { return lastInner; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/DegradationModelNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/DegradationModelNeuron.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.DegradationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 3 per-asset RUL estimator. Each wear measurement consumes a
+ * small fraction of the remaining-useful-life hours. Simple but
+ * honest: deployments wire in a proper fatigue / Arrhenius model
+ * behind the same interface. Loop=2 / Epoch=3.
+ */
+public class DegradationModelNeuron extends ModulatableNeuron implements IDegradationModelNeuron {
+
+    private static final class Asset { double rulHours; double confidence = 0.5; int samples; }
+    private final Map<String, Asset> assets = new HashMap<>();
+    private double wearPerUnit = 1.0;
+
+    public DegradationModelNeuron() { super(); }
+    public DegradationModelNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    public void setWearPerUnit(double w) { this.wearPerUnit = Math.max(0.0, w); }
+
+    @Override public void seedAsset(String assetId, double initialRulHours) {
+        if (assetId == null) return;
+        Asset a = new Asset();
+        a.rulHours = Math.max(0.0, initialRulHours);
+        assets.put(assetId, a);
+    }
+
+    @Override
+    public DegradationSignal observe(String assetId, MeasurementSignal wear) {
+        if (assetId == null || wear == null) return null;
+        Asset a = assets.get(assetId);
+        if (a == null) { seedAsset(assetId, 1000.0); a = assets.get(assetId); }
+        double consume = Math.max(0.0, wear.getMeasurement()) * wearPerUnit;
+        a.rulHours = Math.max(0.0, a.rulHours - consume);
+        a.samples++;
+        a.confidence = Math.min(1.0, 0.5 + a.samples / 200.0);
+        return new DegradationSignal(assetId, a.rulHours, a.confidence);
+    }
+
+    @Override public double rulFor(String assetId) {
+        Asset a = assets.get(assetId);
+        return a == null ? Double.NaN : a.rulHours;
+    }
+
+    @Override public int trackedAssets() { return assets.size(); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/EnergyAccountingNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/EnergyAccountingNeuron.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.EfficiencySignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 7 production-aware energy accounting. Efficiency is reported as
+ * production-units per kWh for each unit against a baseline the first
+ * observation establishes. Loop=2 / Epoch=1.
+ */
+public class EnergyAccountingNeuron extends ModulatableNeuron implements IEnergyAccountingNeuron {
+
+    private static final class Unit { double kwh; double production; double baseline = Double.NaN; }
+
+    private final Map<String, Unit> units = new HashMap<>();
+
+    public EnergyAccountingNeuron() { super(); }
+    public EnergyAccountingNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void recordEnergy(String unitId, double kwh) {
+        if (unitId == null) return;
+        units.computeIfAbsent(unitId, k -> new Unit()).kwh += Math.max(0.0, kwh);
+    }
+
+    @Override public void recordProduction(String unitId, double production) {
+        if (unitId == null) return;
+        units.computeIfAbsent(unitId, k -> new Unit()).production += Math.max(0.0, production);
+    }
+
+    @Override
+    public EfficiencySignal efficiencyFor(String unitId) {
+        Unit u = units.get(unitId);
+        if (u == null || u.kwh <= 0.0) return new EfficiencySignal(unitId, 0.0, 0.0);
+        double eff = u.production / u.kwh;
+        if (Double.isNaN(u.baseline)) u.baseline = eff;
+        return new EfficiencySignal(unitId, eff, u.baseline);
+    }
+
+    @Override
+    public void observe(MeasurementSignal m) {
+        if (m == null || m.getTag() == null) return;
+        // Convention: tag format is "<unitId>/energy" or "<unitId>/production".
+        int slash = m.getTag().lastIndexOf('/');
+        if (slash <= 0) return;
+        String unit = m.getTag().substring(0, slash);
+        String kind = m.getTag().substring(slash + 1);
+        if ("energy".equalsIgnoreCase(kind)) recordEnergy(unit, m.getMeasurement());
+        else if ("production".equalsIgnoreCase(kind)) recordProduction(unit, m.getMeasurement());
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/FeedForwardNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/FeedForwardNeuron.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+/**
+ * Layer 1 feed-forward compensator. Adds a bias proportional to a
+ * disturbance measurement onto the downstream actuator. Loop=1 / Epoch=1.
+ */
+public class FeedForwardNeuron extends ModulatableNeuron implements IFeedForwardNeuron {
+
+    private double gain;
+
+    public FeedForwardNeuron() { super(); }
+    public FeedForwardNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void setGain(double k) { this.gain = k; }
+    @Override public double getGain() { return gain; }
+
+    @Override
+    public ActuatorCommandSignal compensate(MeasurementSignal disturbance, String targetTag, double currentValue) {
+        if (disturbance == null) return null;
+        double target = currentValue + gain * disturbance.getMeasurement();
+        return new ActuatorCommandSignal(targetTag, target, currentValue, true);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IActuatorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IActuatorNeuron.java
@@ -1,0 +1,21 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.OperatorOverrideSignal;
+
+public interface IActuatorNeuron extends IModulatableNeuron {
+    void onOverride(OperatorOverrideSignal o);
+    void clearOverride(String tag);
+    boolean isOverridden(String tag);
+    OverrideKind overrideKind(String tag);
+    /**
+     * Write the command to the field (returns true iff written). Honours
+     * any active operator override — MANUAL freezes at the manual value,
+     * BYPASS drops the command.
+     */
+    boolean dispatch(ActuatorCommandSignal cmd);
+    long getDispatched();
+    long getBlocked();
+    Double lastDispatchedValue(String tag);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IAlarmAggregationNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IAlarmAggregationNeuron.java
@@ -1,0 +1,12 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+
+public interface IAlarmAggregationNeuron extends IModulatableNeuron {
+    /** Ingest an alarm; returns null if suppressed / grouped, otherwise the forwarded alarm. */
+    AlarmSignal observe(AlarmSignal a);
+    int standingAlarmCount();
+    double alarmRatePerMin();
+    void setSuppressionWindowTicks(long t);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ICampaignPlanningNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ICampaignPlanningNeuron.java
@@ -1,0 +1,11 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.BatchStateSignal;
+
+public interface ICampaignPlanningNeuron extends IModulatableNeuron {
+    void enqueueCampaign(String campaignId, BatchStateSignal target);
+    String currentCampaign();
+    BatchStateSignal nextPhase();
+    int queuedCampaigns();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ICascadeNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ICascadeNeuron.java
@@ -1,0 +1,14 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+
+public interface ICascadeNeuron extends IModulatableNeuron {
+    /** Route the outer-PID actuator output as setpoint for the inner loop. */
+    SetpointSignal forward(ActuatorCommandSignal outerOutput, String innerTag);
+    /** Temporarily break the cascade so the inner loop freezes on its last-good setpoint. */
+    void setBroken(boolean broken);
+    boolean isBroken();
+    SetpointSignal lastInnerSetpoint();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IDegradationModelNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IDegradationModelNeuron.java
@@ -1,0 +1,13 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.DegradationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+public interface IDegradationModelNeuron extends IModulatableNeuron {
+    void seedAsset(String assetId, double initialRulHours);
+    /** Ingest a wear-related measurement for {@code assetId} and emit an updated RUL estimate. */
+    DegradationSignal observe(String assetId, MeasurementSignal wear);
+    double rulFor(String assetId);
+    int trackedAssets();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IEnergyAccountingNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IEnergyAccountingNeuron.java
@@ -1,0 +1,15 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.EfficiencySignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+public interface IEnergyAccountingNeuron extends IModulatableNeuron {
+    /** Record energy usage for a unit. */
+    void recordEnergy(String unitId, double kwh);
+    /** Record the production rate (baseline for attribution). */
+    void recordProduction(String unitId, double units);
+    EfficiencySignal efficiencyFor(String unitId);
+    /** Convenience: update from a raw measurement. */
+    void observe(MeasurementSignal m);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IFeedForwardNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IFeedForwardNeuron.java
@@ -1,0 +1,12 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+public interface IFeedForwardNeuron extends IModulatableNeuron {
+    void setGain(double k);
+    double getGain();
+    /** Apply a disturbance reading to produce a corrective bias on the downstream actuator. */
+    ActuatorCommandSignal compensate(MeasurementSignal disturbance, String targetTag, double currentValue);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IInterlockNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IInterlockNeuron.java
@@ -1,0 +1,21 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.InterlockSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+import java.util.List;
+
+public interface IInterlockNeuron extends IModulatableNeuron {
+    /** Record immutable interlock rule (active after construction); throws if invoked after {@link #seal()}. */
+    void addInterlock(String interlockId, String measurementTag, double threshold,
+                      boolean tripHigh, String safeActuatorTag, double safeValue);
+    /** Freeze the interlock set. Subsequent {@code addInterlock} calls throw. */
+    void seal();
+    boolean isSealed();
+    /** Evaluate a measurement against all interlocks; returns trip signal list when triggered. */
+    List<InterlockSignal> evaluate(MeasurementSignal m);
+    /** Fail-safe commands emitted by the most recent trips, intended to bypass planning direct-to-actuator. */
+    List<ActuatorCommandSignal> failSafeCommands();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IMPCPlanningNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IMPCPlanningNeuron.java
@@ -1,0 +1,15 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+
+public interface IMPCPlanningNeuron extends IModulatableNeuron {
+    void setHorizon(int horizonTicks);
+    void setControlHorizon(int controlHorizonTicks);
+    void setProcessModel(IProcessModelNeuron model);
+    /** Solve one MPC step for {@code sp} against {@code currentValue}; returns the first control move. */
+    ActuatorCommandSignal step(SetpointSignal sp, double currentValue);
+    int getHorizon();
+    int getControlHorizon();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IMaintenanceSchedulingNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IMaintenanceSchedulingNeuron.java
@@ -1,0 +1,13 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.DegradationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MaintenanceWindowSignal;
+
+public interface IMaintenanceSchedulingNeuron extends IModulatableNeuron {
+    /** Propose a maintenance window based on current RUL and a target leadtime. */
+    MaintenanceWindowSignal schedule(DegradationSignal rul, long currentTick, long leadTimeTicks);
+    int scheduledFor(String assetId);
+    void setMinLeadTimeTicks(long t);
+    long getMinLeadTimeTicks();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IMeasurementValidatorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IMeasurementValidatorNeuron.java
@@ -1,0 +1,12 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+public interface IMeasurementValidatorNeuron extends IModulatableNeuron {
+    void setRange(String tag, double min, double max);
+    void setMaxRateOfChange(String tag, double unitsPerSecond);
+    /** Validate in-place; may downgrade quality to UNCERTAIN but never drops the reading. */
+    MeasurementSignal validate(MeasurementSignal m);
+    int suspiciousCount();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IModeControllerNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IModeControllerNeuron.java
@@ -1,0 +1,13 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.BatchStateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.InterlockSignal;
+
+public interface IModeControllerNeuron extends IModulatableNeuron {
+    PlantMode getMode();
+    void requestMode(PlantMode requested);
+    void onBatchState(BatchStateSignal s);
+    void onInterlock(InterlockSignal s);
+    boolean allowsNormalControl();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IOscillationMonitorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IOscillationMonitorNeuron.java
@@ -1,0 +1,14 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+public interface IOscillationMonitorNeuron extends IModulatableNeuron {
+    void observe(MeasurementSignal m);
+    /** Normalised severity in [0,1] — 0 means no oscillation, 1 is maximum. */
+    double severity(String tag);
+    /** Spec §6 intervention band at the current severity. */
+    OscillationIntervention intervention(String tag);
+    void setAcfWindowTicks(int w);
+    int getAcfWindowTicks();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IPIDNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IPIDNeuron.java
@@ -1,0 +1,23 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+
+public interface IPIDNeuron extends IModulatableNeuron {
+    void setGains(double kp, double ki, double kd);
+    double getKp();
+    double getKi();
+    double getKd();
+    /** Scale current gains in place (temporary tuning — {@code LoopCircuitBreaker} SCALE_WEIGHTS intervention). */
+    void scaleGains(double factor);
+    void setSetpoint(SetpointSignal s);
+    double getSetpoint();
+    void setOutputLimits(double min, double max);
+    /** Process one measurement and emit the corresponding actuator command. {@code dtSeconds} is the loop period. */
+    ActuatorCommandSignal step(MeasurementSignal m, double dtSeconds);
+    void reset();
+    double getLastError();
+    double getLastOutput();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IProcessModelNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IProcessModelNeuron.java
@@ -1,0 +1,11 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+
+public interface IProcessModelNeuron extends IModulatableNeuron {
+    /** Forward-predict the response of {@code tag} to {@code controlInput} after {@code horizonTicks}. */
+    double predict(String tag, double controlInput, int horizonTicks);
+    void setGain(String tag, double k);
+    void setDeadTimeTicks(String tag, int dtTicks);
+    void setTimeConstantTicks(String tag, double tauTicks);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IProductQualityModelNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IProductQualityModelNeuron.java
@@ -1,0 +1,11 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+
+public interface IProductQualityModelNeuron extends IModulatableNeuron {
+    void setTarget(double target);
+    void setTolerance(double tol);
+    /** Predicted compliance probability in [0,1] for the current conditions. */
+    double predictCompliance(double[] conditions);
+    boolean inSpec(double[] conditions);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ISafetyGateNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ISafetyGateNeuron.java
@@ -1,0 +1,17 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+
+public interface ISafetyGateNeuron extends IModulatableNeuron {
+    /**
+     * Gate a proposed actuator command. Returns the (possibly downgraded
+     * — {@code execute=false} for shadow mode) command if safe, or null
+     * when the harm path vetoes.
+     */
+    ActuatorCommandSignal gate(ActuatorCommandSignal cmd);
+    void setModeFor(String tag, SafetyMode mode);
+    SafetyMode modeFor(String tag);
+    SafetyMode defaultMode();
+    void setDefaultMode(SafetyMode m);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ISensorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ISensorNeuron.java
@@ -1,0 +1,9 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+public interface ISensorNeuron extends IModulatableNeuron {
+    MeasurementSignal read(String tag, double value, Quality quality, long timestamp);
+    long getReads();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ISetpointOptimiserNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ISetpointOptimiserNeuron.java
@@ -1,0 +1,12 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.EfficiencySignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+
+public interface ISetpointOptimiserNeuron extends IModulatableNeuron {
+    void setConstraint(String tag, double min, double max);
+    void setStep(double step);
+    /** Propose a setpoint nudge for {@code tag} based on the efficiency delta. */
+    SetpointSignal optimise(EfficiencySignal eff, String tag, double currentSetpoint);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IndustrialConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IndustrialConfig.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+/**
+ * Configuration for the industrial-process-control module. Mirrors the
+ * YAML section {@code industrial} in spec §9. Defaults are
+ * production-safe: advisory mode per-loop, rollback / autonomous opt-in
+ * at deployment time, tamper-evident audit trail, operator override
+ * always honoured.
+ */
+public final class IndustrialConfig {
+
+    private boolean enabled = true;
+    private int tickRateHz = 100;
+
+    // safety
+    private SafetyMode safetyMode = SafetyMode.ADVISORY;
+    private String interlocksSource = "srs.yaml";
+    private long interlockTestIntervalTicks = 864_000L;
+
+    // oscillation
+    private boolean oscillationDetectionEnabled = true;
+    private int acfWindowTicks = 200;
+    private int circuitBreakerMaxDurationTicks = 6_000;
+
+    // MPC
+    private int mpcHorizonTicks = 60;
+    private int mpcControlHorizonTicks = 10;
+
+    // maintenance
+    private long rulRefreshTicks = 100_000L;
+    private int schedulingHorizonDays = 90;
+
+    // audit
+    private boolean logEveryDecision = true;
+    private boolean hashChainEnabled = true;
+    private int retentionDays = 2555;
+
+    // operator override
+    private boolean overrideAlwaysHonoured = true;
+    private boolean overrideLockoutDuringEmergencyOnly = true;
+
+    // ISA-95
+    private int isa95Level = 2;
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean v) { this.enabled = v; }
+    public int getTickRateHz() { return tickRateHz; }
+    public void setTickRateHz(int v) { this.tickRateHz = Math.max(1, v); }
+
+    public SafetyMode getSafetyMode() { return safetyMode; }
+    public void setSafetyMode(SafetyMode m) {
+        if (m == null) throw new IllegalArgumentException("safety.mode must be SHADOW / ADVISORY / AUTONOMOUS");
+        this.safetyMode = m;
+    }
+    public String getInterlocksSource() { return interlocksSource; }
+    public void setInterlocksSource(String s) { this.interlocksSource = s; }
+    public long getInterlockTestIntervalTicks() { return interlockTestIntervalTicks; }
+    public void setInterlockTestIntervalTicks(long t) { this.interlockTestIntervalTicks = Math.max(1L, t); }
+
+    public boolean isOscillationDetectionEnabled() { return oscillationDetectionEnabled; }
+    public void setOscillationDetectionEnabled(boolean v) { this.oscillationDetectionEnabled = v; }
+    public int getAcfWindowTicks() { return acfWindowTicks; }
+    public void setAcfWindowTicks(int v) { this.acfWindowTicks = Math.max(8, v); }
+    public int getCircuitBreakerMaxDurationTicks() { return circuitBreakerMaxDurationTicks; }
+    public void setCircuitBreakerMaxDurationTicks(int v) { this.circuitBreakerMaxDurationTicks = Math.max(1, v); }
+
+    public int getMpcHorizonTicks() { return mpcHorizonTicks; }
+    public void setMpcHorizonTicks(int v) { this.mpcHorizonTicks = Math.max(1, v); }
+    public int getMpcControlHorizonTicks() { return mpcControlHorizonTicks; }
+    public void setMpcControlHorizonTicks(int v) {
+        this.mpcControlHorizonTicks = Math.max(1, Math.min(mpcHorizonTicks, v));
+    }
+
+    public long getRulRefreshTicks() { return rulRefreshTicks; }
+    public void setRulRefreshTicks(long v) { this.rulRefreshTicks = Math.max(1L, v); }
+    public int getSchedulingHorizonDays() { return schedulingHorizonDays; }
+    public void setSchedulingHorizonDays(int v) { this.schedulingHorizonDays = Math.max(1, v); }
+
+    public boolean isLogEveryDecision() { return logEveryDecision; }
+    public void setLogEveryDecision(boolean v) { this.logEveryDecision = v; }
+    public boolean isHashChainEnabled() { return hashChainEnabled; }
+    public void setHashChainEnabled(boolean v) { this.hashChainEnabled = v; }
+    public int getRetentionDays() { return retentionDays; }
+    public void setRetentionDays(int v) { this.retentionDays = Math.max(1, v); }
+
+    public boolean isOverrideAlwaysHonoured() { return overrideAlwaysHonoured; }
+    /** Per spec §11 operator override authority must remain enabled in this module. */
+    public void setOverrideAlwaysHonoured(boolean v) {
+        if (!v) throw new IllegalArgumentException("operator-override.always-honoured must be true for industrial module");
+        this.overrideAlwaysHonoured = true;
+    }
+    public boolean isOverrideLockoutDuringEmergencyOnly() { return overrideLockoutDuringEmergencyOnly; }
+    public void setOverrideLockoutDuringEmergencyOnly(boolean v) { this.overrideLockoutDuringEmergencyOnly = v; }
+
+    public int getIsa95Level() { return isa95Level; }
+    public void setIsa95Level(int v) { this.isa95Level = v; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/InterlockNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/InterlockNeuron.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.InterlockSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Layer 5 hard-wired interlocks. Rules are frozen at {@link #seal()};
+ * any subsequent addition throws — the SRS is compiled once. Per spec
+ * §5 the interlock is the only signal path permitted to bypass planning
+ * and action-selection, and only in the fail-safe direction.
+ * Loop=1 / Epoch=1.
+ */
+public class InterlockNeuron extends ModulatableNeuron implements IInterlockNeuron {
+
+    private static final class Rule {
+        final String id;
+        final String measTag;
+        final double threshold;
+        final boolean tripHigh;
+        final String safeActuator;
+        final double safeValue;
+        Rule(String id, String t, double th, boolean high, String sa, double sv) {
+            this.id = id; this.measTag = t; this.threshold = th;
+            this.tripHigh = high; this.safeActuator = sa; this.safeValue = sv;
+        }
+    }
+
+    private final List<Rule> rules = new ArrayList<>();
+    private final List<ActuatorCommandSignal> lastFailSafe = new ArrayList<>();
+    private boolean sealed;
+
+    public InterlockNeuron() { super(); }
+    public InterlockNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override
+    public void addInterlock(String interlockId, String measurementTag, double threshold,
+                             boolean tripHigh, String safeActuatorTag, double safeValue) {
+        if (sealed) throw new IllegalStateException("interlock set is sealed");
+        if (interlockId == null || measurementTag == null || safeActuatorTag == null) return;
+        rules.add(new Rule(interlockId, measurementTag, threshold, tripHigh, safeActuatorTag, safeValue));
+    }
+
+    @Override public void seal() { this.sealed = true; }
+    @Override public boolean isSealed() { return sealed; }
+
+    @Override
+    public List<InterlockSignal> evaluate(MeasurementSignal m) {
+        List<InterlockSignal> out = new ArrayList<>();
+        lastFailSafe.clear();
+        if (m == null || m.getTag() == null) return out;
+        for (Rule r : rules) {
+            if (!r.measTag.equals(m.getTag())) continue;
+            boolean trip = r.tripHigh ? m.getMeasurement() > r.threshold
+                                       : m.getMeasurement() < r.threshold;
+            if (trip) {
+                out.add(new InterlockSignal(r.id, true, Arrays.asList(r.measTag)));
+                lastFailSafe.add(new ActuatorCommandSignal(r.safeActuator, r.safeValue, Double.NaN, true));
+            }
+        }
+        return out;
+    }
+
+    @Override public List<ActuatorCommandSignal> failSafeCommands() {
+        return new ArrayList<>(lastFailSafe);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/MPCPlanningNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/MPCPlanningNeuron.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+
+/**
+ * Layer 4 model-predictive controller. Samples a set of candidate
+ * control moves across the control horizon, evaluates each against
+ * the {@link IProcessModelNeuron} forecast over the prediction
+ * horizon, and emits the first move of the best-scoring trajectory.
+ * Loop=1 / Epoch=3.
+ */
+public class MPCPlanningNeuron extends ModulatableNeuron implements IMPCPlanningNeuron {
+
+    private int horizon = 60;
+    private int controlHorizon = 10;
+    private IProcessModelNeuron model;
+
+    public MPCPlanningNeuron() { super(); }
+    public MPCPlanningNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void setHorizon(int horizonTicks) { this.horizon = Math.max(1, horizonTicks); }
+    @Override public void setControlHorizon(int controlHorizonTicks) {
+        this.controlHorizon = Math.max(1, Math.min(this.horizon, controlHorizonTicks));
+    }
+    @Override public void setProcessModel(IProcessModelNeuron model) { this.model = model; }
+    @Override public int getHorizon() { return horizon; }
+    @Override public int getControlHorizon() { return controlHorizon; }
+
+    @Override
+    public ActuatorCommandSignal step(SetpointSignal sp, double currentValue) {
+        if (sp == null) return null;
+        double bestMove = currentValue;
+        double bestCost = Double.POSITIVE_INFINITY;
+        for (double move = -1.0; move <= 1.0; move += 0.25) {
+            double predicted = (model == null)
+                    ? currentValue + move
+                    : currentValue + model.predict(sp.getTag(), move, horizon);
+            double err = sp.getSetpoint() - predicted;
+            double cost = err * err + 0.05 * move * move;
+            if (cost < bestCost) { bestCost = cost; bestMove = currentValue + move; }
+        }
+        return new ActuatorCommandSignal(sp.getTag(), bestMove, currentValue, true);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/MaintenanceSchedulingNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/MaintenanceSchedulingNeuron.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.DegradationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MaintenanceWindowSignal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** Layer 4 maintenance scheduler. Loop=2 / Epoch=10. */
+public class MaintenanceSchedulingNeuron extends ModulatableNeuron implements IMaintenanceSchedulingNeuron {
+
+    private final Map<String, Integer> scheduled = new HashMap<>();
+    private long minLeadTimeTicks = 10_000L;
+    private long ticksPerHour = 360_000L; // 100Hz baseline
+
+    public MaintenanceSchedulingNeuron() { super(); }
+    public MaintenanceSchedulingNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    public void setTicksPerHour(long t) { this.ticksPerHour = Math.max(1L, t); }
+
+    @Override
+    public MaintenanceWindowSignal schedule(DegradationSignal rul, long currentTick, long leadTimeTicks) {
+        if (rul == null || rul.getAssetId() == null) return null;
+        long rulTicks = (long) (rul.getRemainingUsefulLifeHours() * ticksPerHour);
+        long lead = Math.max(leadTimeTicks, minLeadTimeTicks);
+        long scheduledTick = Math.max(currentTick, currentTick + rulTicks - lead);
+        int duration = (int) Math.min(Integer.MAX_VALUE, Math.max(1L, ticksPerHour));
+        scheduled.merge(rul.getAssetId(), 1, Integer::sum);
+        return new MaintenanceWindowSignal(rul.getAssetId(), scheduledTick, duration);
+    }
+
+    @Override public int scheduledFor(String assetId) { return scheduled.getOrDefault(assetId, 0); }
+    @Override public void setMinLeadTimeTicks(long t) { this.minLeadTimeTicks = Math.max(0L, t); }
+    @Override public long getMinLeadTimeTicks() { return minLeadTimeTicks; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/MeasurementValidatorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/MeasurementValidatorNeuron.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 0 range / rate-of-change filter. Downgrades quality to
+ * UNCERTAIN on anomalies rather than dropping the reading — a dropped
+ * measurement is worse than a flagged one in industrial control.
+ * Loop=1 / Epoch=1.
+ */
+public class MeasurementValidatorNeuron extends ModulatableNeuron implements IMeasurementValidatorNeuron {
+
+    private static final class Range { double min, max; Range(double l, double h){min=l;max=h;} }
+    private static final class Rate { double maxAbsPerSec; Rate(double r){maxAbsPerSec=r;} }
+    private static final class Last { double value; long tsMs; Last(double v,long t){value=v;tsMs=t;} }
+
+    private final Map<String, Range> ranges = new HashMap<>();
+    private final Map<String, Rate> rates = new HashMap<>();
+    private final Map<String, Last> lastSample = new HashMap<>();
+    private int suspicious;
+
+    public MeasurementValidatorNeuron() { super(); }
+    public MeasurementValidatorNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void setRange(String tag, double min, double max) {
+        if (tag != null) ranges.put(tag, new Range(Math.min(min, max), Math.max(min, max)));
+    }
+    @Override public void setMaxRateOfChange(String tag, double unitsPerSecond) {
+        if (tag != null) rates.put(tag, new Rate(Math.max(0.0, unitsPerSecond)));
+    }
+
+    @Override
+    public MeasurementSignal validate(MeasurementSignal m) {
+        if (m == null || m.getTag() == null) return m;
+        boolean bad = false;
+        Range r = ranges.get(m.getTag());
+        if (r != null && (m.getMeasurement() < r.min || m.getMeasurement() > r.max)) bad = true;
+        Rate rate = rates.get(m.getTag());
+        Last last = lastSample.get(m.getTag());
+        if (!bad && rate != null && last != null && m.getTimestamp() > last.tsMs) {
+            double dt = (m.getTimestamp() - last.tsMs) / 1000.0;
+            double slope = Math.abs(m.getMeasurement() - last.value) / Math.max(1e-6, dt);
+            if (slope > rate.maxAbsPerSec) bad = true;
+        }
+        if (bad) {
+            m.setQuality(Quality.UNCERTAIN);
+            suspicious++;
+        }
+        lastSample.put(m.getTag(), new Last(m.getMeasurement(), m.getTimestamp()));
+        return m;
+    }
+
+    @Override public int suspiciousCount() { return suspicious; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ModeControllerNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ModeControllerNeuron.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.BatchStateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.InterlockSignal;
+
+/**
+ * Layer 2 plant-mode state machine. STARTUP / NORMAL / SHUTDOWN /
+ * EMERGENCY. Any interlock trip forces EMERGENCY; operator can request
+ * transitions but an EMERGENCY state clears only by explicit reset.
+ * Loop=2 / Epoch=1.
+ */
+public class ModeControllerNeuron extends ModulatableNeuron implements IModeControllerNeuron {
+
+    private PlantMode mode = PlantMode.STARTUP;
+
+    public ModeControllerNeuron() { super(); }
+    public ModeControllerNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public PlantMode getMode() { return mode; }
+
+    @Override
+    public void requestMode(PlantMode requested) {
+        if (requested == null || mode == PlantMode.EMERGENCY) return;
+        this.mode = requested;
+    }
+
+    @Override
+    public void onBatchState(BatchStateSignal s) {
+        if (s == null) return;
+        switch (s.getPhase()) {
+            case RUNNING: if (mode != PlantMode.EMERGENCY) mode = PlantMode.NORMAL; break;
+            case ABORTED:
+            case STOPPED: mode = PlantMode.SHUTDOWN; break;
+            default: break;
+        }
+    }
+
+    @Override
+    public void onInterlock(InterlockSignal s) {
+        if (s != null && s.isTripped()) mode = PlantMode.EMERGENCY;
+    }
+
+    /** Operator-initiated reset from EMERGENCY back to SHUTDOWN. */
+    public void resetFromEmergency() {
+        if (mode == PlantMode.EMERGENCY) mode = PlantMode.SHUTDOWN;
+    }
+
+    @Override public boolean allowsNormalControl() { return mode == PlantMode.NORMAL || mode == PlantMode.STARTUP; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/OscillationIntervention.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/OscillationIntervention.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+/** Graduated oscillation-damping interventions from spec §6. */
+public enum OscillationIntervention { NONE, SCALE_WEIGHTS, INJECT_INHIBITION, BREAK_CONNECTION, QUARANTINE_NEURON }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/OscillationMonitorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/OscillationMonitorNeuron.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 7 oscillation monitor. Uses the autocorrelation at lag=2 as a
+ * cheap proxy for periodicity (autocorrelation close to -1 indicates a
+ * tight oscillation). Maps the severity to the graduated interventions
+ * from spec §6. Loop=1 / Epoch=2.
+ */
+public class OscillationMonitorNeuron extends ModulatableNeuron implements IOscillationMonitorNeuron {
+
+    private final Map<String, Deque<Double>> windows = new HashMap<>();
+    private int acfWindowTicks = 200;
+
+    public OscillationMonitorNeuron() { super(); }
+    public OscillationMonitorNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void setAcfWindowTicks(int w) { this.acfWindowTicks = Math.max(8, w); }
+    @Override public int getAcfWindowTicks() { return acfWindowTicks; }
+
+    @Override
+    public void observe(MeasurementSignal m) {
+        if (m == null || m.getTag() == null) return;
+        Deque<Double> w = windows.computeIfAbsent(m.getTag(), k -> new ArrayDeque<>());
+        w.addLast(m.getMeasurement());
+        while (w.size() > acfWindowTicks) w.removeFirst();
+    }
+
+    @Override
+    public double severity(String tag) {
+        Deque<Double> w = windows.get(tag);
+        if (w == null || w.size() < 4) return 0.0;
+        double[] arr = new double[w.size()];
+        int i = 0;
+        double mean = 0.0;
+        for (Double v : w) { arr[i] = v; mean += v; i++; }
+        mean /= arr.length;
+        double num = 0.0, den = 0.0;
+        // Control-loop oscillation shows as negative ACF at lag 1.
+        for (int j = 1; j < arr.length; j++) num += (arr[j] - mean) * (arr[j - 1] - mean);
+        for (double d : arr) den += (d - mean) * (d - mean);
+        if (den <= 0) return 0.0;
+        double rho = num / den;
+        // Tight alternation ⇒ rho near -1; no oscillation ⇒ rho near 0 or positive.
+        return Math.max(0.0, Math.min(1.0, -rho));
+    }
+
+    @Override
+    public OscillationIntervention intervention(String tag) {
+        double s = severity(tag);
+        if (s < 0.30) return OscillationIntervention.NONE;
+        if (s < 0.60) return OscillationIntervention.SCALE_WEIGHTS;
+        if (s < 0.85) return OscillationIntervention.INJECT_INHIBITION;
+        // Per spec §6: ≥0.85 is BREAK_CONNECTION; sustained-and-extreme
+        // (rho saturated at -1) escalates to QUARANTINE_NEURON.
+        if (s < 0.98) return OscillationIntervention.BREAK_CONNECTION;
+        return OscillationIntervention.QUARANTINE_NEURON;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/OverrideKind.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/OverrideKind.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+/** Operator-override mode — MANUAL locks the actuator value, BYPASS disables the loop entirely. */
+public enum OverrideKind { MANUAL, BYPASS }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/PIDNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/PIDNeuron.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+
+/**
+ * Layer 1 PID controller. Velocity-form update with anti-windup via
+ * output clamping. Three gains (Kp, Ki, Kd) can be scaled at runtime
+ * to implement the {@link OscillationIntervention#SCALE_WEIGHTS}
+ * intervention. Loop=1 / Epoch=1.
+ */
+public class PIDNeuron extends ModulatableNeuron implements IPIDNeuron {
+
+    private double kp, ki, kd;
+    private double setpoint;
+    private double outMin = -Double.MAX_VALUE, outMax = Double.MAX_VALUE;
+    private double integrator;
+    private double lastError;
+    private double lastOutput;
+    private boolean hasPrev;
+    private String tag;
+
+    public PIDNeuron() { super(); }
+    public PIDNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    public void setTag(String tag) { this.tag = tag; }
+    public String getTag() { return tag; }
+
+    @Override public void setGains(double kp, double ki, double kd) { this.kp = kp; this.ki = ki; this.kd = kd; }
+    @Override public double getKp() { return kp; }
+    @Override public double getKi() { return ki; }
+    @Override public double getKd() { return kd; }
+
+    @Override public void scaleGains(double factor) {
+        kp *= factor;
+        ki *= factor;
+        kd *= factor;
+    }
+
+    @Override public void setSetpoint(SetpointSignal s) { if (s != null) this.setpoint = s.getSetpoint(); }
+    @Override public double getSetpoint() { return setpoint; }
+    @Override public void setOutputLimits(double min, double max) {
+        this.outMin = Math.min(min, max);
+        this.outMax = Math.max(min, max);
+    }
+
+    @Override
+    public ActuatorCommandSignal step(MeasurementSignal m, double dtSeconds) {
+        if (m == null || dtSeconds <= 0) return null;
+        double err = setpoint - m.getMeasurement();
+        integrator += ki * err * dtSeconds;
+        if (integrator > outMax) integrator = outMax;
+        if (integrator < outMin) integrator = outMin;
+        double derivative = hasPrev ? (err - lastError) / dtSeconds : 0.0;
+        double output = kp * err + integrator + kd * derivative;
+        if (output > outMax) output = outMax;
+        if (output < outMin) output = outMin;
+        lastError = err;
+        lastOutput = output;
+        hasPrev = true;
+        return new ActuatorCommandSignal(tag, output, m.getMeasurement(), true);
+    }
+
+    @Override public void reset() {
+        integrator = 0;
+        lastError = 0;
+        lastOutput = 0;
+        hasPrev = false;
+    }
+
+    @Override public double getLastError() { return lastError; }
+    @Override public double getLastOutput() { return lastOutput; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/PlantMode.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/PlantMode.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+/** Supervisory plant-mode state machine. */
+public enum PlantMode { STARTUP, NORMAL, SHUTDOWN, EMERGENCY }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ProcessModelNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ProcessModelNeuron.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 3 first-order-plus-dead-time process model. {@code predict}
+ * returns the value {@code horizonTicks} ahead under a sustained
+ * {@code controlInput}. Loop=2 / Epoch=1.
+ */
+public class ProcessModelNeuron extends ModulatableNeuron implements IProcessModelNeuron {
+
+    private static final class Params { double k = 1.0; int deadTicks; double tauTicks = 1.0; }
+
+    private final Map<String, Params> byTag = new HashMap<>();
+
+    public ProcessModelNeuron() { super(); }
+    public ProcessModelNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    private Params p(String tag) { return byTag.computeIfAbsent(tag, k -> new Params()); }
+
+    @Override public void setGain(String tag, double k) { if (tag != null) p(tag).k = k; }
+    @Override public void setDeadTimeTicks(String tag, int dtTicks) { if (tag != null) p(tag).deadTicks = Math.max(0, dtTicks); }
+    @Override public void setTimeConstantTicks(String tag, double tauTicks) { if (tag != null) p(tag).tauTicks = Math.max(1e-6, tauTicks); }
+
+    @Override
+    public double predict(String tag, double controlInput, int horizonTicks) {
+        Params pp = byTag.get(tag);
+        if (pp == null) return controlInput;
+        int after = Math.max(0, horizonTicks - pp.deadTicks);
+        double response = 1.0 - Math.exp(-after / pp.tauTicks);
+        return pp.k * controlInput * response;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ProductQualityModelNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/ProductQualityModelNeuron.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+
+/**
+ * Layer 3 product-quality model. Compliance probability is derived
+ * from the distance between a summary statistic of {@code conditions}
+ * and the configured {@code target}. Loop=2 / Epoch=2.
+ */
+public class ProductQualityModelNeuron extends ModulatableNeuron implements IProductQualityModelNeuron {
+
+    private double target;
+    private double tolerance = 1.0;
+
+    public ProductQualityModelNeuron() { super(); }
+    public ProductQualityModelNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void setTarget(double target) { this.target = target; }
+    @Override public void setTolerance(double tol) { this.tolerance = Math.max(1e-6, tol); }
+
+    @Override
+    public double predictCompliance(double[] conditions) {
+        if (conditions == null || conditions.length == 0) return 0.0;
+        double mean = 0.0;
+        for (double v : conditions) mean += v;
+        mean /= conditions.length;
+        double dev = Math.abs(mean - target) / tolerance;
+        return Math.max(0.0, Math.min(1.0, 1.0 - dev));
+    }
+
+    @Override public boolean inSpec(double[] conditions) { return predictCompliance(conditions) >= 0.5; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/Quality.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/Quality.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+/** Quality flag per OPC-UA convention. */
+public enum Quality { GOOD, BAD, UNCERTAIN }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/SafetyGateNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/SafetyGateNeuron.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 5 harm gate — per-loop shadow / advisory / autonomous mode
+ * control per spec §7. SHADOW downgrades {@code execute} to false;
+ * ADVISORY passes through unchanged (physician / operator confirms
+ * downstream); AUTONOMOUS allows free execution. Loop=1 / Epoch=1.
+ */
+public class SafetyGateNeuron extends ModulatableNeuron implements ISafetyGateNeuron {
+
+    private final Map<String, SafetyMode> perTag = new HashMap<>();
+    private SafetyMode defaultMode = SafetyMode.ADVISORY;
+
+    public SafetyGateNeuron() { super(); }
+    public SafetyGateNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void setModeFor(String tag, SafetyMode mode) {
+        if (tag != null && mode != null) perTag.put(tag, mode);
+    }
+    @Override public SafetyMode modeFor(String tag) { return perTag.getOrDefault(tag, defaultMode); }
+    @Override public SafetyMode defaultMode() { return defaultMode; }
+    @Override public void setDefaultMode(SafetyMode m) { if (m != null) this.defaultMode = m; }
+
+    @Override
+    public ActuatorCommandSignal gate(ActuatorCommandSignal cmd) {
+        if (cmd == null) return null;
+        SafetyMode m = modeFor(cmd.getTag());
+        ActuatorCommandSignal out = new ActuatorCommandSignal(
+                cmd.getTag(), cmd.getTargetValue(), cmd.getCurrentValue(),
+                m == SafetyMode.AUTONOMOUS || (m == SafetyMode.ADVISORY && cmd.isExecute()));
+        if (m == SafetyMode.SHADOW) out.setExecute(false);
+        return out;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/SafetyMode.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/SafetyMode.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+/** Per-loop deployment mode per spec §7. */
+public enum SafetyMode { SHADOW, ADVISORY, AUTONOMOUS }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/SensorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/SensorNeuron.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+/**
+ * Layer 0 sensor reader. Quality-aware; emits one {@link MeasurementSignal}
+ * per accepted sample. Biological analogue: peripheral receptor.
+ * Loop=1 / Epoch=1.
+ */
+public class SensorNeuron extends ModulatableNeuron implements ISensorNeuron {
+
+    private long reads;
+
+    public SensorNeuron() { super(); }
+    public SensorNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override
+    public MeasurementSignal read(String tag, double value, Quality quality, long timestamp) {
+        reads++;
+        return new MeasurementSignal(tag, value, quality, timestamp);
+    }
+
+    @Override public long getReads() { return reads; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/SetpointOptimiserNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/SetpointOptimiserNeuron.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.EfficiencySignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 2 setpoint optimiser. Nudges a setpoint up / down in response
+ * to an efficiency signal deviation from baseline, clamped by
+ * configurable range constraints. Loop=1 / Epoch=3.
+ */
+public class SetpointOptimiserNeuron extends ModulatableNeuron implements ISetpointOptimiserNeuron {
+
+    private static final class Range { double min, max; Range(double l,double h){min=l;max=h;} }
+    private final Map<String, Range> constraints = new HashMap<>();
+    private double step = 0.01;
+
+    public SetpointOptimiserNeuron() { super(); }
+    public SetpointOptimiserNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void setConstraint(String tag, double min, double max) {
+        if (tag != null) constraints.put(tag, new Range(Math.min(min, max), Math.max(min, max)));
+    }
+    @Override public void setStep(double step) { this.step = Math.max(0.0, step); }
+
+    @Override
+    public SetpointSignal optimise(EfficiencySignal eff, String tag, double currentSetpoint) {
+        if (eff == null || tag == null) return null;
+        double delta = eff.getEfficiency() - eff.getBaseline();
+        double proposed = currentSetpoint + Math.signum(delta) * step;
+        Range r = constraints.get(tag);
+        if (r != null) {
+            if (proposed < r.min) proposed = r.min;
+            if (proposed > r.max) proposed = r.max;
+        }
+        return new SetpointSignal(tag, proposed, 0.0, "optimiser");
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * Industrial process control &amp; digital twin module. Implements
+ * {@code use-case-industrial-process-control.md}: regulatory control
+ * (PID, cascade, feed-forward), supervisory layer (setpoint optimiser,
+ * alarm aggregation, plant-mode state machine), process / degradation
+ * / product-quality models, MPC and campaign planning, safety gate /
+ * actuator with operator override, hard-wired interlocks, oscillation
+ * monitor with graduated interventions, and energy accounting.
+ *
+ * <p>Architectural invariants enforced at the package level:
+ * <ul>
+ *   <li>Operator override always wins for regulatory control; an
+ *       interlock trip always wins for safety.
+ *       {@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.ActuatorNeuron}
+ *       honours the most-recent
+ *       {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.OperatorOverrideSignal}.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.InterlockNeuron}
+ *       rules are compiled at construction; {@code addInterlock} throws
+ *       after {@code seal()} — the SRS is immutable at runtime.</li>
+ *   <li>Per-loop deployment mode is
+ *       {@code SHADOW / ADVISORY / AUTONOMOUS}; the SafetyGate
+ *       downgrades {@code execute} accordingly (spec §7).</li>
+ * </ul>
+ *
+ * @see com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/ActuatorCommandSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/ActuatorCommandSignal.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Actuator command. {@code execute=false} means shadow-mode — the
+ * signal is logged and compared but not written to the field.
+ * ProcessingFrequency: loop=1, epoch=1.
+ */
+public class ActuatorCommandSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private String tag;
+    private double targetValue;
+    private double currentValue;
+    private boolean execute;
+
+    public ActuatorCommandSignal() { super(); this.loop = 1; this.epoch = 1L; this.timeAlive = 30; }
+
+    public ActuatorCommandSignal(String tag, double targetValue, double currentValue, boolean execute) {
+        this();
+        this.tag = tag;
+        this.targetValue = targetValue;
+        this.currentValue = currentValue;
+        this.execute = execute;
+    }
+
+    public String getTag() { return tag; }
+    public void setTag(String t) { this.tag = t; }
+    public double getTargetValue() { return targetValue; }
+    public void setTargetValue(double v) { this.targetValue = v; }
+    public double getCurrentValue() { return currentValue; }
+    public void setCurrentValue(double v) { this.currentValue = v; }
+    public boolean isExecute() { return execute; }
+    public void setExecute(boolean e) { this.execute = e; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return ActuatorCommandSignal.class; }
+    @Override public String getDescription() { return "ActuatorCommandSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        ActuatorCommandSignal c = new ActuatorCommandSignal(tag, targetValue, currentValue, execute);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/AlarmSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/AlarmSignal.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmPriority;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * ISA-18.2 alarm with a priority and a condition code.
+ * ProcessingFrequency: loop=1, epoch=1.
+ */
+public class AlarmSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private AlarmPriority priority;
+    private String tag;
+    private String conditionCode;
+    private long timestamp;
+
+    public AlarmSignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 1L;
+        this.timeAlive = 100;
+        this.priority = AlarmPriority.JOURNAL;
+    }
+
+    public AlarmSignal(AlarmPriority priority, String tag, String conditionCode, long timestamp) {
+        this();
+        this.priority = priority == null ? AlarmPriority.JOURNAL : priority;
+        this.tag = tag;
+        this.conditionCode = conditionCode;
+        this.timestamp = timestamp;
+    }
+
+    public AlarmPriority getPriority() { return priority; }
+    public void setPriority(AlarmPriority p) { this.priority = p == null ? AlarmPriority.JOURNAL : p; }
+    public String getTag() { return tag; }
+    public void setTag(String t) { this.tag = t; }
+    public String getConditionCode() { return conditionCode; }
+    public void setConditionCode(String c) { this.conditionCode = c; }
+    public long getTimestamp() { return timestamp; }
+    public void setTimestamp(long t) { this.timestamp = t; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return AlarmSignal.class; }
+    @Override public String getDescription() { return "AlarmSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        AlarmSignal c = new AlarmSignal(priority, tag, conditionCode, timestamp);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/BatchStateSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/BatchStateSignal.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.BatchPhase;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * ISA-88 batch state snapshot with key metrics. ProcessingFrequency:
+ * loop=2, epoch=2.
+ */
+public class BatchStateSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 2);
+
+    private String batchId;
+    private BatchPhase phase;
+    private Map<String, Double> keyMetrics;
+
+    public BatchStateSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 2L;
+        this.timeAlive = 1000;
+        this.phase = BatchPhase.IDLE;
+        this.keyMetrics = new HashMap<>();
+    }
+
+    public BatchStateSignal(String batchId, BatchPhase phase, Map<String, Double> keyMetrics) {
+        this();
+        this.batchId = batchId;
+        this.phase = phase == null ? BatchPhase.IDLE : phase;
+        this.keyMetrics = keyMetrics == null ? new HashMap<>() : new HashMap<>(keyMetrics);
+    }
+
+    public String getBatchId() { return batchId; }
+    public void setBatchId(String b) { this.batchId = b; }
+    public BatchPhase getPhase() { return phase; }
+    public void setPhase(BatchPhase p) { this.phase = p == null ? BatchPhase.IDLE : p; }
+    public Map<String, Double> getKeyMetrics() { return Collections.unmodifiableMap(keyMetrics); }
+    public void setKeyMetrics(Map<String, Double> m) {
+        this.keyMetrics = m == null ? new HashMap<>() : new HashMap<>(m);
+    }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return BatchStateSignal.class; }
+    @Override public String getDescription() { return "BatchStateSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        BatchStateSignal c = new BatchStateSignal(batchId, phase, keyMetrics);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/DegradationSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/DegradationSignal.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Remaining-useful-life estimate for an asset (fatigue, corrosion,
+ * catalyst age). ProcessingFrequency: loop=2, epoch=3.
+ */
+public class DegradationSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(3L, 2);
+
+    private String assetId;
+    private double remainingUsefulLifeHours;
+    private double confidence;
+
+    public DegradationSignal() { super(); this.loop = 2; this.epoch = 3L; this.timeAlive = 10_000; }
+
+    public DegradationSignal(String assetId, double remainingUsefulLifeHours, double confidence) {
+        this();
+        this.assetId = assetId;
+        this.remainingUsefulLifeHours = Math.max(0.0, remainingUsefulLifeHours);
+        this.confidence = Math.max(0.0, Math.min(1.0, confidence));
+    }
+
+    public String getAssetId() { return assetId; }
+    public void setAssetId(String a) { this.assetId = a; }
+    public double getRemainingUsefulLifeHours() { return remainingUsefulLifeHours; }
+    public void setRemainingUsefulLifeHours(double r) { this.remainingUsefulLifeHours = Math.max(0.0, r); }
+    public double getConfidence() { return confidence; }
+    public void setConfidence(double c) { this.confidence = Math.max(0.0, Math.min(1.0, c)); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return DegradationSignal.class; }
+    @Override public String getDescription() { return "DegradationSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        DegradationSignal c = new DegradationSignal(assetId, remainingUsefulLifeHours, confidence);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/EfficiencySignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/EfficiencySignal.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Per-unit efficiency measurement with its baseline.
+ * ProcessingFrequency: loop=2, epoch=1.
+ */
+public class EfficiencySignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 2);
+
+    private String unitId;
+    private double efficiency;
+    private double baseline;
+
+    public EfficiencySignal() { super(); this.loop = 2; this.epoch = 1L; this.timeAlive = 300; }
+
+    public EfficiencySignal(String unitId, double efficiency, double baseline) {
+        this();
+        this.unitId = unitId;
+        this.efficiency = efficiency;
+        this.baseline = baseline;
+    }
+
+    public String getUnitId() { return unitId; }
+    public void setUnitId(String u) { this.unitId = u; }
+    public double getEfficiency() { return efficiency; }
+    public void setEfficiency(double e) { this.efficiency = e; }
+    public double getBaseline() { return baseline; }
+    public void setBaseline(double b) { this.baseline = b; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return EfficiencySignal.class; }
+    @Override public String getDescription() { return "EfficiencySignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        EfficiencySignal c = new EfficiencySignal(unitId, efficiency, baseline);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/InterlockSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/InterlockSignal.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Hard-wired interlock trip signal. Per spec §5 every trip also emits
+ * a TransparencyLogSignal at the dispatch layer.
+ * ProcessingFrequency: loop=1, epoch=1.
+ */
+public class InterlockSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private String interlockId;
+    private boolean tripped;
+    private List<String> causes;
+
+    public InterlockSignal() { super(); this.loop = 1; this.epoch = 1L; this.timeAlive = 30; this.causes = new ArrayList<>(); }
+
+    public InterlockSignal(String interlockId, boolean tripped, List<String> causes) {
+        this();
+        this.interlockId = interlockId;
+        this.tripped = tripped;
+        this.causes = causes == null ? new ArrayList<>() : new ArrayList<>(causes);
+    }
+
+    public String getInterlockId() { return interlockId; }
+    public void setInterlockId(String i) { this.interlockId = i; }
+    public boolean isTripped() { return tripped; }
+    public void setTripped(boolean t) { this.tripped = t; }
+    public List<String> getCauses() { return Collections.unmodifiableList(causes); }
+    public void setCauses(List<String> c) { this.causes = c == null ? new ArrayList<>() : new ArrayList<>(c); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return InterlockSignal.class; }
+    @Override public String getDescription() { return "InterlockSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        InterlockSignal c = new InterlockSignal(interlockId, tripped, causes);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/MaintenanceWindowSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/MaintenanceWindowSignal.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Scheduled maintenance window for an asset. ProcessingFrequency:
+ * loop=2, epoch=10.
+ */
+public class MaintenanceWindowSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(10L, 2);
+
+    private String assetId;
+    private long scheduledTick;
+    private int durationTicks;
+
+    public MaintenanceWindowSignal() { super(); this.loop = 2; this.epoch = 10L; this.timeAlive = 100_000; }
+
+    public MaintenanceWindowSignal(String assetId, long scheduledTick, int durationTicks) {
+        this();
+        this.assetId = assetId;
+        this.scheduledTick = scheduledTick;
+        this.durationTicks = Math.max(1, durationTicks);
+    }
+
+    public String getAssetId() { return assetId; }
+    public void setAssetId(String a) { this.assetId = a; }
+    public long getScheduledTick() { return scheduledTick; }
+    public void setScheduledTick(long s) { this.scheduledTick = s; }
+    public int getDurationTicks() { return durationTicks; }
+    public void setDurationTicks(int d) { this.durationTicks = Math.max(1, d); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return MaintenanceWindowSignal.class; }
+    @Override public String getDescription() { return "MaintenanceWindowSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        MaintenanceWindowSignal c = new MaintenanceWindowSignal(assetId, scheduledTick, durationTicks);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/MeasurementSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/MeasurementSignal.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.Quality;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * A field measurement read from a sensor. {@code tag} is an ISA-95
+ * reference (process-area/unit/loop). {@code timestamp} is wall-clock
+ * in epoch-millis; per spec §3 industrial compliance requires this in
+ * addition to the jneopallium tick.
+ * ProcessingFrequency: loop=1, epoch=1.
+ */
+public class MeasurementSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private String tag;
+    private double value;
+    private Quality quality;
+    private long timestamp;
+
+    public MeasurementSignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 1L;
+        this.timeAlive = 30;
+        this.quality = Quality.GOOD;
+    }
+
+    public MeasurementSignal(String tag, double value, Quality quality, long timestamp) {
+        this();
+        this.tag = tag;
+        this.value = value;
+        this.quality = quality == null ? Quality.UNCERTAIN : quality;
+        this.timestamp = timestamp;
+    }
+
+    public String getTag() { return tag; }
+    public void setTag(String t) { this.tag = t; }
+    public double getMeasurement() { return value; }
+    public void setMeasurement(double v) { this.value = v; }
+    public Quality getQuality() { return quality; }
+    public void setQuality(Quality q) { this.quality = q == null ? Quality.UNCERTAIN : q; }
+    public long getTimestamp() { return timestamp; }
+    public void setTimestamp(long t) { this.timestamp = t; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return MeasurementSignal.class; }
+    @Override public String getDescription() { return "MeasurementSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        MeasurementSignal c = new MeasurementSignal(tag, value, quality, timestamp);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/OperatorOverrideSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/OperatorOverrideSignal.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.OverrideKind;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Operator override. Per spec §5 operator override always wins for
+ * regulatory control; it does not affect interlocks. ProcessingFrequency:
+ * loop=1, epoch=1.
+ */
+public class OperatorOverrideSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private String tag;
+    private OverrideKind kind;
+    private String operatorId;
+    private String reason;
+    private double manualValue;
+
+    public OperatorOverrideSignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 1L;
+        this.timeAlive = 30;
+        this.kind = OverrideKind.MANUAL;
+    }
+
+    public OperatorOverrideSignal(String tag, OverrideKind kind, String operatorId, String reason, double manualValue) {
+        this();
+        this.tag = tag;
+        this.kind = kind == null ? OverrideKind.MANUAL : kind;
+        this.operatorId = operatorId;
+        this.reason = reason;
+        this.manualValue = manualValue;
+    }
+
+    public String getTag() { return tag; }
+    public void setTag(String t) { this.tag = t; }
+    public OverrideKind getKind() { return kind; }
+    public void setKind(OverrideKind k) { this.kind = k == null ? OverrideKind.MANUAL : k; }
+    public String getOperatorId() { return operatorId; }
+    public void setOperatorId(String o) { this.operatorId = o; }
+    public String getReason() { return reason; }
+    public void setReason(String r) { this.reason = r; }
+    public double getManualValue() { return manualValue; }
+    public void setManualValue(double v) { this.manualValue = v; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return OperatorOverrideSignal.class; }
+    @Override public String getDescription() { return "OperatorOverrideSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        OperatorOverrideSignal c = new OperatorOverrideSignal(tag, kind, operatorId, reason, manualValue);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/SetpointSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/SetpointSignal.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Setpoint update for a control loop with an optional ramp rate.
+ * ProcessingFrequency: loop=1, epoch=2.
+ */
+public class SetpointSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
+
+    private String tag;
+    private double setpoint;
+    private double rampRate;
+    private String source;
+
+    public SetpointSignal() { super(); this.loop = 1; this.epoch = 2L; this.timeAlive = 100; }
+
+    public SetpointSignal(String tag, double setpoint, double rampRate, String source) {
+        this();
+        this.tag = tag;
+        this.setpoint = setpoint;
+        this.rampRate = rampRate;
+        this.source = source;
+    }
+
+    public String getTag() { return tag; }
+    public void setTag(String t) { this.tag = t; }
+    public double getSetpoint() { return setpoint; }
+    public void setSetpoint(double v) { this.setpoint = v; }
+    public double getRampRate() { return rampRate; }
+    public void setRampRate(double r) { this.rampRate = r; }
+    public String getSource() { return source; }
+    public void setSource(String s) { this.source = s; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return SetpointSignal.class; }
+    @Override public String getDescription() { return "SetpointSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        SetpointSignal c = new SetpointSignal(tag, setpoint, rampRate, source);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * Domain signals for the industrial process-control module. Measurement
+ * and actuator-command signals run on the fast loop (1/1); setpoints
+ * and alarms on 1/2; interlocks at 1/1; efficiency, batch-state,
+ * degradation, and maintenance-window signals live on the slow loop so
+ * the scheduler keeps regulatory latency low. Every signal carries a
+ * wall-clock timestamp in addition to the jneopallium tick, per spec §3.
+ *
+ * @see com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/ActuatorDispatchProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/ActuatorDispatchProcessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.IActuatorNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: dispatches a gated {@link ActuatorCommandSignal}
+ * to the field. Operator overrides held on the actuator neuron take
+ * precedence over the command (spec §5: override always wins).
+ */
+public class ActuatorDispatchProcessor implements ISignalProcessor<ActuatorCommandSignal, IActuatorNeuron> {
+
+    private static final String DESCRIPTION = "Field-layer actuator dispatch (override-aware)";
+
+    @Override
+    public <I extends ISignal> List<I> process(ActuatorCommandSignal input, IActuatorNeuron neuron) {
+        if (input != null && neuron != null) neuron.dispatch(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return ActuatorDispatchProcessor.class; }
+    @Override public Class<IActuatorNeuron> getNeuronClass() { return IActuatorNeuron.class; }
+    @Override public Class<ActuatorCommandSignal> getSignalClass() { return ActuatorCommandSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/ActuatorSafetyGateProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/ActuatorSafetyGateProcessor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.ISafetyGateNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: every proposed {@link ActuatorCommandSignal}
+ * passes through the safety gate, which downgrades execute=false in
+ * SHADOW mode and passes unchanged otherwise.
+ */
+public class ActuatorSafetyGateProcessor implements ISignalProcessor<ActuatorCommandSignal, ISafetyGateNeuron> {
+
+    private static final String DESCRIPTION = "Per-loop safety gate (shadow / advisory / autonomous)";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(ActuatorCommandSignal input, ISafetyGateNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        ActuatorCommandSignal gated = neuron.gate(input);
+        if (gated != null) out.add((I) gated);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return ActuatorSafetyGateProcessor.class; }
+    @Override public Class<ISafetyGateNeuron> getNeuronClass() { return ISafetyGateNeuron.class; }
+    @Override public Class<ActuatorCommandSignal> getSignalClass() { return ActuatorCommandSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/AlarmAggregationProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/AlarmAggregationProcessor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.IAlarmAggregationNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: passes a raw {@link AlarmSignal} through the
+ * ISA-18.2 aggregator. Suppressed standing alarms are dropped; the
+ * rest are forwarded.
+ */
+public class AlarmAggregationProcessor implements ISignalProcessor<AlarmSignal, IAlarmAggregationNeuron> {
+
+    private static final String DESCRIPTION = "ISA-18.2 alarm aggregation and suppression";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(AlarmSignal input, IAlarmAggregationNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        AlarmSignal forwarded = neuron.observe(input);
+        if (forwarded != null) out.add((I) forwarded);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return AlarmAggregationProcessor.class; }
+    @Override public Class<IAlarmAggregationNeuron> getNeuronClass() { return IAlarmAggregationNeuron.class; }
+    @Override public Class<AlarmSignal> getSignalClass() { return AlarmSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/BatchModeProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/BatchModeProcessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.IModeControllerNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.BatchStateSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: informs the plant-mode state machine of batch
+ * phase transitions (ISA-88).
+ */
+public class BatchModeProcessor implements ISignalProcessor<BatchStateSignal, IModeControllerNeuron> {
+
+    private static final String DESCRIPTION = "Batch-phase-driven plant-mode transition";
+
+    @Override
+    public <I extends ISignal> List<I> process(BatchStateSignal input, IModeControllerNeuron neuron) {
+        if (input != null && neuron != null) neuron.onBatchState(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return BatchModeProcessor.class; }
+    @Override public Class<IModeControllerNeuron> getNeuronClass() { return IModeControllerNeuron.class; }
+    @Override public Class<BatchStateSignal> getSignalClass() { return BatchStateSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/DegradationSchedulingProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/DegradationSchedulingProcessor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.IMaintenanceSchedulingNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.DegradationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MaintenanceWindowSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: forwards a {@link DegradationSignal} into the
+ * maintenance scheduler and emits the proposed window.
+ */
+public class DegradationSchedulingProcessor implements ISignalProcessor<DegradationSignal, IMaintenanceSchedulingNeuron> {
+
+    private static final String DESCRIPTION = "RUL-driven maintenance scheduling";
+
+    private long leadTimeTicks = 10_000L;
+
+    public void setLeadTimeTicks(long t) { this.leadTimeTicks = Math.max(0L, t); }
+    public long getLeadTimeTicks() { return leadTimeTicks; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(DegradationSignal input, IMaintenanceSchedulingNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        MaintenanceWindowSignal w = neuron.schedule(input, input.getEpoch(), leadTimeTicks);
+        if (w != null) out.add((I) w);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return DegradationSchedulingProcessor.class; }
+    @Override public Class<IMaintenanceSchedulingNeuron> getNeuronClass() { return IMaintenanceSchedulingNeuron.class; }
+    @Override public Class<DegradationSignal> getSignalClass() { return DegradationSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/EfficiencyOptimiserProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/EfficiencyOptimiserProcessor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.ISetpointOptimiserNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.EfficiencySignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: turns an {@link EfficiencySignal} into a proposed
+ * {@link SetpointSignal} nudge via the setpoint optimiser. The target
+ * tag and the current setpoint must be supplied by the caller; this
+ * implementation uses the unit id as tag and a current setpoint of zero
+ * as a neutral default (a real deployment injects a factory).
+ */
+public class EfficiencyOptimiserProcessor implements ISignalProcessor<EfficiencySignal, ISetpointOptimiserNeuron> {
+
+    private static final String DESCRIPTION = "Efficiency-driven setpoint optimiser";
+
+    private double currentSetpoint;
+
+    public void setCurrentSetpoint(double v) { this.currentSetpoint = v; }
+    public double getCurrentSetpoint() { return currentSetpoint; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(EfficiencySignal input, ISetpointOptimiserNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null || input.getUnitId() == null) return out;
+        SetpointSignal sp = neuron.optimise(input, input.getUnitId(), currentSetpoint);
+        if (sp != null) out.add((I) sp);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return EfficiencyOptimiserProcessor.class; }
+    @Override public Class<ISetpointOptimiserNeuron> getNeuronClass() { return ISetpointOptimiserNeuron.class; }
+    @Override public Class<EfficiencySignal> getSignalClass() { return EfficiencySignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/InterlockModeProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/InterlockModeProcessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.IModeControllerNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.InterlockSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: any interlock trip forces the plant-mode state
+ * machine into EMERGENCY.
+ */
+public class InterlockModeProcessor implements ISignalProcessor<InterlockSignal, IModeControllerNeuron> {
+
+    private static final String DESCRIPTION = "Interlock-driven plant-mode transition";
+
+    @Override
+    public <I extends ISignal> List<I> process(InterlockSignal input, IModeControllerNeuron neuron) {
+        if (input != null && neuron != null) neuron.onInterlock(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return InterlockModeProcessor.class; }
+    @Override public Class<IModeControllerNeuron> getNeuronClass() { return IModeControllerNeuron.class; }
+    @Override public Class<InterlockSignal> getSignalClass() { return InterlockSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/MaintenanceWindowSchedulingProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/MaintenanceWindowSchedulingProcessor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.IMaintenanceSchedulingNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.DegradationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MaintenanceWindowSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: echoes an external {@link MaintenanceWindowSignal}
+ * back through the scheduler (e.g. a technician-entered window) so
+ * bookkeeping stays consistent. Re-emits the signal unchanged for any
+ * downstream consumer.
+ */
+public class MaintenanceWindowSchedulingProcessor implements ISignalProcessor<MaintenanceWindowSignal, IMaintenanceSchedulingNeuron> {
+
+    private static final String DESCRIPTION = "External maintenance-window registration";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(MaintenanceWindowSignal input, IMaintenanceSchedulingNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        // Record via a synthetic DegradationSignal so the scheduler
+        // increments its per-asset counter through the same code path.
+        neuron.schedule(new DegradationSignal(input.getAssetId(), 0.0, 1.0),
+                input.getScheduledTick(), neuron.getMinLeadTimeTicks());
+        out.add((I) input);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return MaintenanceWindowSchedulingProcessor.class; }
+    @Override public Class<IMaintenanceSchedulingNeuron> getNeuronClass() { return IMaintenanceSchedulingNeuron.class; }
+    @Override public Class<MaintenanceWindowSignal> getSignalClass() { return MaintenanceWindowSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/MeasurementInterlockProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/MeasurementInterlockProcessor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.IInterlockNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.InterlockSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: evaluates the hard-wired interlock rules against
+ * every incoming measurement and forwards any trip signals. Fail-safe
+ * actuator commands produced by the same evaluation are retrieved
+ * separately by the caller via {@link IInterlockNeuron#failSafeCommands()}.
+ */
+public class MeasurementInterlockProcessor implements ISignalProcessor<MeasurementSignal, IInterlockNeuron> {
+
+    private static final String DESCRIPTION = "Hard-wired interlock evaluation";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(MeasurementSignal input, IInterlockNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        List<InterlockSignal> trips = neuron.evaluate(input);
+        if (trips != null) for (InterlockSignal t : trips) if (t != null) out.add((I) t);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return MeasurementInterlockProcessor.class; }
+    @Override public Class<IInterlockNeuron> getNeuronClass() { return IInterlockNeuron.class; }
+    @Override public Class<MeasurementSignal> getSignalClass() { return MeasurementSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/MeasurementOscillationProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/MeasurementOscillationProcessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.IOscillationMonitorNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: feeds a {@link MeasurementSignal} into the
+ * oscillation monitor's ACF window. Emits nothing; the intervention
+ * band is read on demand by a supervisory controller.
+ */
+public class MeasurementOscillationProcessor implements ISignalProcessor<MeasurementSignal, IOscillationMonitorNeuron> {
+
+    private static final String DESCRIPTION = "ACF oscillation monitor update";
+
+    @Override
+    public <I extends ISignal> List<I> process(MeasurementSignal input, IOscillationMonitorNeuron neuron) {
+        if (input != null && neuron != null) neuron.observe(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return MeasurementOscillationProcessor.class; }
+    @Override public Class<IOscillationMonitorNeuron> getNeuronClass() { return IOscillationMonitorNeuron.class; }
+    @Override public Class<MeasurementSignal> getSignalClass() { return MeasurementSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/MeasurementPIDProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/MeasurementPIDProcessor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.IPIDNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: drives a PID step from a fresh measurement and
+ * forwards the resulting actuator command. Loop period is inferred
+ * from the measurement's epoch delta via a configurable default.
+ */
+public class MeasurementPIDProcessor implements ISignalProcessor<MeasurementSignal, IPIDNeuron> {
+
+    private static final String DESCRIPTION = "PID controller measurement→actuator step";
+
+    private double dtSeconds = 0.01;
+
+    public void setDtSeconds(double dt) { this.dtSeconds = Math.max(1e-6, dt); }
+    public double getDtSeconds() { return dtSeconds; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(MeasurementSignal input, IPIDNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        ActuatorCommandSignal cmd = neuron.step(input, dtSeconds);
+        if (cmd != null) out.add((I) cmd);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return MeasurementPIDProcessor.class; }
+    @Override public Class<IPIDNeuron> getNeuronClass() { return IPIDNeuron.class; }
+    @Override public Class<MeasurementSignal> getSignalClass() { return MeasurementSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/MeasurementValidationProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/MeasurementValidationProcessor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.IMeasurementValidatorNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: passes every {@link MeasurementSignal} through
+ * an {@link IMeasurementValidatorNeuron} (range / rate-of-change
+ * check). The signal is always forwarded — quality may have been
+ * downgraded in place — because in industrial control a dropped
+ * measurement is worse than a flagged one.
+ */
+public class MeasurementValidationProcessor implements ISignalProcessor<MeasurementSignal, IMeasurementValidatorNeuron> {
+
+    private static final String DESCRIPTION = "Range / rate-of-change measurement validation";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(MeasurementSignal input, IMeasurementValidatorNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        MeasurementSignal validated = neuron.validate(input);
+        if (validated != null) out.add((I) validated);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return MeasurementValidationProcessor.class; }
+    @Override public Class<IMeasurementValidatorNeuron> getNeuronClass() { return IMeasurementValidatorNeuron.class; }
+    @Override public Class<MeasurementSignal> getSignalClass() { return MeasurementSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/OperatorOverrideProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/OperatorOverrideProcessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.IActuatorNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.OperatorOverrideSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: registers an {@link OperatorOverrideSignal} on
+ * the actuator neuron. Per spec §5 override always wins for regulatory
+ * control.
+ */
+public class OperatorOverrideProcessor implements ISignalProcessor<OperatorOverrideSignal, IActuatorNeuron> {
+
+    private static final String DESCRIPTION = "Operator-override registration on the actuator";
+
+    @Override
+    public <I extends ISignal> List<I> process(OperatorOverrideSignal input, IActuatorNeuron neuron) {
+        if (input != null && neuron != null) neuron.onOverride(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return OperatorOverrideProcessor.class; }
+    @Override public Class<IActuatorNeuron> getNeuronClass() { return IActuatorNeuron.class; }
+    @Override public Class<OperatorOverrideSignal> getSignalClass() { return OperatorOverrideSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/SetpointPIDProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/SetpointPIDProcessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.IPIDNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: forwards a new {@link SetpointSignal} to the
+ * PID neuron. The PID holds the setpoint until the next measurement
+ * triggers a step.
+ */
+public class SetpointPIDProcessor implements ISignalProcessor<SetpointSignal, IPIDNeuron> {
+
+    private static final String DESCRIPTION = "PID setpoint update";
+
+    @Override
+    public <I extends ISignal> List<I> process(SetpointSignal input, IPIDNeuron neuron) {
+        if (input != null && neuron != null) neuron.setSetpoint(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return SetpointPIDProcessor.class; }
+    @Override public Class<IPIDNeuron> getNeuronClass() { return IPIDNeuron.class; }
+    @Override public Class<SetpointSignal> getSignalClass() { return SetpointSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/industrial/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * Stateless signal processors for the industrial process-control module.
+ * Every processor's {@code getNeuronClass()} returns an {@code I<Neuron>}
+ * interface from
+ * {@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial};
+ * concrete neurons are dependency-injected at network construction time.
+ *
+ * <p>Signal → processor coverage:
+ * <ul>
+ *   <li>MeasurementSignal → MeasurementValidationProcessor,
+ *       MeasurementPIDProcessor, MeasurementOscillationProcessor,
+ *       MeasurementInterlockProcessor</li>
+ *   <li>SetpointSignal → SetpointPIDProcessor</li>
+ *   <li>ActuatorCommandSignal → ActuatorSafetyGateProcessor,
+ *       ActuatorDispatchProcessor</li>
+ *   <li>AlarmSignal → AlarmAggregationProcessor</li>
+ *   <li>InterlockSignal → InterlockModeProcessor</li>
+ *   <li>DegradationSignal → DegradationSchedulingProcessor</li>
+ *   <li>EfficiencySignal → EfficiencyOptimiserProcessor</li>
+ *   <li>BatchStateSignal → BatchModeProcessor</li>
+ *   <li>OperatorOverrideSignal → OperatorOverrideProcessor</li>
+ *   <li>MaintenanceWindowSignal → MaintenanceWindowSchedulingProcessor</li>
+ * </ul>
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial;

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IndustrialModuleTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/IndustrialModuleTest.java
@@ -1,0 +1,416 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.BatchStateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.DegradationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.EfficiencySignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.InterlockSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MaintenanceWindowSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.OperatorOverrideSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial.ActuatorDispatchProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial.ActuatorSafetyGateProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial.AlarmAggregationProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial.BatchModeProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial.DegradationSchedulingProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial.EfficiencyOptimiserProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial.InterlockModeProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial.MaintenanceWindowSchedulingProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial.MeasurementInterlockProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial.MeasurementOscillationProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial.MeasurementPIDProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial.MeasurementValidationProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial.OperatorOverrideProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.industrial.SetpointPIDProcessor;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IndustrialModuleTest {
+
+    // ---------- enums ----------
+
+    @Test
+    void enums_cardinality() {
+        assertEquals(3, Quality.values().length);
+        assertEquals(4, AlarmPriority.values().length);
+        assertEquals(7, BatchPhase.values().length);
+        assertEquals(2, OverrideKind.values().length);
+        assertEquals(4, PlantMode.values().length);
+        assertEquals(3, SafetyMode.values().length);
+        assertEquals(5, OscillationIntervention.values().length);
+    }
+
+    // ---------- ProcessingFrequency ----------
+
+    @Test
+    void signals_frequencies() {
+        assertEquals(1L, MeasurementSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(1, MeasurementSignal.PROCESSING_FREQUENCY.getLoop());
+        assertEquals(2L, SetpointSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(1L, ActuatorCommandSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(1L, AlarmSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(1L, InterlockSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(3L, DegradationSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(2, DegradationSignal.PROCESSING_FREQUENCY.getLoop());
+        assertEquals(1L, EfficiencySignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(2, EfficiencySignal.PROCESSING_FREQUENCY.getLoop());
+        assertEquals(2L, BatchStateSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(1L, OperatorOverrideSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(10L, MaintenanceWindowSignal.PROCESSING_FREQUENCY.getEpoch());
+    }
+
+    // ---------- Layer 0 ----------
+
+    @Test
+    void validator_downgradesOutOfRange() {
+        MeasurementValidatorNeuron v = new MeasurementValidatorNeuron();
+        v.setRange("t1", 0.0, 100.0);
+        MeasurementSignal m = new MeasurementSignal("t1", 250.0, Quality.GOOD, 0L);
+        MeasurementSignal r = v.validate(m);
+        assertEquals(Quality.UNCERTAIN, r.getQuality());
+        assertEquals(1, v.suspiciousCount());
+    }
+
+    @Test
+    void validator_rateOfChange() {
+        MeasurementValidatorNeuron v = new MeasurementValidatorNeuron();
+        v.setMaxRateOfChange("t1", 10.0);
+        v.validate(new MeasurementSignal("t1", 0.0, Quality.GOOD, 0L));
+        MeasurementSignal spike = new MeasurementSignal("t1", 100.0, Quality.GOOD, 1_000L);
+        assertEquals(Quality.UNCERTAIN, v.validate(spike).getQuality());
+    }
+
+    // ---------- PID ----------
+
+    @Test
+    void pid_drivesTowardSetpoint() {
+        PIDNeuron pid = new PIDNeuron();
+        pid.setTag("out");
+        pid.setGains(1.0, 0.0, 0.0);
+        pid.setOutputLimits(-10.0, 10.0);
+        pid.setSetpoint(new SetpointSignal("sp", 10.0, 0.0, "ui"));
+        ActuatorCommandSignal cmd = pid.step(new MeasurementSignal("pv", 0.0, Quality.GOOD, 0L), 0.1);
+        assertNotNull(cmd);
+        assertEquals(10.0, cmd.getTargetValue(), 1e-9);
+    }
+
+    @Test
+    void pid_scaleGainsIntervention() {
+        PIDNeuron pid = new PIDNeuron();
+        pid.setGains(2.0, 1.0, 0.5);
+        pid.scaleGains(0.5);
+        assertEquals(1.0, pid.getKp(), 1e-9);
+        assertEquals(0.5, pid.getKi(), 1e-9);
+        assertEquals(0.25, pid.getKd(), 1e-9);
+    }
+
+    // ---------- Cascade / FeedForward ----------
+
+    @Test
+    void cascade_breaksReleasesLastGood() {
+        CascadeNeuron c = new CascadeNeuron();
+        SetpointSignal first = c.forward(new ActuatorCommandSignal("o", 5.0, 0.0, true), "inner");
+        assertEquals(5.0, first.getSetpoint(), 1e-9);
+        c.setBroken(true);
+        SetpointSignal broken = c.forward(new ActuatorCommandSignal("o", 99.0, 0.0, true), "inner");
+        assertSame(first, broken);
+    }
+
+    @Test
+    void feedForward_addsProportionalBias() {
+        FeedForwardNeuron f = new FeedForwardNeuron();
+        f.setGain(2.0);
+        ActuatorCommandSignal c = f.compensate(new MeasurementSignal("dist", 3.0, Quality.GOOD, 0L), "out", 1.0);
+        assertEquals(7.0, c.getTargetValue(), 1e-9);
+    }
+
+    // ---------- Supervisory ----------
+
+    @Test
+    void setpointOptimiser_nudgesWithinConstraints() {
+        SetpointOptimiserNeuron s = new SetpointOptimiserNeuron();
+        s.setConstraint("sp", 0.0, 10.0);
+        s.setStep(0.5);
+        SetpointSignal out = s.optimise(new EfficiencySignal("u1", 0.9, 0.8), "sp", 9.9);
+        assertEquals(10.0, out.getSetpoint(), 1e-9);
+    }
+
+    @Test
+    void alarmAggregator_suppressesStanding() {
+        AlarmAggregationNeuron a = new AlarmAggregationNeuron();
+        a.setSuppressionWindowTicks(5_000L);
+        AlarmSignal raw = new AlarmSignal(AlarmPriority.LOW, "t", "C1", 0L);
+        assertNotNull(a.observe(raw));
+        AlarmSignal again = new AlarmSignal(AlarmPriority.LOW, "t", "C1", 1_000L);
+        assertNull(a.observe(again));
+    }
+
+    @Test
+    void modeController_interlockForcesEmergency() {
+        ModeControllerNeuron m = new ModeControllerNeuron();
+        m.requestMode(PlantMode.NORMAL);
+        m.onInterlock(new InterlockSignal("I1", true, null));
+        assertEquals(PlantMode.EMERGENCY, m.getMode());
+        m.requestMode(PlantMode.NORMAL);
+        assertEquals(PlantMode.EMERGENCY, m.getMode(), "requestMode must be ignored while EMERGENCY");
+        m.resetFromEmergency();
+        assertEquals(PlantMode.SHUTDOWN, m.getMode());
+    }
+
+    // ---------- Layer 3 models ----------
+
+    @Test
+    void processModel_predict() {
+        ProcessModelNeuron p = new ProcessModelNeuron();
+        p.setGain("t", 2.0);
+        p.setTimeConstantTicks("t", 10.0);
+        p.setDeadTimeTicks("t", 2);
+        double near = p.predict("t", 1.0, 1);
+        double far = p.predict("t", 1.0, 50);
+        assertTrue(far > near);
+        assertTrue(far < 2.0 * 1.0 + 1e-9);
+    }
+
+    @Test
+    void degradationModel_reducesRul() {
+        DegradationModelNeuron d = new DegradationModelNeuron();
+        d.seedAsset("pump-1", 1000.0);
+        d.setWearPerUnit(1.0);
+        d.observe("pump-1", new MeasurementSignal("wear", 5.0, Quality.GOOD, 0L));
+        assertEquals(995.0, d.rulFor("pump-1"), 1e-9);
+    }
+
+    @Test
+    void productQualityModel_compliance() {
+        ProductQualityModelNeuron pq = new ProductQualityModelNeuron();
+        pq.setTarget(100.0);
+        pq.setTolerance(10.0);
+        assertTrue(pq.inSpec(new double[]{98.0, 100.0, 102.0}));
+        assertFalse(pq.inSpec(new double[]{200.0}));
+    }
+
+    // ---------- Layer 4 planning ----------
+
+    @Test
+    void mpc_picksBestMove() {
+        ProcessModelNeuron p = new ProcessModelNeuron();
+        p.setGain("t", 1.0);
+        p.setTimeConstantTicks("t", 1.0);
+        MPCPlanningNeuron m = new MPCPlanningNeuron();
+        m.setProcessModel(p);
+        ActuatorCommandSignal cmd = m.step(new SetpointSignal("t", 5.0, 0.0, "ui"), 4.0);
+        assertNotNull(cmd);
+        assertTrue(cmd.getTargetValue() > 4.0);
+    }
+
+    @Test
+    void campaignPlanner_fifo() {
+        CampaignPlanningNeuron c = new CampaignPlanningNeuron();
+        c.enqueueCampaign("c1", new BatchStateSignal("b1", BatchPhase.RUNNING, null));
+        c.enqueueCampaign("c2", new BatchStateSignal("b2", BatchPhase.RUNNING, null));
+        assertEquals("c1", c.currentCampaign());
+        c.nextPhase();
+        assertEquals("c2", c.currentCampaign());
+    }
+
+    @Test
+    void maintenance_scheduleLeadsToWindow() {
+        MaintenanceSchedulingNeuron m = new MaintenanceSchedulingNeuron();
+        MaintenanceWindowSignal w = m.schedule(new DegradationSignal("pump-1", 1.0, 0.9), 0L, 100L);
+        assertNotNull(w);
+        assertEquals("pump-1", w.getAssetId());
+    }
+
+    // ---------- Layer 5 response ----------
+
+    @Test
+    void safetyGate_shadowDisablesExecute() {
+        SafetyGateNeuron g = new SafetyGateNeuron();
+        g.setDefaultMode(SafetyMode.SHADOW);
+        ActuatorCommandSignal c = g.gate(new ActuatorCommandSignal("t", 1.0, 0.0, true));
+        assertFalse(c.isExecute());
+    }
+
+    @Test
+    void safetyGate_autonomousExecutes() {
+        SafetyGateNeuron g = new SafetyGateNeuron();
+        g.setDefaultMode(SafetyMode.AUTONOMOUS);
+        ActuatorCommandSignal c = g.gate(new ActuatorCommandSignal("t", 1.0, 0.0, false));
+        assertTrue(c.isExecute());
+    }
+
+    @Test
+    void actuator_honoursOverride() {
+        ActuatorNeuron a = new ActuatorNeuron();
+        a.onOverride(new OperatorOverrideSignal("t", OverrideKind.MANUAL, "op1", "hold", 7.0));
+        assertTrue(a.dispatch(new ActuatorCommandSignal("t", 3.0, 0.0, true)));
+        assertEquals(7.0, a.lastDispatchedValue("t"));
+        a.onOverride(new OperatorOverrideSignal("t", OverrideKind.BYPASS, "op1", "lockout", 0.0));
+        assertFalse(a.dispatch(new ActuatorCommandSignal("t", 3.0, 0.0, true)));
+    }
+
+    @Test
+    void interlock_sealedIsImmutable() {
+        InterlockNeuron i = new InterlockNeuron();
+        i.addInterlock("I1", "t", 100.0, true, "act", 0.0);
+        i.seal();
+        assertTrue(i.isSealed());
+        assertThrows(IllegalStateException.class,
+                () -> i.addInterlock("I2", "t", 200.0, true, "act", 0.0));
+    }
+
+    @Test
+    void interlock_tripsOnThreshold() {
+        InterlockNeuron i = new InterlockNeuron();
+        i.addInterlock("I1", "t", 100.0, true, "act", 0.0);
+        i.seal();
+        List<InterlockSignal> trips = i.evaluate(new MeasurementSignal("t", 150.0, Quality.GOOD, 0L));
+        assertEquals(1, trips.size());
+        assertTrue(trips.get(0).isTripped());
+        assertEquals(1, i.failSafeCommands().size());
+    }
+
+    // ---------- Layer 7 ----------
+
+    @Test
+    void oscillation_detectsAndEscalates() {
+        OscillationMonitorNeuron m = new OscillationMonitorNeuron();
+        m.setAcfWindowTicks(16);
+        // Alternating sequence: strong negative autocorrelation at lag 2
+        for (int i = 0; i < 16; i++) {
+            double v = (i % 2 == 0) ? 1.0 : -1.0;
+            m.observe(new MeasurementSignal("t", v, Quality.GOOD, i));
+        }
+        double sev = m.severity("t");
+        assertTrue(sev > 0.0);
+    }
+
+    @Test
+    void oscillation_interventionMapping() {
+        // A bit of manual severity probing across the bands.
+        OscillationMonitorNeuron m = new OscillationMonitorNeuron();
+        m.setAcfWindowTicks(16);
+        // Gentle ripple ~ low severity
+        for (int i = 0; i < 16; i++) {
+            m.observe(new MeasurementSignal("t", Math.sin(i * 0.2), Quality.GOOD, i));
+        }
+        OscillationIntervention band = m.intervention("t");
+        assertNotNull(band);
+    }
+
+    @Test
+    void energyAccounting_efficiency() {
+        EnergyAccountingNeuron e = new EnergyAccountingNeuron();
+        e.recordEnergy("u1", 100.0);
+        e.recordProduction("u1", 50.0);
+        EfficiencySignal s = e.efficiencyFor("u1");
+        assertEquals(0.5, s.getEfficiency(), 1e-9);
+    }
+
+    // ---------- Config ----------
+
+    @Test
+    void config_safetyModeValidation() {
+        IndustrialConfig c = new IndustrialConfig();
+        assertEquals(SafetyMode.ADVISORY, c.getSafetyMode());
+        c.setSafetyMode(SafetyMode.AUTONOMOUS);
+        assertEquals(SafetyMode.AUTONOMOUS, c.getSafetyMode());
+        assertThrows(IllegalArgumentException.class, () -> c.setSafetyMode(null));
+    }
+
+    @Test
+    void config_overrideAlwaysHonouredCannotBeDisabled() {
+        IndustrialConfig c = new IndustrialConfig();
+        assertTrue(c.isOverrideAlwaysHonoured());
+        assertThrows(IllegalArgumentException.class, () -> c.setOverrideAlwaysHonoured(false));
+    }
+
+    // ---------- Processors ----------
+
+    private static void assertInterfaceTyped(ISignalProcessor<?, ?> p) {
+        assertTrue(p.getNeuronClass().isInterface(),
+                p.getClass().getSimpleName() + " must target an interface");
+        assertNotNull(p.getSignalClass());
+        assertNotNull(p.getDescription());
+        assertFalse(p.hasMerger());
+    }
+
+    @Test
+    void processors_allInterfaceTyped() {
+        assertInterfaceTyped(new MeasurementValidationProcessor());
+        assertInterfaceTyped(new MeasurementPIDProcessor());
+        assertInterfaceTyped(new MeasurementOscillationProcessor());
+        assertInterfaceTyped(new MeasurementInterlockProcessor());
+        assertInterfaceTyped(new SetpointPIDProcessor());
+        assertInterfaceTyped(new ActuatorSafetyGateProcessor());
+        assertInterfaceTyped(new ActuatorDispatchProcessor());
+        assertInterfaceTyped(new AlarmAggregationProcessor());
+        assertInterfaceTyped(new InterlockModeProcessor());
+        assertInterfaceTyped(new DegradationSchedulingProcessor());
+        assertInterfaceTyped(new EfficiencyOptimiserProcessor());
+        assertInterfaceTyped(new BatchModeProcessor());
+        assertInterfaceTyped(new OperatorOverrideProcessor());
+        assertInterfaceTyped(new MaintenanceWindowSchedulingProcessor());
+    }
+
+    @Test
+    void measurementPIDProcessor_emitsActuatorCommand() {
+        PIDNeuron pid = new PIDNeuron();
+        pid.setTag("act");
+        pid.setGains(1.0, 0.0, 0.0);
+        pid.setOutputLimits(-10, 10);
+        pid.setSetpoint(new SetpointSignal("act", 5.0, 0.0, "ui"));
+        MeasurementPIDProcessor p = new MeasurementPIDProcessor();
+        p.setDtSeconds(0.1);
+        List<ISignal> out = p.process(new MeasurementSignal("act", 0.0, Quality.GOOD, 0L), pid);
+        assertEquals(1, out.size());
+        assertTrue(out.get(0) instanceof ActuatorCommandSignal);
+    }
+
+    @Test
+    void safetyGateProcessor_shadowsExecute() {
+        SafetyGateNeuron g = new SafetyGateNeuron();
+        g.setDefaultMode(SafetyMode.SHADOW);
+        ActuatorSafetyGateProcessor p = new ActuatorSafetyGateProcessor();
+        List<ISignal> out = p.process(new ActuatorCommandSignal("t", 1.0, 0.0, true), g);
+        assertEquals(1, out.size());
+        assertFalse(((ActuatorCommandSignal) out.get(0)).isExecute());
+    }
+
+    @Test
+    void interlockModeProcessor_forcesEmergency() {
+        ModeControllerNeuron m = new ModeControllerNeuron();
+        new InterlockModeProcessor().process(new InterlockSignal("I", true, null), m);
+        assertEquals(PlantMode.EMERGENCY, m.getMode());
+    }
+
+    @Test
+    void operatorOverrideProcessor_registersOnActuator() {
+        ActuatorNeuron a = new ActuatorNeuron();
+        new OperatorOverrideProcessor().process(
+                new OperatorOverrideSignal("t", OverrideKind.MANUAL, "op", "hold", 4.0), a);
+        assertTrue(a.isOverridden("t"));
+    }
+
+    @Test
+    void batchStateSignal_copyPreservesFields() {
+        HashMap<String, Double> km = new HashMap<>();
+        km.put("temp", 80.0);
+        BatchStateSignal s = new BatchStateSignal("b1", BatchPhase.RUNNING, km);
+        BatchStateSignal c = (BatchStateSignal) s.copySignal();
+        assertEquals("b1", c.getBatchId());
+        assertEquals(BatchPhase.RUNNING, c.getPhase());
+        assertEquals(80.0, c.getKeyMetrics().get("temp"), 1e-9);
+    }
+}


### PR DESCRIPTION
…se-industrial-process-control.md)

Adds the industrial module under worker/net/neuron/impl/industrial, worker/net/signals/impl/industrial, and
worker/signalprocessor/impl/industrial, plus docs/modules/industrial.md.

Enums / helpers (7): Quality, AlarmPriority, BatchPhase, OverrideKind, PlantMode, SafetyMode, OscillationIntervention.

Signals (10): MeasurementSignal (1/1), SetpointSignal (1/2), ActuatorCommandSignal (1/1), AlarmSignal (1/1), InterlockSignal (1/1), DegradationSignal (2/3), EfficiencySignal (2/1), BatchStateSignal (2/2), OperatorOverrideSignal (1/1), MaintenanceWindowSignal (2/10). Every signal carries a wall-clock timestamp in addition to the jneopallium tick per spec §3.

Neurons (18), each paired with an I<Name> interface so processors never depend on the concrete type:

* Layer 0 — SensorNeuron, MeasurementValidatorNeuron (quality- downgrade-never-drop).
* Layer 1 — PIDNeuron (velocity-form, runtime-scalable gains for SCALE_WEIGHTS intervention), CascadeNeuron (break-and-hold implements BREAK_CONNECTION), FeedForwardNeuron.
* Layer 2 — SetpointOptimiserNeuron (constraint-clamped efficiency nudge), AlarmAggregationNeuron (ISA-18.2 suppression + rate), ModeControllerNeuron (STARTUP/NORMAL/SHUTDOWN/EMERGENCY; interlock trip always forces EMERGENCY).
* Layer 3 — ProcessModelNeuron (first-order-plus-deadtime), DegradationModelNeuron (per-asset RUL), ProductQualityModelNeuron.
* Layer 4 — MPCPlanningNeuron (candidate-move search against the process model), CampaignPlanningNeuron (FIFO batch queue), MaintenanceSchedulingNeuron.
* Layer 5 — SafetyGateNeuron (per-tag SHADOW/ADVISORY/AUTONOMOUS), ActuatorNeuron (operator-override always wins: MANUAL freezes at operator's value, BYPASS blocks), InterlockNeuron (rules sealed at construction; addInterlock after seal() throws).
* Layer 7 — OscillationMonitorNeuron (ACF-at-lag-1 severity mapped to OscillationIntervention bands per spec §6), EnergyAccountingNeuron (production-per-kWh efficiency).

Processors (14), all parameterised by I<Neuron> interfaces:

* MeasurementSignal → MeasurementValidationProcessor, MeasurementPIDProcessor, MeasurementOscillationProcessor, MeasurementInterlockProcessor
* SetpointSignal → SetpointPIDProcessor
* ActuatorCommandSignal → ActuatorSafetyGateProcessor, ActuatorDispatchProcessor
* AlarmSignal → AlarmAggregationProcessor
* InterlockSignal → InterlockModeProcessor
* DegradationSignal → DegradationSchedulingProcessor
* EfficiencySignal → EfficiencyOptimiserProcessor
* BatchStateSignal → BatchModeProcessor
* OperatorOverrideSignal → OperatorOverrideProcessor
* MaintenanceWindowSignal → MaintenanceWindowSchedulingProcessor

IndustrialConfig mirrors spec §9 and enforces two program-level invariants: setSafetyMode(null) throws;
setOverrideAlwaysHonoured(false) throws. The SRS stays compiled once via InterlockNeuron.seal().

IndustrialModuleTest adds 33 tests: enum cardinalities, every signal's ProcessingFrequency, validator range+rate-of-change, PID drive + gain scaling, cascade break-and-hold, feed-forward bias, setpoint clamp, alarm suppression, mode-machine EMERGENCY lockout, process-model dynamics, degradation RUL, product-quality, MPC move selection, campaign FIFO, maintenance window, safety-gate shadow / autonomous, operator override (MANUAL+BYPASS), sealed-interlock immutability, interlock trip + fail-safe command, oscillation detection at lag 1, energy accounting, config validation, plus per-processor smoke tests and the processors_allInterfaceTyped invariant.

Full worker suite: 445/445 pass (412 prior + 33 new), no regressions.

https://claude.ai/code/session_018DLgBWsQFe4q32RCbqYsAQ