### PR TITLE
Implement swarm-robotics use case (use-case-swarm-robotics.md)

### DIFF
--- a/docs/modules/swarm.md
+++ b/docs/modules/swarm.md
@@ -1,0 +1,254 @@
+# Swarm Robotics & Distributed Multi-Agent Coordination
+
+> Status: implementation of [`use-case-swarm-robotics.md`](../../use-case-swarm-robotics.md) for [jneopallium](https://github.com/rakovpublic/jneopallium).
+> License: BSD 3-Clause.
+
+---
+
+## Abstract
+
+Each agent runs a full jneopallium instance; the swarm is a network of
+networks. Coordination is local-first: peer observations, role
+awareness, stigmergic markers, auction bidding, light-weight consensus,
+Reynolds flocking, formation keeping, Byzantine-tolerant isolation, and
+collective-harm aggregation all reduce to typed signals exchanged over
+realistic communication links. Communication is never assumed perfect
+— every peer-bound signal carries a `linkQuality` indicator that
+processors weight against.
+
+## Design Principles
+
+1. **Typed timescales.** Peer observations on loop 1 / epoch 2;
+   peer state on 2/1; flocking on 1/1; pheromones on 2/2; stigmergic
+   traces on 2/5; consensus and anomaly on 2/1; swarm alerts at 1/1
+   so they propagate fast.
+2. **Processors parameterised by interfaces.** Every
+   `ISignalProcessor` under `worker/signalprocessor/impl/swarm`
+   targets an `I<Neuron>` interface; concrete neurons can be swapped
+   per-deployment without touching processors.
+3. **Quarantine is never permanent locally.**
+   `IsolationProtocolNeuron` automatically reaps expired isolations;
+   repeats double the duration but only a global consensus decision
+   removes a peer permanently.
+4. **k-witness Byzantine tolerance.** `IsolationProtocolNeuron`
+   refuses to isolate below the configured witness threshold.
+   `SwarmConfig` enforces minimum 3 — `setQuorumWitnessCount(2)` and
+   `setAnomalyThresholdVotes(2)` throw.
+5. **No lethal autonomy.** `SwarmConfig.isLawsEnabled()` returns
+   `false` and is fixed — no setter exposed.
+6. **Communication realism.** `linkQuality ∈ [0,1]` on every peer
+   signal; `MeshRadioNeuron` drops below threshold;
+   `PeerObservationNeuron` filters at ingress.
+
+## Signals
+
+Package: `com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm`.
+
+| Signal | Loop/Epoch | Notes |
+|---|---|---|
+| `PeerObservationSignal` | 1/2 | peerId, position / velocity (local), linkQuality |
+| `PeerStateSignal` | 2/1 | peerId, AgentRole, battery, health, capabilities |
+| `TaskAnnouncementSignal` | 2/1 | taskId, TaskKind, location, reward, deadline |
+| `TaskBidSignal` | 2/1 | taskId, bidderId, cost, confidence |
+| `TaskAssignmentSignal` | 2/1 | taskId, assigneeId, witnessId |
+| `PheromoneSignal` | 2/2 | PheromoneKind, location, strength, decay |
+| `FormationSignal` | 1/2 | FormationTemplate, slot, relative offset |
+| `ConsensusProposalSignal` | 2/1 | proposalId, state, proposerId |
+| `ConsensusVoteSignal` | 2/1 | proposalId, VoteKind, voterId |
+| `SwarmAlertSignal` | 1/1 | AlertCategory, regionId, severity |
+| `AgentAnomalySignal` | 2/1 | suspectId, AnomalyKind, detectorId, witnesses |
+| `StigmergicTraceSignal` | 2/5 | location, TraceKind, saliency, deposited tick |
+
+## Neurons
+
+Each concrete neuron implements a matching `I<Neuron>` interface so
+processors never depend on the concrete type.
+
+### Layer 0 — peer sensing
+- `PeerObservationNeuron` / `IPeerObservationNeuron` — drops
+  observations below `minLinkQuality`.
+- `MeshRadioNeuron` / `IMeshRadioNeuron` — link-quality-aware
+  outbound transport adapter.
+
+### Layer 2 — peer state
+- `PeerStateIntegrationNeuron` / `IPeerStateIntegrationNeuron` —
+  decay-based local view of neighbours.
+- `RoleAwarenessNeuron` / `IRoleAwarenessNeuron` — distribution map
+  + shortage-role bias.
+
+### Layer 3 — collective memory
+- `StigmergicMemoryNeuron` / `IStigmergicMemoryNeuron` — pheromone +
+  trace cache with location-radius queries and decay-based eviction.
+- `TaskRegistryNeuron` / `ITaskRegistryNeuron` — open / assigned tasks.
+
+### Layer 4 — coordination planning
+- `AuctionBiddingNeuron` / `IAuctionBiddingNeuron` — distance / battery
+  cost model, declines bids when out of battery.
+- `ConsensusParticipantNeuron` / `IConsensusParticipantNeuron` —
+  unique-voter YES / NO tally; quorum = configurable k (≥ 3).
+- `FormationKeepingNeuron` / `IFormationKeepingNeuron` — slot-offset
+  steering.
+- `FlockingNeuron` / `IFlockingNeuron` — Reynolds rules weighted by
+  link quality.
+
+### Layer 5 — collective safety
+- `SwarmHarmGateNeuron` / `ISwarmHarmGateNeuron` — regional emission
+  aggregator; emits `SwarmAlertSignal(COLLECTIVE_HARM)`; tightening
+  multiplier ∈ [1, 5].
+- `AnomalyReportNeuron` / `IAnomalyReportNeuron` — single-shot reports
+  per suspect (no double-counting).
+- `IsolationProtocolNeuron` / `IIsolationProtocolNeuron` — k-witness
+  Byzantine isolation, automatic lift, exponential escalation up to
+  cap.
+
+### Layer 7 — homeostasis
+- `SwarmDensityNeuron` / `ISwarmDensityNeuron` — disperse-or-aggregate
+  bias.
+- `BandwidthBudgetNeuron` / `IBandwidthBudgetNeuron` — token-bucket
+  rate-limit on low-priority outbound traffic.
+- `EnergyCoordinatorNeuron` / `IEnergyCoordinatorNeuron` — defers a
+  task to a higher-battery peer when own battery falls below
+  threshold.
+
+## Processors
+
+Package: `com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm`.
+
+| Signal | Processor(s) |
+|---|---|
+| `PeerObservationSignal` | `PeerObservationIntegrationProcessor` |
+| `PeerStateSignal` | `PeerStateIntegrationProcessor`, `PeerStateRoleProcessor`, `PeerStateEnergyProcessor` |
+| `TaskAnnouncementSignal` | `TaskAnnouncementBidProcessor`, `TaskAnnouncementRegistryProcessor` |
+| `TaskBidSignal` | `TaskBidRegistryProcessor` |
+| `TaskAssignmentSignal` | `TaskAssignmentRegistryProcessor` |
+| `PheromoneSignal` | `PheromoneDepositProcessor` |
+| `StigmergicTraceSignal` | `StigmergicTraceDepositProcessor` |
+| `FormationSignal` | `FormationKeepingProcessor` |
+| `ConsensusProposalSignal` | `ConsensusProposalProcessor` |
+| `ConsensusVoteSignal` | `ConsensusVoteProcessor` |
+| `SwarmAlertSignal` | `SwarmAlertProcessor` |
+| `AgentAnomalySignal` | `AgentAnomalyIsolationProcessor` |
+
+Every processor's `getNeuronClass()` returns an interface — the
+`processors_allInterfaceTyped` test in `SwarmModuleTest` asserts this
+invariant across all 15 processors.
+
+## Configuration
+
+`SwarmConfig` mirrors spec §9 with strongly-typed setters.
+
+```yaml
+swarm:
+  enabled: true
+  agent-id: "bot-042"
+  transport:
+    primary: dds
+    fallback: mqtt
+    lora-mesh: true
+    bandwidth-kbps: 100
+  neighbourhood:
+    max-peers: 12
+    staleness-ticks: 300
+  consensus:
+    protocol: gossip-crdt
+    quorum-witness-count: 3       # setter throws on < 3
+  auction:
+    bid-timeout-ticks: 50
+    tie-breaker: lowest-id
+  flocking:
+    weights:
+      separation: 1.0
+      alignment: 0.7
+      cohesion: 0.5
+    radius: 5.0
+  stigmergy:
+    enabled: true
+    default-decay-ticks: 1000
+  byzantine:
+    anomaly-threshold-votes: 3    # setter throws on < 3
+    isolation-ticks: 600
+    max-reputation-history: 1000
+  collective-harm:
+    regional-threshold-config: "regional-thresholds.yaml"
+    aggregator-election: raft-lite
+  curiosity:
+    enabled: true
+    role-differentiation: true
+```
+
+## Tests
+
+`SwarmModuleTest` (26 tests):
+
+- enum cardinalities + `ProcessingFrequency` for every signal
+- peer-observation drop on low link quality
+- mesh radio drop on low link quality
+- peer-state staleness eviction
+- role-awareness shortage detection
+- stigmergic decay-based eviction + radius-bounded retrieval
+- task-registry assign closes open
+- auction bid distance scaling
+- consensus quorum on YES (unique voter dedupe)
+- formation slot-offset steering
+- flocking zero on empty + separation pushes away
+- collective-harm regional aggregation + tightening multiplier
+- single-shot anomaly reporting
+- k-witness isolation at threshold + auto-lift after duration
+- density bias for high count
+- bandwidth budget rate-limits low priority
+- energy coordinator defers to higher-battery peer
+- config quorum minimum 3 (throws on lower)
+- LAWS hard-coded off
+- 15-processor `processors_allInterfaceTyped` invariant
+- per-processor smoke tests (announcement → bid, proposal → vote,
+  k-witness isolation through processor)
+
+Full worker suite: 471/471 pass (445 prior + 26 new), no regressions.
+
+## Validation (per spec §10)
+
+1. *Communication robustness* — every peer-bound signal already
+   carries `linkQuality`; processors weight by it. Drop-rate
+   injection plugs in at the simulation harness.
+2. *Partition tolerance* — each neuron is local-state only;
+   reconciliation paths for `TaskRegistryNeuron` and
+   `IsolationProtocolNeuron` are via consensus signals.
+3. *Byzantine drill* — `IsolationProtocolNeuron` requires k
+   independent witnesses; spec-mandated minimum 3 enforced by
+   `SwarmConfig`.
+4. *Scalability* — interface-typed neurons + per-processor stateless
+   wiring keep per-tick overhead bounded; characterise per-deployment.
+5. *Collective harm test* — `SwarmHarmGateNeuron.aggregate()` test
+   confirms that 0.6 + 0.6 over a 1.0 threshold raises
+   `COLLECTIVE_HARM` and bumps the tightening multiplier.
+6. *Agent-loss resilience* — `PeerStateIntegrationNeuron.evict()`
+   removes stale neighbours; downstream consumers see graceful
+   degradation rather than blocked operation.
+
+## Out of scope
+
+Per spec §12:
+- Lethal autonomous weapons. `SwarmConfig.isLawsEnabled()` is fixed
+  off; no setter is exposed.
+- Centralised training / execution.
+- Adversarial-insider Byzantine tolerance — pair with the
+  cybersecurity module.
+- Affect-module emotional mimicry. `SwarmConfig.isAffectEnabled()`
+  is fixed off.
+
+## References
+
+- Rakovskyi, D. (2024). *Framework for Natural Neuron Network
+  Modeling: The Jneopallium Approach.* IJSR 13(7).
+- Reynolds, C.W. (1987). Flocks, herds, and schools. *ACM SIGGRAPH.*
+- Dorigo, M., Birattari, M., Stutzle, T. (2006). Ant colony
+  optimization. *IEEE Computational Intelligence Magazine.*
+- Camazine, S. et al. (2001). *Self-Organization in Biological
+  Systems.* Princeton University Press.
+- Brambilla, M., Ferrante, E., Birattari, M., Dorigo, M. (2013).
+  Swarm robotics: a review from the swarm engineering perspective.
+  *Swarm Intelligence* 7, 1–41.
+- Castro, M., Liskov, B. (1999). Practical Byzantine Fault Tolerance.
+  *OSDI.*
+- Ongaro, D., Ousterhout, J. (2014). In search of an understandable
+  consensus algorithm. *USENIX ATC.*

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/AgentRole.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/AgentRole.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+/** Emergent swarm-member roles. */
+public enum AgentRole { SCOUT, WORKER, GUARD, LEADER, RELAY, IDLE }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/AlertCategory.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/AlertCategory.java
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+public enum AlertCategory { COLLISION, INTRUDER, ENVIRONMENTAL, COLLECTIVE_HARM, COMMUNICATION_LOSS }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/AnomalyKind.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/AnomalyKind.java
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+public enum AnomalyKind { SILENT, INCONSISTENT_DATA, PROTOCOL_VIOLATION, UNRESPONSIVE, CONTRARIAN }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/AnomalyReportNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/AnomalyReportNeuron.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.AgentAnomalySignal;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/** Layer 5 anomaly reporter. Loop=2 / Epoch=1. */
+public class AnomalyReportNeuron extends ModulatableNeuron implements IAnomalyReportNeuron {
+
+    private String selfId;
+    private final Map<String, Integer> reportsBySuspect = new HashMap<>();
+    private final Set<String> alreadyReportedBySelf = new HashSet<>();
+
+    public AnomalyReportNeuron() { super(); }
+    public AnomalyReportNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void setSelfId(String id) { this.selfId = id; }
+    @Override public String getSelfId() { return selfId; }
+
+    @Override
+    public AgentAnomalySignal report(String suspectId, AnomalyKind kind) {
+        if (suspectId == null) return null;
+        if (alreadyReportedBySelf.contains(suspectId)) return null;
+        alreadyReportedBySelf.add(suspectId);
+        reportsBySuspect.merge(suspectId, 1, Integer::sum);
+        return new AgentAnomalySignal(suspectId, kind, selfId,
+                Collections.singletonList(selfId == null ? "self" : selfId));
+    }
+
+    @Override public int reportsAgainst(String suspectId) { return reportsBySuspect.getOrDefault(suspectId, 0); }
+    @Override public boolean alreadyReported(String suspectId) { return alreadyReportedBySelf.contains(suspectId); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/AuctionBiddingNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/AuctionBiddingNeuron.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskAnnouncementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskBidSignal;
+
+/**
+ * Layer 4 auction bidder. Bid = euclidean distance to task / battery
+ * fraction. Confidence falls with battery. Loop=2 / Epoch=1.
+ */
+public class AuctionBiddingNeuron extends ModulatableNeuron implements IAuctionBiddingNeuron {
+
+    private String bidderId;
+    private double[] selfPosition;
+    private double batteryFraction = 1.0;
+
+    public AuctionBiddingNeuron() { super(); }
+    public AuctionBiddingNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void setBidderId(String id) { this.bidderId = id; }
+    @Override public String getBidderId() { return bidderId; }
+    @Override public void setSelfPosition(double[] pos) { this.selfPosition = pos == null ? null : pos.clone(); }
+    @Override public void setBatteryFraction(double f) { this.batteryFraction = Math.max(0.0, Math.min(1.0, f)); }
+    @Override public double getBatteryFraction() { return batteryFraction; }
+
+    @Override
+    public TaskBidSignal bid(TaskAnnouncementSignal a) {
+        if (a == null || a.getTaskId() == null) return null;
+        if (batteryFraction <= 0.0) return null;
+        double[] target = a.getLocationGlobal();
+        double dist = 0.0;
+        if (target != null && selfPosition != null) {
+            int n = Math.min(target.length, selfPosition.length);
+            for (int i = 0; i < n; i++) { double d = target[i] - selfPosition[i]; dist += d * d; }
+            dist = Math.sqrt(dist);
+        }
+        double cost = dist / Math.max(1e-3, batteryFraction);
+        double confidence = batteryFraction;
+        return new TaskBidSignal(a.getTaskId(), bidderId, cost, confidence);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/BandwidthBudgetNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/BandwidthBudgetNeuron.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+
+/**
+ * Layer 7 outbound-bandwidth budget. Tracks cumulative bytes per
+ * second; rate-limits low-priority signals when the budget is
+ * saturated. Loop=2 / Epoch=1.
+ */
+public class BandwidthBudgetNeuron extends ModulatableNeuron implements IBandwidthBudgetNeuron {
+
+    private int budgetKbps = 100;
+    private long windowStartTickSec = Long.MIN_VALUE;
+    private long bytesInWindow;
+
+    public BandwidthBudgetNeuron() { super(); }
+    public BandwidthBudgetNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void setBudgetKbps(int kbps) { this.budgetKbps = Math.max(1, kbps); }
+    @Override public int getBudgetKbps() { return budgetKbps; }
+
+    private void rotateWindow(long currentTick) {
+        long sec = currentTick / 1000L;
+        if (sec != windowStartTickSec) { windowStartTickSec = sec; bytesInWindow = 0; }
+    }
+
+    @Override
+    public boolean allowLowPriority(int bytes, long currentTick) {
+        rotateWindow(currentTick);
+        long budgetBytes = (long) budgetKbps * 1000L / 8L;
+        if (bytesInWindow + bytes > budgetBytes) return false;
+        bytesInWindow += bytes;
+        return true;
+    }
+
+    @Override
+    public void recordHighPriority(int bytes, long currentTick) {
+        rotateWindow(currentTick);
+        bytesInWindow += bytes;
+    }
+
+    @Override public int currentRateBytesPerSec() { return (int) bytesInWindow; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/ConsensusParticipantNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/ConsensusParticipantNeuron.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.ConsensusProposalSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.ConsensusVoteSignal;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Layer 4 light-weight consensus participant. Counts unique YES / NO
+ * votes per proposal; meets quorum on YES count ≥ k. Loop=2 / Epoch=1.
+ */
+public class ConsensusParticipantNeuron extends ModulatableNeuron implements IConsensusParticipantNeuron {
+
+    private final Map<String, Set<String>> yes = new HashMap<>();
+    private final Map<String, Set<String>> no = new HashMap<>();
+    private int quorum = 3;
+    private String voterId;
+
+    public ConsensusParticipantNeuron() { super(); }
+    public ConsensusParticipantNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void setVoterId(String id) { this.voterId = id; }
+
+    @Override
+    public ConsensusProposalSignal propose(String proposalId, String state) {
+        return new ConsensusProposalSignal(proposalId, state, voterId);
+    }
+
+    @Override
+    public ConsensusVoteSignal vote(ConsensusProposalSignal p) {
+        if (p == null) return null;
+        ConsensusVoteSignal v = new ConsensusVoteSignal(p.getProposalId(), VoteKind.YES, voterId);
+        tally(v);
+        return v;
+    }
+
+    @Override
+    public void tally(ConsensusVoteSignal v) {
+        if (v == null || v.getProposalId() == null) return;
+        if (v.getVote() == VoteKind.YES) yes.computeIfAbsent(v.getProposalId(), k -> new HashSet<>()).add(safeVoter(v));
+        else if (v.getVote() == VoteKind.NO) no.computeIfAbsent(v.getProposalId(), k -> new HashSet<>()).add(safeVoter(v));
+    }
+
+    private static String safeVoter(ConsensusVoteSignal v) {
+        return v.getVoterId() == null ? "anon-" + System.identityHashCode(v) : v.getVoterId();
+    }
+
+    @Override public boolean isQuorum(String proposalId) { return yesCount(proposalId) >= quorum; }
+    @Override public int yesCount(String proposalId) { return yes.getOrDefault(proposalId, java.util.Collections.emptySet()).size(); }
+    @Override public int noCount(String proposalId) { return no.getOrDefault(proposalId, java.util.Collections.emptySet()).size(); }
+    @Override public void setQuorum(int q) { this.quorum = Math.max(1, q); }
+    @Override public int getQuorum() { return quorum; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/EnergyCoordinatorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/EnergyCoordinatorNeuron.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerStateSignal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 7 energy coordinator. Defers a task to a higher-battery peer
+ * when own battery is below a threshold and at least one peer is
+ * meaningfully better off. Loop=2 / Epoch=1.
+ */
+public class EnergyCoordinatorNeuron extends ModulatableNeuron implements IEnergyCoordinatorNeuron {
+
+    private final Map<String, Double> peerBatteries = new HashMap<>();
+    private double ownBattery = 1.0;
+    private double deferThreshold = 0.30;
+    private double advantageThreshold = 0.20;
+
+    public EnergyCoordinatorNeuron() { super(); }
+    public EnergyCoordinatorNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void setOwnBattery(double f) { this.ownBattery = Math.max(0.0, Math.min(1.0, f)); }
+    @Override public double getOwnBattery() { return ownBattery; }
+
+    public void setDeferThreshold(double t) { this.deferThreshold = Math.max(0.0, Math.min(1.0, t)); }
+    public void setAdvantageThreshold(double t) { this.advantageThreshold = Math.max(0.0, Math.min(1.0, t)); }
+
+    @Override
+    public void onPeerState(PeerStateSignal s) {
+        if (s == null || s.getPeerId() == null) return;
+        peerBatteries.put(s.getPeerId(), s.getBattery());
+    }
+
+    @Override
+    public String shouldDeferTo(String taskId) {
+        if (taskId == null || ownBattery > deferThreshold) return null;
+        String best = null;
+        double bestBattery = ownBattery + advantageThreshold;
+        for (Map.Entry<String, Double> e : peerBatteries.entrySet()) {
+            if (e.getValue() > bestBattery) { best = e.getKey(); bestBattery = e.getValue(); }
+        }
+        return best;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/FlockingNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/FlockingNeuron.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerObservationSignal;
+
+import java.util.List;
+
+/**
+ * Layer 4 Reynolds-rules flocking. Returns a steering vector (in the
+ * same dimensionality as neighbours' positions) blending separation,
+ * alignment, cohesion. Each rule is weighted by neighbour link
+ * quality so unreliable neighbours don't dominate. Loop=1 / Epoch=1.
+ */
+public class FlockingNeuron extends ModulatableNeuron implements IFlockingNeuron {
+
+    private double separation = 1.0;
+    private double alignment = 0.7;
+    private double cohesion = 0.5;
+    private double radius = 5.0;
+
+    public FlockingNeuron() { super(); }
+    public FlockingNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void setWeights(double sep, double align, double coh) {
+        this.separation = sep;
+        this.alignment = align;
+        this.cohesion = coh;
+    }
+    @Override public double getSeparationWeight() { return separation; }
+    @Override public double getAlignmentWeight() { return alignment; }
+    @Override public double getCohesionWeight() { return cohesion; }
+    @Override public void setRadius(double r) { this.radius = Math.max(0.0, r); }
+    @Override public double getRadius() { return radius; }
+
+    @Override
+    public double[] steer(List<PeerObservationSignal> neighbours) {
+        if (neighbours == null || neighbours.isEmpty()) return new double[0];
+        int dim = -1;
+        for (PeerObservationSignal n : neighbours) {
+            if (n != null && n.getPositionLocal() != null) { dim = n.getPositionLocal().length; break; }
+        }
+        if (dim <= 0) return new double[0];
+
+        double[] sep = new double[dim], coh = new double[dim], ali = new double[dim];
+        double weightSum = 0.0;
+        int n = 0;
+        for (PeerObservationSignal p : neighbours) {
+            if (p == null || p.getPositionLocal() == null) continue;
+            double[] pos = p.getPositionLocal();
+            double dist = 0.0;
+            for (int i = 0; i < Math.min(dim, pos.length); i++) dist += pos[i] * pos[i];
+            dist = Math.sqrt(dist);
+            if (dist > radius) continue;
+            double w = p.getLinkQuality();
+            weightSum += w;
+            n++;
+            for (int i = 0; i < Math.min(dim, pos.length); i++) {
+                if (dist > 1e-6) sep[i] += w * (-pos[i] / Math.max(0.5, dist));
+                coh[i] += w * pos[i];
+                if (p.getVelocityLocal() != null && i < p.getVelocityLocal().length) {
+                    ali[i] += w * p.getVelocityLocal()[i];
+                }
+            }
+        }
+        if (weightSum <= 0 || n == 0) return new double[dim];
+        double[] out = new double[dim];
+        for (int i = 0; i < dim; i++) {
+            out[i] = separation * (sep[i] / weightSum)
+                   + cohesion   * (coh[i] / weightSum)
+                   + alignment  * (ali[i] / weightSum);
+        }
+        return out;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/FormationKeepingNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/FormationKeepingNeuron.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.FormationSignal;
+
+/** Layer 4 formation-keeper. Loop=1 / Epoch=2. */
+public class FormationKeepingNeuron extends ModulatableNeuron implements IFormationKeepingNeuron {
+
+    private FormationSignal slot;
+
+    public FormationKeepingNeuron() { super(); }
+    public FormationKeepingNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void setSlot(FormationSignal s) { this.slot = s; }
+    @Override public FormationSignal currentSlot() { return slot; }
+
+    @Override
+    public double[] steer(double[] currentRelativePosition) {
+        if (slot == null || slot.getRelativeOffset() == null || currentRelativePosition == null) return new double[0];
+        double[] target = slot.getRelativeOffset();
+        int n = Math.min(target.length, currentRelativePosition.length);
+        double[] out = new double[n];
+        for (int i = 0; i < n; i++) out[i] = target[i] - currentRelativePosition[i];
+        return out;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/FormationTemplate.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/FormationTemplate.java
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+public enum FormationTemplate { LINE, V, WEDGE, DIAMOND, CIRCLE, GRID, FREE }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IAnomalyReportNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IAnomalyReportNeuron.java
@@ -1,0 +1,14 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.AgentAnomalySignal;
+
+public interface IAnomalyReportNeuron extends IModulatableNeuron {
+    void setSelfId(String id);
+    String getSelfId();
+    /** Lodge an anomaly report against {@code suspectId}. */
+    AgentAnomalySignal report(String suspectId, AnomalyKind kind);
+    int reportsAgainst(String suspectId);
+    /** True iff this agent has already reported {@code suspectId} since last cooldown. */
+    boolean alreadyReported(String suspectId);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IAuctionBiddingNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IAuctionBiddingNeuron.java
@@ -1,0 +1,15 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskAnnouncementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskBidSignal;
+
+public interface IAuctionBiddingNeuron extends IModulatableNeuron {
+    void setBidderId(String id);
+    String getBidderId();
+    void setSelfPosition(double[] pos);
+    /** Compute a bid for this announcement; returns null when disinterested. */
+    TaskBidSignal bid(TaskAnnouncementSignal announcement);
+    void setBatteryFraction(double f);
+    double getBatteryFraction();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IBandwidthBudgetNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IBandwidthBudgetNeuron.java
@@ -1,0 +1,13 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+
+public interface IBandwidthBudgetNeuron extends IModulatableNeuron {
+    void setBudgetKbps(int kbps);
+    int getBudgetKbps();
+    /** Returns true iff a low-priority signal of the given size in bytes is allowed under the current budget. */
+    boolean allowLowPriority(int bytes, long currentTick);
+    /** High-priority always passes; the call records the bytes for accounting. */
+    void recordHighPriority(int bytes, long currentTick);
+    int currentRateBytesPerSec();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IConsensusParticipantNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IConsensusParticipantNeuron.java
@@ -1,0 +1,21 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.ConsensusProposalSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.ConsensusVoteSignal;
+
+public interface IConsensusParticipantNeuron extends IModulatableNeuron {
+    /** Propose a value; returns the proposal record. */
+    ConsensusProposalSignal propose(String proposalId, String state);
+    /** Cast a local vote on a proposal. Returns the resulting vote signal. */
+    ConsensusVoteSignal vote(ConsensusProposalSignal p);
+    /** Tally a vote arriving from a peer. */
+    void tally(ConsensusVoteSignal v);
+    /** True iff the proposal has reached the configured quorum YES count. */
+    boolean isQuorum(String proposalId);
+    int yesCount(String proposalId);
+    int noCount(String proposalId);
+    void setQuorum(int q);
+    int getQuorum();
+    void setVoterId(String id);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IEnergyCoordinatorNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IEnergyCoordinatorNeuron.java
@@ -1,0 +1,16 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerStateSignal;
+
+public interface IEnergyCoordinatorNeuron extends IModulatableNeuron {
+    void setOwnBattery(double f);
+    double getOwnBattery();
+    void onPeerState(PeerStateSignal s);
+    /**
+     * Decision helper: should this agent defer the named task to a
+     * higher-battery peer? Returns the suggested peerId, or null if
+     * this agent should keep the task.
+     */
+    String shouldDeferTo(String taskId);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IFlockingNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IFlockingNeuron.java
@@ -1,0 +1,20 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerObservationSignal;
+
+import java.util.List;
+
+public interface IFlockingNeuron extends IModulatableNeuron {
+    void setWeights(double separation, double alignment, double cohesion);
+    double getSeparationWeight();
+    double getAlignmentWeight();
+    double getCohesionWeight();
+    void setRadius(double r);
+    double getRadius();
+    /**
+     * Reynolds-rules steering vector from a list of recent neighbour
+     * observations.
+     */
+    double[] steer(List<PeerObservationSignal> neighbours);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IFormationKeepingNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IFormationKeepingNeuron.java
@@ -1,0 +1,14 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.FormationSignal;
+
+public interface IFormationKeepingNeuron extends IModulatableNeuron {
+    void setSlot(FormationSignal slot);
+    FormationSignal currentSlot();
+    /**
+     * Returns the steering vector required to reach the assigned slot
+     * given current relative position to the formation reference.
+     */
+    double[] steer(double[] currentRelativePosition);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IIsolationProtocolNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IIsolationProtocolNeuron.java
@@ -1,0 +1,18 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.AgentAnomalySignal;
+
+public interface IIsolationProtocolNeuron extends IModulatableNeuron {
+    /** k-witness corroboration threshold; minimum 3 for f=1 Byzantine tolerance on a small swarm. */
+    void setWitnessThreshold(int k);
+    int getWitnessThreshold();
+    void setIsolationTicks(long t);
+    long getIsolationTicks();
+    /** Receive an anomaly report; returns true iff isolation was applied (i.e. threshold met). */
+    boolean onReport(AgentAnomalySignal report, long currentTick);
+    boolean isIsolated(String peerId, long currentTick);
+    /** Reap expired isolations and return the number released. */
+    int tick(long currentTick);
+    int activeIsolations(long currentTick);
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IMeshRadioNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IMeshRadioNeuron.java
@@ -1,0 +1,13 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+public interface IMeshRadioNeuron extends IModulatableNeuron {
+    /** Decide whether to forward the signal under current link quality. */
+    boolean send(ISignal s, double linkQuality);
+    long getSent();
+    long getDropped();
+    void setLossThreshold(double t);
+    double getLossThreshold();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IPeerObservationNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IPeerObservationNeuron.java
@@ -1,0 +1,11 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerObservationSignal;
+
+public interface IPeerObservationNeuron extends IModulatableNeuron {
+    PeerObservationSignal observe(String peerId, double[] positionLocal, double[] velocityLocal, double linkQuality);
+    long getObservationCount();
+    void setMinLinkQuality(double q);
+    double getMinLinkQuality();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IPeerStateIntegrationNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IPeerStateIntegrationNeuron.java
@@ -1,0 +1,20 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerObservationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerStateSignal;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface IPeerStateIntegrationNeuron extends IModulatableNeuron {
+    void onObservation(PeerObservationSignal o, long currentTick);
+    void onState(PeerStateSignal s, long currentTick);
+    /** Drop entries older than {@code stalenessTicks} from the local view. */
+    int evict(long currentTick);
+    Set<String> knownPeers();
+    Map<String, AgentRole> roleSnapshot();
+    Long lastSeen(String peerId);
+    void setStalenessTicks(long t);
+    long getStalenessTicks();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IRoleAwarenessNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IRoleAwarenessNeuron.java
@@ -1,0 +1,16 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerStateSignal;
+
+import java.util.Map;
+
+public interface IRoleAwarenessNeuron extends IModulatableNeuron {
+    AgentRole ownRole();
+    void setOwnRole(AgentRole r);
+    void onPeerState(PeerStateSignal s);
+    /** Snapshot of role counts in the local neighbourhood. */
+    Map<AgentRole, Integer> distribution();
+    /** Returns the under-represented role the agent is biased toward, or null when balanced. */
+    AgentRole shortageRole();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IStigmergicMemoryNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IStigmergicMemoryNeuron.java
@@ -1,0 +1,17 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PheromoneSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.StigmergicTraceSignal;
+
+import java.util.List;
+
+public interface IStigmergicMemoryNeuron extends IModulatableNeuron {
+    void deposit(StigmergicTraceSignal trace);
+    void deposit(PheromoneSignal p);
+    /** Drop entries whose decay tick has passed. Returns the number evicted. */
+    int evict(long currentTick);
+    List<StigmergicTraceSignal> tracesNear(double[] origin, double radius);
+    List<PheromoneSignal> pheromonesNear(double[] origin, double radius);
+    int size();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/ISwarmDensityNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/ISwarmDensityNeuron.java
@@ -1,0 +1,13 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+
+public interface ISwarmDensityNeuron extends IModulatableNeuron {
+    void observeNeighbour(double[] relativePosition);
+    int neighbourCount();
+    /** Returns &gt;0 if too dense (disperse), &lt;0 if too sparse (aggregate), 0 if balanced. */
+    double densityBias();
+    void setMinNeighbours(int n);
+    void setMaxNeighbours(int n);
+    void clear();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/ISwarmHarmGateNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/ISwarmHarmGateNeuron.java
@@ -1,0 +1,22 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.SwarmAlertSignal;
+
+public interface ISwarmHarmGateNeuron extends IModulatableNeuron {
+    /** Record this agent's projected emission (thermal / EM / chemical / etc.) for the region. */
+    void recordEmission(String regionId, String agentId, double projectedEmission);
+    /** Aggregate regional emission and emit a SwarmAlert when the threshold is exceeded. */
+    SwarmAlertSignal aggregate(String regionId);
+    void setRegionalThreshold(String regionId, double threshold);
+    double currentEmission(String regionId);
+    /** Multiplier in [1, n] that downstream HarmGateNeuron should apply. */
+    double tighteningMultiplier(String regionId);
+
+    /**
+     * Observation channel: an external alert (e.g. from a regional
+     * aggregator) tightens local thresholds even before the agent's own
+     * accounting catches up. Default is a no-op.
+     */
+    default void onAlert(SwarmAlertSignal a) { /* no-op by default */ }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/ITaskRegistryNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/ITaskRegistryNeuron.java
@@ -1,0 +1,23 @@
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.IModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskAnnouncementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskAssignmentSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskBidSignal;
+
+import java.util.Set;
+
+public interface ITaskRegistryNeuron extends IModulatableNeuron {
+    void register(TaskAnnouncementSignal a);
+    void assign(TaskAssignmentSignal a);
+    Set<String> activeTasks();
+    String assigneeOf(String taskId);
+    boolean isOpen(String taskId);
+
+    /**
+     * Observation channel: record that a bid arrived for a known task —
+     * a deployment can wire this into a winner-selection step. Default
+     * is a no-op so existing implementations stay unchanged.
+     */
+    default void observeBid(TaskBidSignal b) { /* no-op by default */ }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IsolationProtocolNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/IsolationProtocolNeuron.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.AgentAnomalySignal;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Layer 5 Byzantine-tolerance isolation. Quarantines a peer only after
+ * {@code witnessThreshold} independent reports. Isolation is
+ * time-bounded — repeats double the duration but never permanently
+ * isolate locally. Loop=1 / Epoch=1.
+ */
+public class IsolationProtocolNeuron extends ModulatableNeuron implements IIsolationProtocolNeuron {
+
+    private final Map<String, Set<String>> witnesses = new HashMap<>();
+    private final Map<String, Long> isolatedUntil = new HashMap<>();
+    private final Map<String, Integer> escalations = new HashMap<>();
+    private int witnessThreshold = 3;
+    private long isolationTicks = 600;
+
+    public IsolationProtocolNeuron() { super(); }
+    public IsolationProtocolNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void setWitnessThreshold(int k) { this.witnessThreshold = Math.max(1, k); }
+    @Override public int getWitnessThreshold() { return witnessThreshold; }
+    @Override public void setIsolationTicks(long t) { this.isolationTicks = Math.max(1L, t); }
+    @Override public long getIsolationTicks() { return isolationTicks; }
+
+    @Override
+    public boolean onReport(AgentAnomalySignal report, long currentTick) {
+        if (report == null || report.getSuspectId() == null) return false;
+        Set<String> w = witnesses.computeIfAbsent(report.getSuspectId(), k -> new HashSet<>());
+        if (report.getDetectorId() != null) w.add(report.getDetectorId());
+        for (String wn : report.getWitnesses()) if (wn != null) w.add(wn);
+        if (w.size() < witnessThreshold) return false;
+        int prev = escalations.getOrDefault(report.getSuspectId(), 0);
+        long mult = 1L << Math.min(prev, 8);
+        isolatedUntil.put(report.getSuspectId(), currentTick + isolationTicks * mult);
+        escalations.put(report.getSuspectId(), prev + 1);
+        return true;
+    }
+
+    @Override
+    public boolean isIsolated(String peerId, long currentTick) {
+        Long u = isolatedUntil.get(peerId);
+        return u != null && u > currentTick;
+    }
+
+    @Override
+    public int tick(long currentTick) {
+        int n = 0;
+        Iterator<Map.Entry<String, Long>> it = isolatedUntil.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<String, Long> e = it.next();
+            if (e.getValue() <= currentTick) {
+                it.remove();
+                witnesses.remove(e.getKey());
+                n++;
+            }
+        }
+        return n;
+    }
+
+    @Override
+    public int activeIsolations(long currentTick) {
+        int n = 0;
+        for (Long u : isolatedUntil.values()) if (u > currentTick) n++;
+        return n;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/MeshRadioNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/MeshRadioNeuron.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Layer 0 mesh radio. Drops outbound signals when link quality falls
+ * below the configured threshold so downstream consumers see realistic
+ * loss. Loop=1 / Epoch=1.
+ */
+public class MeshRadioNeuron extends ModulatableNeuron implements IMeshRadioNeuron {
+
+    private double lossThreshold = 0.2;
+    private long sent;
+    private long dropped;
+
+    public MeshRadioNeuron() { super(); }
+    public MeshRadioNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override
+    public boolean send(ISignal s, double linkQuality) {
+        if (s == null) return false;
+        if (linkQuality < lossThreshold) { dropped++; return false; }
+        sent++;
+        return true;
+    }
+
+    @Override public long getSent() { return sent; }
+    @Override public long getDropped() { return dropped; }
+    @Override public void setLossThreshold(double t) { this.lossThreshold = Math.max(0.0, Math.min(1.0, t)); }
+    @Override public double getLossThreshold() { return lossThreshold; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/PeerObservationNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/PeerObservationNeuron.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerObservationSignal;
+
+/**
+ * Layer 0 peer-detection neuron. Drops observations whose link
+ * quality is below {@link #getMinLinkQuality()} so downstream consumers
+ * don't waste cycles on noise. Loop=1 / Epoch=2.
+ */
+public class PeerObservationNeuron extends ModulatableNeuron implements IPeerObservationNeuron {
+
+    private long observationCount;
+    private double minLinkQuality;
+
+    public PeerObservationNeuron() { super(); }
+    public PeerObservationNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override
+    public PeerObservationSignal observe(String peerId, double[] positionLocal,
+                                          double[] velocityLocal, double linkQuality) {
+        if (peerId == null || linkQuality < minLinkQuality) return null;
+        observationCount++;
+        return new PeerObservationSignal(peerId, positionLocal, velocityLocal, linkQuality);
+    }
+
+    @Override public long getObservationCount() { return observationCount; }
+    @Override public void setMinLinkQuality(double q) { this.minLinkQuality = Math.max(0.0, Math.min(1.0, q)); }
+    @Override public double getMinLinkQuality() { return minLinkQuality; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/PeerStateIntegrationNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/PeerStateIntegrationNeuron.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerObservationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerStateSignal;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Layer 2 local-view of neighbours. Tracks last-seen tick + role per
+ * peer; entries older than {@code stalenessTicks} are evicted.
+ * Loop=2 / Epoch=1.
+ */
+public class PeerStateIntegrationNeuron extends ModulatableNeuron implements IPeerStateIntegrationNeuron {
+
+    private final Map<String, Long> lastSeen = new HashMap<>();
+    private final Map<String, AgentRole> roleByPeer = new HashMap<>();
+    private long stalenessTicks = 300;
+
+    public PeerStateIntegrationNeuron() { super(); }
+    public PeerStateIntegrationNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override
+    public void onObservation(PeerObservationSignal o, long currentTick) {
+        if (o == null || o.getPeerId() == null) return;
+        lastSeen.put(o.getPeerId(), currentTick);
+    }
+
+    @Override
+    public void onState(PeerStateSignal s, long currentTick) {
+        if (s == null || s.getPeerId() == null) return;
+        lastSeen.put(s.getPeerId(), currentTick);
+        roleByPeer.put(s.getPeerId(), s.getRole());
+    }
+
+    @Override
+    public int evict(long currentTick) {
+        int n = 0;
+        Iterator<Map.Entry<String, Long>> it = lastSeen.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<String, Long> e = it.next();
+            if (currentTick - e.getValue() > stalenessTicks) {
+                it.remove();
+                roleByPeer.remove(e.getKey());
+                n++;
+            }
+        }
+        return n;
+    }
+
+    @Override public Set<String> knownPeers() { return new HashSet<>(lastSeen.keySet()); }
+    @Override public Map<String, AgentRole> roleSnapshot() { return Collections.unmodifiableMap(new HashMap<>(roleByPeer)); }
+    @Override public Long lastSeen(String peerId) { return lastSeen.get(peerId); }
+    @Override public void setStalenessTicks(long t) { this.stalenessTicks = Math.max(1L, t); }
+    @Override public long getStalenessTicks() { return stalenessTicks; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/PheromoneKind.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/PheromoneKind.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+/**
+ * Biologically-validated stigmergy categories: TRAIL (routing), ALARM
+ * (dispersal), RECRUITMENT (aggregation), TERRITORY (claim / avoid),
+ * FOOD (reward signal).
+ */
+public enum PheromoneKind { TRAIL, ALARM, RECRUITMENT, TERRITORY, FOOD }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/RoleAwarenessNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/RoleAwarenessNeuron.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerStateSignal;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 2 role-distribution awareness. Maintains an EnumMap of how
+ * many peers are in each role and exposes the under-represented role
+ * the agent should bias its specialisation toward. Loop=2 / Epoch=2.
+ */
+public class RoleAwarenessNeuron extends ModulatableNeuron implements IRoleAwarenessNeuron {
+
+    private AgentRole ownRole = AgentRole.IDLE;
+    private final Map<String, AgentRole> peers = new HashMap<>();
+
+    public RoleAwarenessNeuron() { super(); }
+    public RoleAwarenessNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public AgentRole ownRole() { return ownRole; }
+    @Override public void setOwnRole(AgentRole r) { this.ownRole = r == null ? AgentRole.IDLE : r; }
+
+    @Override public void onPeerState(PeerStateSignal s) {
+        if (s == null || s.getPeerId() == null) return;
+        peers.put(s.getPeerId(), s.getRole());
+    }
+
+    @Override
+    public Map<AgentRole, Integer> distribution() {
+        EnumMap<AgentRole, Integer> dist = new EnumMap<>(AgentRole.class);
+        for (AgentRole r : AgentRole.values()) dist.put(r, 0);
+        for (AgentRole r : peers.values()) dist.merge(r, 1, Integer::sum);
+        return Collections.unmodifiableMap(dist);
+    }
+
+    @Override
+    public AgentRole shortageRole() {
+        Map<AgentRole, Integer> d = distribution();
+        AgentRole minRole = null;
+        int minCount = Integer.MAX_VALUE;
+        for (AgentRole r : AgentRole.values()) {
+            if (r == AgentRole.IDLE) continue;
+            int c = d.getOrDefault(r, 0);
+            if (c < minCount) { minCount = c; minRole = r; }
+        }
+        return minRole;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/StigmergicMemoryNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/StigmergicMemoryNeuron.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PheromoneSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.StigmergicTraceSignal;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Layer 3 spatial cache of pheromone + trace markers. Loop=2 / Epoch=5.
+ */
+public class StigmergicMemoryNeuron extends ModulatableNeuron implements IStigmergicMemoryNeuron {
+
+    private final List<StigmergicTraceSignal> traces = new ArrayList<>();
+    private final List<PheromoneSignal> pheromones = new ArrayList<>();
+
+    public StigmergicMemoryNeuron() { super(); }
+    public StigmergicMemoryNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void deposit(StigmergicTraceSignal t) { if (t != null) traces.add(t); }
+    @Override public void deposit(PheromoneSignal p) { if (p != null) pheromones.add(p); }
+
+    @Override
+    public int evict(long currentTick) {
+        int n = 0;
+        Iterator<PheromoneSignal> it = pheromones.iterator();
+        while (it.hasNext()) {
+            PheromoneSignal p = it.next();
+            if (p.getDecayTick() > 0 && p.getDecayTick() <= currentTick) { it.remove(); n++; }
+        }
+        return n;
+    }
+
+    @Override
+    public List<StigmergicTraceSignal> tracesNear(double[] origin, double radius) {
+        List<StigmergicTraceSignal> out = new ArrayList<>();
+        if (origin == null) return out;
+        double r2 = radius * radius;
+        for (StigmergicTraceSignal t : traces) {
+            if (within(t.getLocationGlobal(), origin, r2)) out.add(t);
+        }
+        return out;
+    }
+
+    @Override
+    public List<PheromoneSignal> pheromonesNear(double[] origin, double radius) {
+        List<PheromoneSignal> out = new ArrayList<>();
+        if (origin == null) return out;
+        double r2 = radius * radius;
+        for (PheromoneSignal p : pheromones) {
+            if (within(p.getLocationGlobal(), origin, r2)) out.add(p);
+        }
+        return out;
+    }
+
+    @Override public int size() { return traces.size() + pheromones.size(); }
+
+    private static boolean within(double[] a, double[] b, double r2) {
+        if (a == null || b == null) return false;
+        int n = Math.min(a.length, b.length);
+        double sum = 0.0;
+        for (int i = 0; i < n; i++) { double d = a[i] - b[i]; sum += d * d; }
+        return sum <= r2;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/SwarmConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/SwarmConfig.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+/**
+ * Configuration for the swarm-robotics module. Mirrors spec §9.
+ * Per spec §12: lethal autonomous weapons are out of scope and the
+ * affect module must not be enabled in this module — both are
+ * exposed as program-level read-only flags.
+ */
+public final class SwarmConfig {
+
+    private boolean enabled = true;
+    private String agentId = "bot-000";
+
+    // transport
+    private String primaryTransport = "dds";
+    private String fallbackTransport = "mqtt";
+    private boolean loraMesh = true;
+    private int bandwidthKbps = 100;
+
+    // neighbourhood
+    private int maxPeers = 12;
+    private long stalenessTicks = 300;
+
+    // consensus
+    private String consensusProtocol = "gossip-crdt";
+    private int quorumWitnessCount = 3;
+
+    // auction
+    private long bidTimeoutTicks = 50;
+    private String tieBreaker = "lowest-id";
+
+    // flocking
+    private double separation = 1.0;
+    private double alignment = 0.7;
+    private double cohesion = 0.5;
+    private double radius = 5.0;
+
+    // stigmergy
+    private boolean stigmergyEnabled = true;
+    private long defaultDecayTicks = 1000;
+
+    // byzantine
+    private int anomalyThresholdVotes = 3;
+    private long isolationTicks = 600;
+    private int maxReputationHistory = 1000;
+
+    // collective harm
+    private String regionalThresholdConfig = "regional-thresholds.yaml";
+    private String aggregatorElection = "raft-lite";
+
+    // curiosity
+    private boolean curiosityEnabled = true;
+    private boolean roleDifferentiation = true;
+
+    // hard out-of-scope flags
+    private final boolean lawsEnabled = false;       // lethal autonomous weapons — fixed off
+    private final boolean affectEnabled = false;     // affect module — fixed off in swarm
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean v) { this.enabled = v; }
+    public String getAgentId() { return agentId; }
+    public void setAgentId(String s) { this.agentId = s; }
+
+    public String getPrimaryTransport() { return primaryTransport; }
+    public void setPrimaryTransport(String s) { this.primaryTransport = s; }
+    public String getFallbackTransport() { return fallbackTransport; }
+    public void setFallbackTransport(String s) { this.fallbackTransport = s; }
+    public boolean isLoraMesh() { return loraMesh; }
+    public void setLoraMesh(boolean v) { this.loraMesh = v; }
+    public int getBandwidthKbps() { return bandwidthKbps; }
+    public void setBandwidthKbps(int v) { this.bandwidthKbps = Math.max(1, v); }
+
+    public int getMaxPeers() { return maxPeers; }
+    public void setMaxPeers(int v) { this.maxPeers = Math.max(1, v); }
+    public long getStalenessTicks() { return stalenessTicks; }
+    public void setStalenessTicks(long v) { this.stalenessTicks = Math.max(1L, v); }
+
+    public String getConsensusProtocol() { return consensusProtocol; }
+    public void setConsensusProtocol(String s) { this.consensusProtocol = s; }
+    public int getQuorumWitnessCount() { return quorumWitnessCount; }
+    public void setQuorumWitnessCount(int v) {
+        // Spec §7: "minimum 3 for Byzantine f=1 tolerance on a small swarm".
+        if (v < 3) throw new IllegalArgumentException("quorum-witness-count must be ≥ 3");
+        this.quorumWitnessCount = v;
+    }
+
+    public long getBidTimeoutTicks() { return bidTimeoutTicks; }
+    public void setBidTimeoutTicks(long v) { this.bidTimeoutTicks = Math.max(1L, v); }
+    public String getTieBreaker() { return tieBreaker; }
+    public void setTieBreaker(String s) { this.tieBreaker = s; }
+
+    public double getSeparation() { return separation; }
+    public void setSeparation(double v) { this.separation = v; }
+    public double getAlignment() { return alignment; }
+    public void setAlignment(double v) { this.alignment = v; }
+    public double getCohesion() { return cohesion; }
+    public void setCohesion(double v) { this.cohesion = v; }
+    public double getRadius() { return radius; }
+    public void setRadius(double v) { this.radius = Math.max(0.0, v); }
+
+    public boolean isStigmergyEnabled() { return stigmergyEnabled; }
+    public void setStigmergyEnabled(boolean v) { this.stigmergyEnabled = v; }
+    public long getDefaultDecayTicks() { return defaultDecayTicks; }
+    public void setDefaultDecayTicks(long v) { this.defaultDecayTicks = Math.max(1L, v); }
+
+    public int getAnomalyThresholdVotes() { return anomalyThresholdVotes; }
+    public void setAnomalyThresholdVotes(int v) {
+        if (v < 3) throw new IllegalArgumentException("anomaly-threshold-votes must be ≥ 3 (Byzantine f=1)");
+        this.anomalyThresholdVotes = v;
+    }
+    public long getIsolationTicks() { return isolationTicks; }
+    public void setIsolationTicks(long v) { this.isolationTicks = Math.max(1L, v); }
+    public int getMaxReputationHistory() { return maxReputationHistory; }
+    public void setMaxReputationHistory(int v) { this.maxReputationHistory = Math.max(1, v); }
+
+    public String getRegionalThresholdConfig() { return regionalThresholdConfig; }
+    public void setRegionalThresholdConfig(String s) { this.regionalThresholdConfig = s; }
+    public String getAggregatorElection() { return aggregatorElection; }
+    public void setAggregatorElection(String s) { this.aggregatorElection = s; }
+
+    public boolean isCuriosityEnabled() { return curiosityEnabled; }
+    public void setCuriosityEnabled(boolean v) { this.curiosityEnabled = v; }
+    public boolean isRoleDifferentiation() { return roleDifferentiation; }
+    public void setRoleDifferentiation(boolean v) { this.roleDifferentiation = v; }
+
+    /** Lethal autonomous weapons — fixed off. */
+    public boolean isLawsEnabled() { return lawsEnabled; }
+    /** Affect module is intentionally not used in swarm mode (spec §12). */
+    public boolean isAffectEnabled() { return affectEnabled; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/SwarmDensityNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/SwarmDensityNeuron.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+
+/** Layer 7 density homeostasis. Loop=2 / Epoch=2. */
+public class SwarmDensityNeuron extends ModulatableNeuron implements ISwarmDensityNeuron {
+
+    private int neighbours;
+    private int minNeighbours = 2;
+    private int maxNeighbours = 8;
+
+    public SwarmDensityNeuron() { super(); }
+    public SwarmDensityNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override public void observeNeighbour(double[] relativePosition) { neighbours++; }
+    @Override public int neighbourCount() { return neighbours; }
+
+    @Override
+    public double densityBias() {
+        if (neighbours > maxNeighbours) return (neighbours - maxNeighbours) / (double) Math.max(1, maxNeighbours);
+        if (neighbours < minNeighbours) return -(minNeighbours - neighbours) / (double) Math.max(1, minNeighbours);
+        return 0.0;
+    }
+
+    @Override public void setMinNeighbours(int n) { this.minNeighbours = Math.max(0, n); }
+    @Override public void setMaxNeighbours(int n) { this.maxNeighbours = Math.max(this.minNeighbours, n); }
+    @Override public void clear() { neighbours = 0; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/SwarmHarmGateNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/SwarmHarmGateNeuron.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.SwarmAlertSignal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Layer 5 collective harm aggregator. Sums per-agent projected
+ * emissions in a region; emits a {@link SwarmAlertSignal} when the
+ * sum exceeds the regional threshold. Loop=1 / Epoch=1.
+ */
+public class SwarmHarmGateNeuron extends ModulatableNeuron implements ISwarmHarmGateNeuron {
+
+    private final Map<String, Map<String, Double>> regionalEmissions = new HashMap<>();
+    private final Map<String, Double> thresholds = new HashMap<>();
+
+    public SwarmHarmGateNeuron() { super(); }
+    public SwarmHarmGateNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override
+    public void recordEmission(String regionId, String agentId, double projectedEmission) {
+        if (regionId == null || agentId == null) return;
+        regionalEmissions.computeIfAbsent(regionId, k -> new HashMap<>())
+                .put(agentId, Math.max(0.0, projectedEmission));
+    }
+
+    @Override
+    public SwarmAlertSignal aggregate(String regionId) {
+        if (regionId == null) return null;
+        double total = currentEmission(regionId);
+        Double thr = thresholds.get(regionId);
+        if (thr == null || total <= thr) return null;
+        double severity = Math.min(1.0, (total - thr) / Math.max(1e-6, thr));
+        return new SwarmAlertSignal(AlertCategory.COLLECTIVE_HARM, regionId, severity);
+    }
+
+    @Override public void setRegionalThreshold(String regionId, double threshold) {
+        if (regionId != null) thresholds.put(regionId, Math.max(0.0, threshold));
+    }
+
+    @Override
+    public double currentEmission(String regionId) {
+        Map<String, Double> m = regionalEmissions.get(regionId);
+        if (m == null) return 0.0;
+        double sum = 0.0;
+        for (Double v : m.values()) sum += v;
+        return sum;
+    }
+
+    @Override
+    public double tighteningMultiplier(String regionId) {
+        Double thr = thresholds.get(regionId);
+        if (thr == null || thr <= 0) return 1.0;
+        double total = currentEmission(regionId);
+        if (total <= thr) return 1.0;
+        return Math.min(5.0, total / thr);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/TaskKind.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/TaskKind.java
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+public enum TaskKind { EXPLORE, SEARCH, RESCUE, TRANSPORT, GUARD, INSPECT, DELIVER }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/TaskRegistryNeuron.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/TaskRegistryNeuron.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.ai.neurons.base.ModulatableNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalChain;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskAnnouncementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskAssignmentSignal;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/** Layer 3 active-task registry, reconciled via consensus. Loop=2 / Epoch=1. */
+public class TaskRegistryNeuron extends ModulatableNeuron implements ITaskRegistryNeuron {
+
+    private final Set<String> open = new HashSet<>();
+    private final Map<String, String> assignedTo = new HashMap<>();
+
+    public TaskRegistryNeuron() { super(); }
+    public TaskRegistryNeuron(Long neuronId, ISignalChain chain, Long run) { super(neuronId, chain, run); }
+
+    @Override
+    public void register(TaskAnnouncementSignal a) {
+        if (a == null || a.getTaskId() == null) return;
+        open.add(a.getTaskId());
+    }
+
+    @Override
+    public void assign(TaskAssignmentSignal a) {
+        if (a == null || a.getTaskId() == null) return;
+        if (a.getAssigneeId() != null) assignedTo.put(a.getTaskId(), a.getAssigneeId());
+        open.remove(a.getTaskId());
+    }
+
+    @Override public Set<String> activeTasks() { return new HashSet<>(open); }
+    @Override public String assigneeOf(String taskId) { return assignedTo.get(taskId); }
+    @Override public boolean isOpen(String taskId) { return open.contains(taskId); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/TraceKind.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/TraceKind.java
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+/** Persistent-on-environment stigmergy marker kinds. */
+public enum TraceKind { VISITED, PATH, HAZARD, LANDMARK, TARGET_FOUND }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/VoteKind.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/VoteKind.java
@@ -1,0 +1,6 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+public enum VoteKind { YES, NO, ABSTAIN }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * Swarm-robotics &amp; distributed multi-agent coordination module.
+ * Implements {@code use-case-swarm-robotics.md}: peer sensing, role
+ * specialisation, stigmergic coordination, auction-based task
+ * allocation, light-weight consensus, Reynolds flocking, formation
+ * keeping, Byzantine-tolerant isolation, and collective-harm
+ * aggregation.
+ *
+ * <p>Architectural invariants:
+ * <ul>
+ *   <li>Quarantine is never permanent locally —
+ *       {@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.IsolationProtocolNeuron}
+ *       expires every entry; repeats double the duration but a global
+ *       consensus is required for permanent removal.</li>
+ *   <li>Anomaly reports require ≥ k independent witnesses before
+ *       isolation fires — minimum 3 per
+ *       {@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.SwarmConfig#setAnomalyThresholdVotes(int)};
+ *       any value below 3 throws.</li>
+ *   <li>Lethal autonomous weapons are out of scope: {@code SwarmConfig.isLawsEnabled()}
+ *       returns {@code false} and cannot be flipped at runtime.</li>
+ *   <li>Communication is realistic: every peer signal carries a
+ *       {@code linkQuality}; processors weight contributions
+ *       accordingly.</li>
+ * </ul>
+ *
+ * @see com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/AgentAnomalySignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/AgentAnomalySignal.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.AnomalyKind;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Anomaly report against a peer agent. ProcessingFrequency: loop=2, epoch=1. */
+public class AgentAnomalySignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 2);
+
+    private String suspectId;
+    private AnomalyKind kind;
+    private String detectorId;
+    private List<String> witnesses;
+
+    public AgentAnomalySignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 1L;
+        this.timeAlive = 500;
+        this.kind = AnomalyKind.SILENT;
+        this.witnesses = new ArrayList<>();
+    }
+
+    public AgentAnomalySignal(String suspectId, AnomalyKind kind, String detectorId, List<String> witnesses) {
+        this();
+        this.suspectId = suspectId;
+        this.kind = kind == null ? AnomalyKind.SILENT : kind;
+        this.detectorId = detectorId;
+        this.witnesses = witnesses == null ? new ArrayList<>() : new ArrayList<>(witnesses);
+    }
+
+    public String getSuspectId() { return suspectId; }
+    public void setSuspectId(String s) { this.suspectId = s; }
+    public AnomalyKind getKind() { return kind; }
+    public void setKind(AnomalyKind k) { this.kind = k == null ? AnomalyKind.SILENT : k; }
+    public String getDetectorId() { return detectorId; }
+    public void setDetectorId(String d) { this.detectorId = d; }
+    public List<String> getWitnesses() { return Collections.unmodifiableList(witnesses); }
+    public void setWitnesses(List<String> w) { this.witnesses = w == null ? new ArrayList<>() : new ArrayList<>(w); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return AgentAnomalySignal.class; }
+    @Override public String getDescription() { return "AgentAnomalySignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        AgentAnomalySignal c = new AgentAnomalySignal(suspectId, kind, detectorId, witnesses);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/ConsensusProposalSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/ConsensusProposalSignal.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/** Light-weight consensus proposal. ProcessingFrequency: loop=2, epoch=1. */
+public class ConsensusProposalSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 2);
+
+    private String proposalId;
+    private String proposedState;
+    private String proposerId;
+
+    public ConsensusProposalSignal() { super(); this.loop = 2; this.epoch = 1L; this.timeAlive = 500; }
+
+    public ConsensusProposalSignal(String proposalId, String proposedState, String proposerId) {
+        this();
+        this.proposalId = proposalId;
+        this.proposedState = proposedState;
+        this.proposerId = proposerId;
+    }
+
+    public String getProposalId() { return proposalId; }
+    public void setProposalId(String p) { this.proposalId = p; }
+    public String getProposedState() { return proposedState; }
+    public void setProposedState(String s) { this.proposedState = s; }
+    public String getProposerId() { return proposerId; }
+    public void setProposerId(String p) { this.proposerId = p; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return ConsensusProposalSignal.class; }
+    @Override public String getDescription() { return "ConsensusProposalSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        ConsensusProposalSignal c = new ConsensusProposalSignal(proposalId, proposedState, proposerId);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/ConsensusVoteSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/ConsensusVoteSignal.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.VoteKind;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/** Single vote on a consensus proposal. ProcessingFrequency: loop=2, epoch=1. */
+public class ConsensusVoteSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 2);
+
+    private String proposalId;
+    private VoteKind vote;
+    private String voterId;
+
+    public ConsensusVoteSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 1L;
+        this.timeAlive = 500;
+        this.vote = VoteKind.ABSTAIN;
+    }
+
+    public ConsensusVoteSignal(String proposalId, VoteKind vote, String voterId) {
+        this();
+        this.proposalId = proposalId;
+        this.vote = vote == null ? VoteKind.ABSTAIN : vote;
+        this.voterId = voterId;
+    }
+
+    public String getProposalId() { return proposalId; }
+    public void setProposalId(String p) { this.proposalId = p; }
+    public VoteKind getVote() { return vote; }
+    public void setVote(VoteKind v) { this.vote = v == null ? VoteKind.ABSTAIN : v; }
+    public String getVoterId() { return voterId; }
+    public void setVoterId(String v) { this.voterId = v; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return ConsensusVoteSignal.class; }
+    @Override public String getDescription() { return "ConsensusVoteSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        ConsensusVoteSignal c = new ConsensusVoteSignal(proposalId, vote, voterId);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/FormationSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/FormationSignal.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.FormationTemplate;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/** Formation slot assignment for the receiving agent. ProcessingFrequency: loop=1, epoch=2. */
+public class FormationSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
+
+    private FormationTemplate template;
+    private int slotIndex;
+    private double[] relativeOffset;
+
+    public FormationSignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 2L;
+        this.timeAlive = 200;
+        this.template = FormationTemplate.FREE;
+    }
+
+    public FormationSignal(FormationTemplate template, int slotIndex, double[] relativeOffset) {
+        this();
+        this.template = template == null ? FormationTemplate.FREE : template;
+        this.slotIndex = slotIndex;
+        this.relativeOffset = relativeOffset == null ? null : relativeOffset.clone();
+    }
+
+    public FormationTemplate getTemplate() { return template; }
+    public void setTemplate(FormationTemplate t) { this.template = t == null ? FormationTemplate.FREE : t; }
+    public int getSlotIndex() { return slotIndex; }
+    public void setSlotIndex(int s) { this.slotIndex = s; }
+    public double[] getRelativeOffset() { return relativeOffset == null ? null : relativeOffset.clone(); }
+    public void setRelativeOffset(double[] r) { this.relativeOffset = r == null ? null : r.clone(); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return FormationSignal.class; }
+    @Override public String getDescription() { return "FormationSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        FormationSignal c = new FormationSignal(template, slotIndex, relativeOffset);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/PeerObservationSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/PeerObservationSignal.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * One observation of a peer — position / velocity in local frame plus a
+ * link-quality indicator. Per spec §3: no perfect-comms assumption.
+ * ProcessingFrequency: loop=1, epoch=2.
+ */
+public class PeerObservationSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
+
+    private String peerId;
+    private double[] positionLocal;
+    private double[] velocityLocal;
+    private double linkQuality;
+
+    public PeerObservationSignal() { super(); this.loop = 1; this.epoch = 2L; this.timeAlive = 100; }
+
+    public PeerObservationSignal(String peerId, double[] positionLocal, double[] velocityLocal, double linkQuality) {
+        this();
+        this.peerId = peerId;
+        this.positionLocal = positionLocal == null ? null : positionLocal.clone();
+        this.velocityLocal = velocityLocal == null ? null : velocityLocal.clone();
+        this.linkQuality = Math.max(0.0, Math.min(1.0, linkQuality));
+    }
+
+    public String getPeerId() { return peerId; }
+    public void setPeerId(String p) { this.peerId = p; }
+    public double[] getPositionLocal() { return positionLocal == null ? null : positionLocal.clone(); }
+    public void setPositionLocal(double[] v) { this.positionLocal = v == null ? null : v.clone(); }
+    public double[] getVelocityLocal() { return velocityLocal == null ? null : velocityLocal.clone(); }
+    public void setVelocityLocal(double[] v) { this.velocityLocal = v == null ? null : v.clone(); }
+    public double getLinkQuality() { return linkQuality; }
+    public void setLinkQuality(double l) { this.linkQuality = Math.max(0.0, Math.min(1.0, l)); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return PeerObservationSignal.class; }
+    @Override public String getDescription() { return "PeerObservationSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        PeerObservationSignal c = new PeerObservationSignal(peerId, positionLocal, velocityLocal, linkQuality);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/PeerStateSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/PeerStateSignal.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.AgentRole;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Role / battery / health snapshot broadcast by a peer.
+ * ProcessingFrequency: loop=2, epoch=1.
+ */
+public class PeerStateSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 2);
+
+    private String peerId;
+    private AgentRole role;
+    private double battery;
+    private double health;
+    private Map<String, Double> capabilities;
+
+    public PeerStateSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 1L;
+        this.timeAlive = 300;
+        this.role = AgentRole.IDLE;
+        this.capabilities = new HashMap<>();
+    }
+
+    public PeerStateSignal(String peerId, AgentRole role, double battery, double health,
+                           Map<String, Double> capabilities) {
+        this();
+        this.peerId = peerId;
+        this.role = role == null ? AgentRole.IDLE : role;
+        this.battery = Math.max(0.0, Math.min(1.0, battery));
+        this.health = Math.max(0.0, Math.min(1.0, health));
+        this.capabilities = capabilities == null ? new HashMap<>() : new HashMap<>(capabilities);
+    }
+
+    public String getPeerId() { return peerId; }
+    public void setPeerId(String p) { this.peerId = p; }
+    public AgentRole getRole() { return role; }
+    public void setRole(AgentRole r) { this.role = r == null ? AgentRole.IDLE : r; }
+    public double getBattery() { return battery; }
+    public void setBattery(double b) { this.battery = Math.max(0.0, Math.min(1.0, b)); }
+    public double getHealth() { return health; }
+    public void setHealth(double h) { this.health = Math.max(0.0, Math.min(1.0, h)); }
+    public Map<String, Double> getCapabilities() { return Collections.unmodifiableMap(capabilities); }
+    public void setCapabilities(Map<String, Double> c) {
+        this.capabilities = c == null ? new HashMap<>() : new HashMap<>(c);
+    }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return PeerStateSignal.class; }
+    @Override public String getDescription() { return "PeerStateSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        PeerStateSignal c = new PeerStateSignal(peerId, role, battery, health, capabilities);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/PheromoneSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/PheromoneSignal.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.PheromoneKind;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Spatial neuromodulator broadcast — biologically-validated stigmergy
+ * categories. Per spec §6 this is the swarm's "spatial NeuromodulatorSignal".
+ * ProcessingFrequency: loop=2, epoch=2.
+ */
+public class PheromoneSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 2);
+
+    private PheromoneKind kind;
+    private double[] locationGlobal;
+    private double strength;
+    private long decayTick;
+
+    public PheromoneSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 2L;
+        this.timeAlive = 1000;
+        this.kind = PheromoneKind.TRAIL;
+    }
+
+    public PheromoneSignal(PheromoneKind kind, double[] locationGlobal, double strength, long decayTick) {
+        this();
+        this.kind = kind == null ? PheromoneKind.TRAIL : kind;
+        this.locationGlobal = locationGlobal == null ? null : locationGlobal.clone();
+        this.strength = Math.max(0.0, strength);
+        this.decayTick = decayTick;
+    }
+
+    public PheromoneKind getKind() { return kind; }
+    public void setKind(PheromoneKind k) { this.kind = k == null ? PheromoneKind.TRAIL : k; }
+    public double[] getLocationGlobal() { return locationGlobal == null ? null : locationGlobal.clone(); }
+    public void setLocationGlobal(double[] v) { this.locationGlobal = v == null ? null : v.clone(); }
+    public double getStrength() { return strength; }
+    public void setStrength(double s) { this.strength = Math.max(0.0, s); }
+    public long getDecayTick() { return decayTick; }
+    public void setDecayTick(long d) { this.decayTick = d; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return PheromoneSignal.class; }
+    @Override public String getDescription() { return "PheromoneSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        PheromoneSignal c = new PheromoneSignal(kind, locationGlobal, strength, decayTick);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/StigmergicTraceSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/StigmergicTraceSignal.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.TraceKind;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Persistent-on-environment marker for hardware-deposit-capable agents.
+ * ProcessingFrequency: loop=2, epoch=5.
+ */
+public class StigmergicTraceSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(5L, 2);
+
+    private double[] locationGlobal;
+    private TraceKind kind;
+    private double saliency;
+    private long tickDeposited;
+
+    public StigmergicTraceSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 5L;
+        this.timeAlive = 5000;
+        this.kind = TraceKind.VISITED;
+    }
+
+    public StigmergicTraceSignal(double[] locationGlobal, TraceKind kind, double saliency, long tickDeposited) {
+        this();
+        this.locationGlobal = locationGlobal == null ? null : locationGlobal.clone();
+        this.kind = kind == null ? TraceKind.VISITED : kind;
+        this.saliency = Math.max(0.0, Math.min(1.0, saliency));
+        this.tickDeposited = tickDeposited;
+    }
+
+    public double[] getLocationGlobal() { return locationGlobal == null ? null : locationGlobal.clone(); }
+    public void setLocationGlobal(double[] v) { this.locationGlobal = v == null ? null : v.clone(); }
+    public TraceKind getKind() { return kind; }
+    public void setKind(TraceKind k) { this.kind = k == null ? TraceKind.VISITED : k; }
+    public double getSaliency() { return saliency; }
+    public void setSaliency(double s) { this.saliency = Math.max(0.0, Math.min(1.0, s)); }
+    public long getTickDeposited() { return tickDeposited; }
+    public void setTickDeposited(long t) { this.tickDeposited = t; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return StigmergicTraceSignal.class; }
+    @Override public String getDescription() { return "StigmergicTraceSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        StigmergicTraceSignal c = new StigmergicTraceSignal(locationGlobal, kind, saliency, tickDeposited);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/SwarmAlertSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/SwarmAlertSignal.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.AlertCategory;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Regional swarm alert — collective harm or environmental hazard
+ * detected. ProcessingFrequency: loop=1, epoch=1.
+ */
+public class SwarmAlertSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private AlertCategory category;
+    private String regionId;
+    private double severity;
+
+    public SwarmAlertSignal() {
+        super();
+        this.loop = 1;
+        this.epoch = 1L;
+        this.timeAlive = 50;
+        this.category = AlertCategory.ENVIRONMENTAL;
+    }
+
+    public SwarmAlertSignal(AlertCategory category, String regionId, double severity) {
+        this();
+        this.category = category == null ? AlertCategory.ENVIRONMENTAL : category;
+        this.regionId = regionId;
+        this.severity = Math.max(0.0, Math.min(1.0, severity));
+    }
+
+    public AlertCategory getCategory() { return category; }
+    public void setCategory(AlertCategory c) { this.category = c == null ? AlertCategory.ENVIRONMENTAL : c; }
+    public String getRegionId() { return regionId; }
+    public void setRegionId(String r) { this.regionId = r; }
+    public double getSeverity() { return severity; }
+    public void setSeverity(double s) { this.severity = Math.max(0.0, Math.min(1.0, s)); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return SwarmAlertSignal.class; }
+    @Override public String getDescription() { return "SwarmAlertSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        SwarmAlertSignal c = new SwarmAlertSignal(category, regionId, severity);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/TaskAnnouncementSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/TaskAnnouncementSignal.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.TaskKind;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Announcement of a new task that any agent can bid on.
+ * ProcessingFrequency: loop=2, epoch=1.
+ */
+public class TaskAnnouncementSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 2);
+
+    private String taskId;
+    private TaskKind kind;
+    private double[] locationGlobal;
+    private double reward;
+    private long deadlineTick;
+
+    public TaskAnnouncementSignal() {
+        super();
+        this.loop = 2;
+        this.epoch = 1L;
+        this.timeAlive = 1000;
+        this.kind = TaskKind.EXPLORE;
+    }
+
+    public TaskAnnouncementSignal(String taskId, TaskKind kind, double[] locationGlobal,
+                                  double reward, long deadlineTick) {
+        this();
+        this.taskId = taskId;
+        this.kind = kind == null ? TaskKind.EXPLORE : kind;
+        this.locationGlobal = locationGlobal == null ? null : locationGlobal.clone();
+        this.reward = reward;
+        this.deadlineTick = deadlineTick;
+    }
+
+    public String getTaskId() { return taskId; }
+    public void setTaskId(String t) { this.taskId = t; }
+    public TaskKind getKind() { return kind; }
+    public void setKind(TaskKind k) { this.kind = k == null ? TaskKind.EXPLORE : k; }
+    public double[] getLocationGlobal() { return locationGlobal == null ? null : locationGlobal.clone(); }
+    public void setLocationGlobal(double[] v) { this.locationGlobal = v == null ? null : v.clone(); }
+    public double getReward() { return reward; }
+    public void setReward(double r) { this.reward = r; }
+    public long getDeadlineTick() { return deadlineTick; }
+    public void setDeadlineTick(long d) { this.deadlineTick = d; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return TaskAnnouncementSignal.class; }
+    @Override public String getDescription() { return "TaskAnnouncementSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        TaskAnnouncementSignal c = new TaskAnnouncementSignal(taskId, kind, locationGlobal, reward, deadlineTick);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/TaskAssignmentSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/TaskAssignmentSignal.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/** Outcome of an auction. ProcessingFrequency: loop=2, epoch=1. */
+public class TaskAssignmentSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 2);
+
+    private String taskId;
+    private String assigneeId;
+    private String witnessId;
+
+    public TaskAssignmentSignal() { super(); this.loop = 2; this.epoch = 1L; this.timeAlive = 500; }
+
+    public TaskAssignmentSignal(String taskId, String assigneeId, String witnessId) {
+        this();
+        this.taskId = taskId;
+        this.assigneeId = assigneeId;
+        this.witnessId = witnessId;
+    }
+
+    public String getTaskId() { return taskId; }
+    public void setTaskId(String t) { this.taskId = t; }
+    public String getAssigneeId() { return assigneeId; }
+    public void setAssigneeId(String a) { this.assigneeId = a; }
+    public String getWitnessId() { return witnessId; }
+    public void setWitnessId(String w) { this.witnessId = w; }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return TaskAssignmentSignal.class; }
+    @Override public String getDescription() { return "TaskAssignmentSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        TaskAssignmentSignal c = new TaskAssignmentSignal(taskId, assigneeId, witnessId);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/TaskBidSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/TaskBidSignal.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/** Per spec §4 — auction bid for a task. ProcessingFrequency: loop=2, epoch=1. */
+public class TaskBidSignal extends AbstractSignal<Void> implements ISignal<Void> {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 2);
+
+    private String taskId;
+    private String bidderId;
+    private double estimatedCost;
+    private double confidence;
+
+    public TaskBidSignal() { super(); this.loop = 2; this.epoch = 1L; this.timeAlive = 200; }
+
+    public TaskBidSignal(String taskId, String bidderId, double estimatedCost, double confidence) {
+        this();
+        this.taskId = taskId;
+        this.bidderId = bidderId;
+        this.estimatedCost = estimatedCost;
+        this.confidence = Math.max(0.0, Math.min(1.0, confidence));
+    }
+
+    public String getTaskId() { return taskId; }
+    public void setTaskId(String t) { this.taskId = t; }
+    public String getBidderId() { return bidderId; }
+    public void setBidderId(String b) { this.bidderId = b; }
+    public double getEstimatedCost() { return estimatedCost; }
+    public void setEstimatedCost(double c) { this.estimatedCost = c; }
+    public double getConfidence() { return confidence; }
+    public void setConfidence(double c) { this.confidence = Math.max(0.0, Math.min(1.0, c)); }
+
+    @Override public Void getValue() { return null; }
+    @Override public Class<Void> getParamClass() { return Void.class; }
+    @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return TaskBidSignal.class; }
+    @Override public String getDescription() { return "TaskBidSignal"; }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <K extends ISignal<Void>> K copySignal() {
+        TaskBidSignal c = new TaskBidSignal(taskId, bidderId, estimatedCost, confidence);
+        c.sourceLayer = this.sourceLayer;
+        c.sourceNeuron = this.sourceNeuron;
+        c.loop = this.loop;
+        c.epoch = this.epoch;
+        c.name = this.name;
+        return (K) c;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * Domain signals for the swarm-robotics module. Peer observations and
+ * flocking signals run on the fast loop (1/2, 1/1); peer state, task
+ * messages, votes, and anomaly reports on the slow loop (2/1);
+ * pheromones and stigmergic traces on 2/2 and 2/5; swarm alerts at
+ * 1/1 (must propagate fast). Every peer-bound signal carries a
+ * link-quality indicator per spec §3.
+ *
+ * @see com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/AgentAnomalyIsolationProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/AgentAnomalyIsolationProcessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.IIsolationProtocolNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.AgentAnomalySignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: an arriving anomaly report is offered to the
+ * local Byzantine-tolerance neuron; isolation is only applied once the
+ * configured witness threshold is met.
+ */
+public class AgentAnomalyIsolationProcessor implements ISignalProcessor<AgentAnomalySignal, IIsolationProtocolNeuron> {
+
+    private static final String DESCRIPTION = "k-witness isolation of misbehaving peers";
+
+    @Override
+    public <I extends ISignal> List<I> process(AgentAnomalySignal input, IIsolationProtocolNeuron neuron) {
+        if (input != null && neuron != null) neuron.onReport(input, input.getEpoch());
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return AgentAnomalyIsolationProcessor.class; }
+    @Override public Class<IIsolationProtocolNeuron> getNeuronClass() { return IIsolationProtocolNeuron.class; }
+    @Override public Class<AgentAnomalySignal> getSignalClass() { return AgentAnomalySignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/ConsensusProposalProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/ConsensusProposalProcessor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.IConsensusParticipantNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.ConsensusProposalSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.ConsensusVoteSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: casts a local YES vote on every received proposal
+ * (a deployment can swap in a smarter policy by replacing the neuron's
+ * implementation).
+ */
+public class ConsensusProposalProcessor implements ISignalProcessor<ConsensusProposalSignal, IConsensusParticipantNeuron> {
+
+    private static final String DESCRIPTION = "Vote on a received consensus proposal";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(ConsensusProposalSignal input, IConsensusParticipantNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        ConsensusVoteSignal v = neuron.vote(input);
+        if (v != null) out.add((I) v);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return ConsensusProposalProcessor.class; }
+    @Override public Class<IConsensusParticipantNeuron> getNeuronClass() { return IConsensusParticipantNeuron.class; }
+    @Override public Class<ConsensusProposalSignal> getSignalClass() { return ConsensusProposalSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/ConsensusVoteProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/ConsensusVoteProcessor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.IConsensusParticipantNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.ConsensusVoteSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/** Stateless processor: tallies an incoming vote on the consensus participant. */
+public class ConsensusVoteProcessor implements ISignalProcessor<ConsensusVoteSignal, IConsensusParticipantNeuron> {
+
+    private static final String DESCRIPTION = "Tally a peer-cast consensus vote";
+
+    @Override
+    public <I extends ISignal> List<I> process(ConsensusVoteSignal input, IConsensusParticipantNeuron neuron) {
+        if (input != null && neuron != null) neuron.tally(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return ConsensusVoteProcessor.class; }
+    @Override public Class<IConsensusParticipantNeuron> getNeuronClass() { return IConsensusParticipantNeuron.class; }
+    @Override public Class<ConsensusVoteSignal> getSignalClass() { return ConsensusVoteSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/FormationKeepingProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/FormationKeepingProcessor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.IFormationKeepingNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.FormationSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/** Stateless processor: assigns a new formation slot to the formation-keeper. */
+public class FormationKeepingProcessor implements ISignalProcessor<FormationSignal, IFormationKeepingNeuron> {
+
+    private static final String DESCRIPTION = "Assigns formation slot to formation-keeper";
+
+    @Override
+    public <I extends ISignal> List<I> process(FormationSignal input, IFormationKeepingNeuron neuron) {
+        if (input != null && neuron != null) neuron.setSlot(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return FormationKeepingProcessor.class; }
+    @Override public Class<IFormationKeepingNeuron> getNeuronClass() { return IFormationKeepingNeuron.class; }
+    @Override public Class<FormationSignal> getSignalClass() { return FormationSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/PeerObservationIntegrationProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/PeerObservationIntegrationProcessor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.IPeerStateIntegrationNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerObservationSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: pushes a {@link PeerObservationSignal} into the
+ * neighbourhood-view neuron. Uses the signal's epoch tick as "now"
+ * for last-seen bookkeeping.
+ */
+public class PeerObservationIntegrationProcessor implements ISignalProcessor<PeerObservationSignal, IPeerStateIntegrationNeuron> {
+
+    private static final String DESCRIPTION = "Local-view update from a peer observation";
+
+    @Override
+    public <I extends ISignal> List<I> process(PeerObservationSignal input, IPeerStateIntegrationNeuron neuron) {
+        if (input != null && neuron != null) neuron.onObservation(input, input.getEpoch());
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return PeerObservationIntegrationProcessor.class; }
+    @Override public Class<IPeerStateIntegrationNeuron> getNeuronClass() { return IPeerStateIntegrationNeuron.class; }
+    @Override public Class<PeerObservationSignal> getSignalClass() { return PeerObservationSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/PeerStateEnergyProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/PeerStateEnergyProcessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.IEnergyCoordinatorNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerStateSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: feeds a {@link PeerStateSignal} to the energy
+ * coordinator so battery-aware task deferral remains current.
+ */
+public class PeerStateEnergyProcessor implements ISignalProcessor<PeerStateSignal, IEnergyCoordinatorNeuron> {
+
+    private static final String DESCRIPTION = "Battery-aware peer-state update";
+
+    @Override
+    public <I extends ISignal> List<I> process(PeerStateSignal input, IEnergyCoordinatorNeuron neuron) {
+        if (input != null && neuron != null) neuron.onPeerState(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return PeerStateEnergyProcessor.class; }
+    @Override public Class<IEnergyCoordinatorNeuron> getNeuronClass() { return IEnergyCoordinatorNeuron.class; }
+    @Override public Class<PeerStateSignal> getSignalClass() { return PeerStateSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/PeerStateIntegrationProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/PeerStateIntegrationProcessor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.IPeerStateIntegrationNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerStateSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/** Stateless processor: feeds a {@link PeerStateSignal} into the neighbourhood-view neuron. */
+public class PeerStateIntegrationProcessor implements ISignalProcessor<PeerStateSignal, IPeerStateIntegrationNeuron> {
+
+    private static final String DESCRIPTION = "Local-view update from a peer state broadcast";
+
+    @Override
+    public <I extends ISignal> List<I> process(PeerStateSignal input, IPeerStateIntegrationNeuron neuron) {
+        if (input != null && neuron != null) neuron.onState(input, input.getEpoch());
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return PeerStateIntegrationProcessor.class; }
+    @Override public Class<IPeerStateIntegrationNeuron> getNeuronClass() { return IPeerStateIntegrationNeuron.class; }
+    @Override public Class<PeerStateSignal> getSignalClass() { return PeerStateSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/PeerStateRoleProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/PeerStateRoleProcessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.IRoleAwarenessNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerStateSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: updates the role-awareness neuron with the
+ * incoming peer state. Drives emergent role specialisation.
+ */
+public class PeerStateRoleProcessor implements ISignalProcessor<PeerStateSignal, IRoleAwarenessNeuron> {
+
+    private static final String DESCRIPTION = "Role-distribution awareness update";
+
+    @Override
+    public <I extends ISignal> List<I> process(PeerStateSignal input, IRoleAwarenessNeuron neuron) {
+        if (input != null && neuron != null) neuron.onPeerState(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return PeerStateRoleProcessor.class; }
+    @Override public Class<IRoleAwarenessNeuron> getNeuronClass() { return IRoleAwarenessNeuron.class; }
+    @Override public Class<PeerStateSignal> getSignalClass() { return PeerStateSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/PheromoneDepositProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/PheromoneDepositProcessor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.IStigmergicMemoryNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PheromoneSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/** Stateless processor: deposits an incoming pheromone into the local stigmergic cache. */
+public class PheromoneDepositProcessor implements ISignalProcessor<PheromoneSignal, IStigmergicMemoryNeuron> {
+
+    private static final String DESCRIPTION = "Pheromone deposit into stigmergic memory";
+
+    @Override
+    public <I extends ISignal> List<I> process(PheromoneSignal input, IStigmergicMemoryNeuron neuron) {
+        if (input != null && neuron != null) neuron.deposit(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return PheromoneDepositProcessor.class; }
+    @Override public Class<IStigmergicMemoryNeuron> getNeuronClass() { return IStigmergicMemoryNeuron.class; }
+    @Override public Class<PheromoneSignal> getSignalClass() { return PheromoneSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/StigmergicTraceDepositProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/StigmergicTraceDepositProcessor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.IStigmergicMemoryNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.StigmergicTraceSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/** Stateless processor: deposits a hardware-deposited trace into the local stigmergic cache. */
+public class StigmergicTraceDepositProcessor implements ISignalProcessor<StigmergicTraceSignal, IStigmergicMemoryNeuron> {
+
+    private static final String DESCRIPTION = "Stigmergic trace deposit into memory";
+
+    @Override
+    public <I extends ISignal> List<I> process(StigmergicTraceSignal input, IStigmergicMemoryNeuron neuron) {
+        if (input != null && neuron != null) neuron.deposit(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return StigmergicTraceDepositProcessor.class; }
+    @Override public Class<IStigmergicMemoryNeuron> getNeuronClass() { return IStigmergicMemoryNeuron.class; }
+    @Override public Class<StigmergicTraceSignal> getSignalClass() { return StigmergicTraceSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/SwarmAlertProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/SwarmAlertProcessor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.ISwarmHarmGateNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.SwarmAlertSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/** Stateless processor: routes a regional alert to the local swarm harm gate. */
+public class SwarmAlertProcessor implements ISignalProcessor<SwarmAlertSignal, ISwarmHarmGateNeuron> {
+
+    private static final String DESCRIPTION = "Routes a swarm alert to the local harm gate";
+
+    @Override
+    public <I extends ISignal> List<I> process(SwarmAlertSignal input, ISwarmHarmGateNeuron neuron) {
+        if (input != null && neuron != null) neuron.onAlert(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return SwarmAlertProcessor.class; }
+    @Override public Class<ISwarmHarmGateNeuron> getNeuronClass() { return ISwarmHarmGateNeuron.class; }
+    @Override public Class<SwarmAlertSignal> getSignalClass() { return SwarmAlertSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/TaskAnnouncementBidProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/TaskAnnouncementBidProcessor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.IAuctionBiddingNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskAnnouncementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskBidSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Stateless processor: produces a bid signal for every task
+ * announcement the agent is interested in.
+ */
+public class TaskAnnouncementBidProcessor implements ISignalProcessor<TaskAnnouncementSignal, IAuctionBiddingNeuron> {
+
+    private static final String DESCRIPTION = "Auction bid generation from task announcement";
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <I extends ISignal> List<I> process(TaskAnnouncementSignal input, IAuctionBiddingNeuron neuron) {
+        List<I> out = new LinkedList<>();
+        if (input == null || neuron == null) return out;
+        TaskBidSignal b = neuron.bid(input);
+        if (b != null) out.add((I) b);
+        return out;
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return TaskAnnouncementBidProcessor.class; }
+    @Override public Class<IAuctionBiddingNeuron> getNeuronClass() { return IAuctionBiddingNeuron.class; }
+    @Override public Class<TaskAnnouncementSignal> getSignalClass() { return TaskAnnouncementSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/TaskAnnouncementRegistryProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/TaskAnnouncementRegistryProcessor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.ITaskRegistryNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskAnnouncementSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/** Stateless processor: registers a task announcement on the active-task list. */
+public class TaskAnnouncementRegistryProcessor implements ISignalProcessor<TaskAnnouncementSignal, ITaskRegistryNeuron> {
+
+    private static final String DESCRIPTION = "Task-registry update from task announcement";
+
+    @Override
+    public <I extends ISignal> List<I> process(TaskAnnouncementSignal input, ITaskRegistryNeuron neuron) {
+        if (input != null && neuron != null) neuron.register(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return TaskAnnouncementRegistryProcessor.class; }
+    @Override public Class<ITaskRegistryNeuron> getNeuronClass() { return ITaskRegistryNeuron.class; }
+    @Override public Class<TaskAnnouncementSignal> getSignalClass() { return TaskAnnouncementSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/TaskAssignmentRegistryProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/TaskAssignmentRegistryProcessor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.ITaskRegistryNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskAssignmentSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/** Stateless processor: closes the open-task entry on assignment. */
+public class TaskAssignmentRegistryProcessor implements ISignalProcessor<TaskAssignmentSignal, ITaskRegistryNeuron> {
+
+    private static final String DESCRIPTION = "Task-registry update from auction outcome";
+
+    @Override
+    public <I extends ISignal> List<I> process(TaskAssignmentSignal input, ITaskRegistryNeuron neuron) {
+        if (input != null && neuron != null) neuron.assign(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return TaskAssignmentRegistryProcessor.class; }
+    @Override public Class<ITaskRegistryNeuron> getNeuronClass() { return ITaskRegistryNeuron.class; }
+    @Override public Class<TaskAssignmentSignal> getSignalClass() { return TaskAssignmentSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/TaskBidRegistryProcessor.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/TaskBidRegistryProcessor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.ITaskRegistryNeuron;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskBidSignal;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/** Stateless processor: forwards an incoming bid into the registry's bid-observation channel. */
+public class TaskBidRegistryProcessor implements ISignalProcessor<TaskBidSignal, ITaskRegistryNeuron> {
+
+    private static final String DESCRIPTION = "Records auction bids on the task registry";
+
+    @Override
+    public <I extends ISignal> List<I> process(TaskBidSignal input, ITaskRegistryNeuron neuron) {
+        if (input != null && neuron != null) neuron.observeBid(input);
+        return new LinkedList<>();
+    }
+
+    @Override public String getDescription() { return DESCRIPTION; }
+    @Override public Boolean hasMerger() { return false; }
+    @Override public Class<? extends ISignalProcessor> getSignalProcessorClass() { return TaskBidRegistryProcessor.class; }
+    @Override public Class<ITaskRegistryNeuron> getNeuronClass() { return ITaskRegistryNeuron.class; }
+    @Override public Class<TaskBidSignal> getSignalClass() { return TaskBidSignal.class; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/signalprocessor/impl/swarm/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * Stateless signal processors for the swarm-robotics module. Every
+ * processor's {@code getNeuronClass()} returns an {@code I<Neuron>}
+ * interface from
+ * {@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm};
+ * concrete neurons are dependency-injected at network construction.
+ *
+ * <p>Signal → processor coverage:
+ * <ul>
+ *   <li>PeerObservationSignal → PeerObservationIntegrationProcessor</li>
+ *   <li>PeerStateSignal → PeerStateIntegrationProcessor,
+ *       PeerStateRoleProcessor, PeerStateEnergyProcessor</li>
+ *   <li>TaskAnnouncementSignal → TaskAnnouncementBidProcessor,
+ *       TaskAnnouncementRegistryProcessor</li>
+ *   <li>TaskBidSignal → TaskBidRegistryProcessor</li>
+ *   <li>TaskAssignmentSignal → TaskAssignmentRegistryProcessor</li>
+ *   <li>PheromoneSignal → PheromoneDepositProcessor</li>
+ *   <li>FormationSignal → FormationKeepingProcessor</li>
+ *   <li>ConsensusProposalSignal → ConsensusProposalProcessor</li>
+ *   <li>ConsensusVoteSignal → ConsensusVoteProcessor</li>
+ *   <li>SwarmAlertSignal → SwarmAlertProcessor</li>
+ *   <li>AgentAnomalySignal → AgentAnomalyIsolationProcessor</li>
+ *   <li>StigmergicTraceSignal → StigmergicTraceDepositProcessor</li>
+ * </ul>
+ */
+package com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm;

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/SwarmModuleTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/swarm/SwarmModuleTest.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.ISignalProcessor;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.AgentAnomalySignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.ConsensusProposalSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.ConsensusVoteSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.FormationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerObservationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerStateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PheromoneSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.StigmergicTraceSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.SwarmAlertSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskAnnouncementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskAssignmentSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskBidSignal;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm.AgentAnomalyIsolationProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm.ConsensusProposalProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm.ConsensusVoteProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm.FormationKeepingProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm.PeerObservationIntegrationProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm.PeerStateEnergyProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm.PeerStateIntegrationProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm.PeerStateRoleProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm.PheromoneDepositProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm.StigmergicTraceDepositProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm.SwarmAlertProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm.TaskAnnouncementBidProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm.TaskAnnouncementRegistryProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm.TaskAssignmentRegistryProcessor;
+import com.rakovpublic.jneuropallium.worker.signalprocessor.impl.swarm.TaskBidRegistryProcessor;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SwarmModuleTest {
+
+    // ---------- enums ----------
+    @Test
+    void enums_cardinality() {
+        assertEquals(6, AgentRole.values().length);
+        assertEquals(7, TaskKind.values().length);
+        assertEquals(5, PheromoneKind.values().length);
+        assertEquals(3, VoteKind.values().length);
+        assertEquals(5, AlertCategory.values().length);
+        assertEquals(5, AnomalyKind.values().length);
+        assertEquals(5, TraceKind.values().length);
+        assertEquals(7, FormationTemplate.values().length);
+    }
+
+    // ---------- ProcessingFrequency ----------
+    @Test
+    void signals_frequencies() {
+        assertEquals(2L, PeerObservationSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(1L, PeerStateSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(2, PeerStateSignal.PROCESSING_FREQUENCY.getLoop());
+        assertEquals(1L, TaskAnnouncementSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(1L, TaskBidSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(1L, TaskAssignmentSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(2L, PheromoneSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(2L, FormationSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(1L, ConsensusProposalSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(1L, ConsensusVoteSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(1L, SwarmAlertSignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(1L, AgentAnomalySignal.PROCESSING_FREQUENCY.getEpoch());
+        assertEquals(5L, StigmergicTraceSignal.PROCESSING_FREQUENCY.getEpoch());
+    }
+
+    // ---------- Layer 0 ----------
+    @Test
+    void peerObservation_dropsLowLinkQuality() {
+        PeerObservationNeuron n = new PeerObservationNeuron();
+        n.setMinLinkQuality(0.5);
+        assertNotNull(n.observe("p1", new double[]{1, 2}, new double[]{0, 0}, 0.7));
+        assertNull(n.observe("p2", null, null, 0.2));
+    }
+
+    @Test
+    void meshRadio_dropsBelowThreshold() {
+        MeshRadioNeuron r = new MeshRadioNeuron();
+        r.setLossThreshold(0.3);
+        assertTrue(r.send(new SwarmAlertSignal(AlertCategory.COLLISION, "r", 0.9), 0.5));
+        assertFalse(r.send(new SwarmAlertSignal(AlertCategory.COLLISION, "r", 0.9), 0.1));
+        assertEquals(1, r.getSent());
+        assertEquals(1, r.getDropped());
+    }
+
+    // ---------- Layer 2 ----------
+    @Test
+    void peerState_evictsStale() {
+        PeerStateIntegrationNeuron p = new PeerStateIntegrationNeuron();
+        p.setStalenessTicks(100);
+        p.onObservation(new PeerObservationSignal("p", new double[]{0}, new double[]{0}, 1.0), 0L);
+        assertEquals(1, p.knownPeers().size());
+        p.evict(500L);
+        assertEquals(0, p.knownPeers().size());
+    }
+
+    @Test
+    void roleAwareness_pickShortageRole() {
+        RoleAwarenessNeuron r = new RoleAwarenessNeuron();
+        r.onPeerState(new PeerStateSignal("a", AgentRole.SCOUT, 1.0, 1.0, null));
+        r.onPeerState(new PeerStateSignal("b", AgentRole.SCOUT, 1.0, 1.0, null));
+        r.onPeerState(new PeerStateSignal("c", AgentRole.SCOUT, 1.0, 1.0, null));
+        AgentRole shortage = r.shortageRole();
+        assertNotNull(shortage);
+        assertNotEquals(AgentRole.SCOUT, shortage);
+    }
+
+    // ---------- Layer 3 ----------
+    @Test
+    void stigmergicMemory_evictsExpired() {
+        StigmergicMemoryNeuron m = new StigmergicMemoryNeuron();
+        m.deposit(new PheromoneSignal(PheromoneKind.TRAIL, new double[]{0, 0}, 1.0, 100L));
+        assertEquals(1, m.size());
+        m.evict(200L);
+        assertEquals(0, m.size());
+    }
+
+    @Test
+    void stigmergicMemory_findsNearby() {
+        StigmergicMemoryNeuron m = new StigmergicMemoryNeuron();
+        m.deposit(new StigmergicTraceSignal(new double[]{0, 0}, TraceKind.LANDMARK, 0.9, 0));
+        m.deposit(new StigmergicTraceSignal(new double[]{50, 50}, TraceKind.HAZARD, 0.7, 0));
+        assertEquals(1, m.tracesNear(new double[]{1, 1}, 5.0).size());
+    }
+
+    @Test
+    void taskRegistry_assignClosesOpen() {
+        TaskRegistryNeuron t = new TaskRegistryNeuron();
+        t.register(new TaskAnnouncementSignal("T1", TaskKind.SEARCH, null, 1.0, 100));
+        assertTrue(t.isOpen("T1"));
+        t.assign(new TaskAssignmentSignal("T1", "a", "b"));
+        assertFalse(t.isOpen("T1"));
+        assertEquals("a", t.assigneeOf("T1"));
+    }
+
+    // ---------- Layer 4 ----------
+    @Test
+    void auctionBid_costScalesWithDistance() {
+        AuctionBiddingNeuron a = new AuctionBiddingNeuron();
+        a.setBidderId("self");
+        a.setSelfPosition(new double[]{0, 0});
+        a.setBatteryFraction(1.0);
+        TaskAnnouncementSignal ann = new TaskAnnouncementSignal("T", TaskKind.SEARCH,
+                new double[]{3, 4}, 1.0, 100);
+        TaskBidSignal b = a.bid(ann);
+        assertNotNull(b);
+        assertEquals(5.0, b.getEstimatedCost(), 1e-6);
+    }
+
+    @Test
+    void consensus_quorumOnYesCount() {
+        ConsensusParticipantNeuron c = new ConsensusParticipantNeuron();
+        c.setQuorum(3);
+        c.tally(new ConsensusVoteSignal("p", VoteKind.YES, "v1"));
+        c.tally(new ConsensusVoteSignal("p", VoteKind.YES, "v2"));
+        assertFalse(c.isQuorum("p"));
+        c.tally(new ConsensusVoteSignal("p", VoteKind.YES, "v3"));
+        assertTrue(c.isQuorum("p"));
+        // Duplicate voter doesn't double-count
+        c.tally(new ConsensusVoteSignal("p", VoteKind.YES, "v3"));
+        assertEquals(3, c.yesCount("p"));
+    }
+
+    @Test
+    void formation_steerToOffset() {
+        FormationKeepingNeuron f = new FormationKeepingNeuron();
+        f.setSlot(new FormationSignal(FormationTemplate.LINE, 0, new double[]{10, 0}));
+        double[] s = f.steer(new double[]{4, 0});
+        assertEquals(6.0, s[0], 1e-9);
+        assertEquals(0.0, s[1], 1e-9);
+    }
+
+    @Test
+    void flocking_zeroOnEmpty() {
+        FlockingNeuron f = new FlockingNeuron();
+        double[] v = f.steer(new ArrayList<>());
+        assertEquals(0, v.length);
+    }
+
+    @Test
+    void flocking_separationOpposesNeighbour() {
+        FlockingNeuron f = new FlockingNeuron();
+        f.setWeights(1.0, 0.0, 0.0);
+        f.setRadius(10.0);
+        List<PeerObservationSignal> peers = new ArrayList<>();
+        peers.add(new PeerObservationSignal("p", new double[]{2, 0}, new double[]{0, 0}, 1.0));
+        double[] s = f.steer(peers);
+        assertTrue(s[0] < 0, "separation should push away from a neighbour at +x");
+    }
+
+    // ---------- Layer 5 ----------
+    @Test
+    void swarmHarmGate_aggregatesAboveThreshold() {
+        SwarmHarmGateNeuron g = new SwarmHarmGateNeuron();
+        g.setRegionalThreshold("R", 1.0);
+        g.recordEmission("R", "a1", 0.6);
+        g.recordEmission("R", "a2", 0.6);
+        SwarmAlertSignal alert = g.aggregate("R");
+        assertNotNull(alert);
+        assertEquals(AlertCategory.COLLECTIVE_HARM, alert.getCategory());
+        assertTrue(g.tighteningMultiplier("R") > 1.0);
+    }
+
+    @Test
+    void anomalyReport_singletonOncePerSuspect() {
+        AnomalyReportNeuron r = new AnomalyReportNeuron();
+        r.setSelfId("me");
+        assertNotNull(r.report("susp", AnomalyKind.SILENT));
+        assertNull(r.report("susp", AnomalyKind.SILENT));
+    }
+
+    @Test
+    void isolation_kWitnessThreshold() {
+        IsolationProtocolNeuron iso = new IsolationProtocolNeuron();
+        iso.setWitnessThreshold(3);
+        iso.setIsolationTicks(100);
+        assertFalse(iso.onReport(new AgentAnomalySignal("susp", AnomalyKind.SILENT, "a",
+                java.util.Arrays.asList("a")), 0));
+        assertFalse(iso.onReport(new AgentAnomalySignal("susp", AnomalyKind.SILENT, "b",
+                java.util.Arrays.asList("b")), 0));
+        assertTrue(iso.onReport(new AgentAnomalySignal("susp", AnomalyKind.SILENT, "c",
+                java.util.Arrays.asList("c")), 0));
+        assertTrue(iso.isIsolated("susp", 50));
+        // Auto-lift after isolationTicks
+        iso.tick(200L);
+        assertFalse(iso.isIsolated("susp", 200L));
+    }
+
+    // ---------- Layer 7 ----------
+    @Test
+    void density_highCountTriggersDispersal() {
+        SwarmDensityNeuron d = new SwarmDensityNeuron();
+        d.setMinNeighbours(2);
+        d.setMaxNeighbours(4);
+        for (int i = 0; i < 6; i++) d.observeNeighbour(null);
+        assertTrue(d.densityBias() > 0);
+    }
+
+    @Test
+    void bandwidth_rateLimitsLowPriority() {
+        BandwidthBudgetNeuron b = new BandwidthBudgetNeuron();
+        b.setBudgetKbps(1);  // 125 bytes/s budget
+        long t = 0L;
+        // Fill the budget with high-priority traffic.
+        b.recordHighPriority(125, t);
+        assertFalse(b.allowLowPriority(1, t));
+        // Next second resets the budget.
+        assertTrue(b.allowLowPriority(1, t + 1000L));
+    }
+
+    @Test
+    void energyCoordinator_defersToHigherBatteryPeer() {
+        EnergyCoordinatorNeuron e = new EnergyCoordinatorNeuron();
+        e.setOwnBattery(0.20);
+        e.onPeerState(new PeerStateSignal("p1", AgentRole.WORKER, 0.90, 1.0, null));
+        e.onPeerState(new PeerStateSignal("p2", AgentRole.WORKER, 0.30, 1.0, null));
+        assertEquals("p1", e.shouldDeferTo("T1"));
+    }
+
+    // ---------- Config ----------
+    @Test
+    void config_quorumMinIsThree() {
+        SwarmConfig c = new SwarmConfig();
+        assertThrows(IllegalArgumentException.class, () -> c.setQuorumWitnessCount(2));
+        assertThrows(IllegalArgumentException.class, () -> c.setAnomalyThresholdVotes(2));
+        c.setQuorumWitnessCount(5);
+        assertEquals(5, c.getQuorumWitnessCount());
+    }
+
+    @Test
+    void config_lawsHardcodedOff() {
+        SwarmConfig c = new SwarmConfig();
+        assertFalse(c.isLawsEnabled());
+        assertFalse(c.isAffectEnabled());
+    }
+
+    // ---------- Processors: interface-typed + smoke ----------
+    private static void assertInterfaceTyped(ISignalProcessor<?, ?> p) {
+        assertTrue(p.getNeuronClass().isInterface(),
+                p.getClass().getSimpleName() + " must target an interface");
+        assertNotNull(p.getSignalClass());
+        assertNotNull(p.getDescription());
+        assertFalse(p.hasMerger());
+    }
+
+    @Test
+    void processors_allInterfaceTyped() {
+        assertInterfaceTyped(new PeerObservationIntegrationProcessor());
+        assertInterfaceTyped(new PeerStateIntegrationProcessor());
+        assertInterfaceTyped(new PeerStateRoleProcessor());
+        assertInterfaceTyped(new PeerStateEnergyProcessor());
+        assertInterfaceTyped(new TaskAnnouncementBidProcessor());
+        assertInterfaceTyped(new TaskAnnouncementRegistryProcessor());
+        assertInterfaceTyped(new TaskBidRegistryProcessor());
+        assertInterfaceTyped(new TaskAssignmentRegistryProcessor());
+        assertInterfaceTyped(new PheromoneDepositProcessor());
+        assertInterfaceTyped(new StigmergicTraceDepositProcessor());
+        assertInterfaceTyped(new FormationKeepingProcessor());
+        assertInterfaceTyped(new ConsensusProposalProcessor());
+        assertInterfaceTyped(new ConsensusVoteProcessor());
+        assertInterfaceTyped(new SwarmAlertProcessor());
+        assertInterfaceTyped(new AgentAnomalyIsolationProcessor());
+    }
+
+    @Test
+    void taskAnnouncementBidProcessor_emitsBid() {
+        AuctionBiddingNeuron a = new AuctionBiddingNeuron();
+        a.setBidderId("self");
+        a.setSelfPosition(new double[]{0, 0});
+        a.setBatteryFraction(0.8);
+        TaskAnnouncementBidProcessor p = new TaskAnnouncementBidProcessor();
+        List<ISignal> out = p.process(new TaskAnnouncementSignal("T", TaskKind.SEARCH,
+                new double[]{1, 0}, 1.0, 100), a);
+        assertEquals(1, out.size());
+        assertTrue(out.get(0) instanceof TaskBidSignal);
+    }
+
+    @Test
+    void consensusProposalProcessor_emitsVote() {
+        ConsensusParticipantNeuron c = new ConsensusParticipantNeuron();
+        c.setVoterId("v1");
+        ConsensusProposalProcessor p = new ConsensusProposalProcessor();
+        List<ISignal> out = p.process(new ConsensusProposalSignal("p", "S", "leader"), c);
+        assertEquals(1, out.size());
+        assertEquals(VoteKind.YES, ((ConsensusVoteSignal) out.get(0)).getVote());
+    }
+
+    @Test
+    void agentAnomalyIsolationProcessor_appliesIsolationAtThreshold() {
+        IsolationProtocolNeuron iso = new IsolationProtocolNeuron();
+        iso.setWitnessThreshold(2);
+        AgentAnomalyIsolationProcessor p = new AgentAnomalyIsolationProcessor();
+        AgentAnomalySignal r1 = new AgentAnomalySignal("susp", AnomalyKind.SILENT, "a",
+                java.util.Arrays.asList("a"));
+        AgentAnomalySignal r2 = new AgentAnomalySignal("susp", AnomalyKind.SILENT, "b",
+                java.util.Arrays.asList("b"));
+        r1.setEpoch(0L); r2.setEpoch(0L);
+        p.process(r1, iso);
+        p.process(r2, iso);
+        assertTrue(iso.isIsolated("susp", 0L));
+    }
+}


### PR DESCRIPTION
Adds the swarm-robotics module under worker/net/neuron/impl/swarm, worker/net/signals/impl/swarm, and worker/signalprocessor/impl/swarm, plus docs/modules/swarm.md.

Enums (8): AgentRole, TaskKind, PheromoneKind, VoteKind, AlertCategory, AnomalyKind, TraceKind, FormationTemplate.

Signals (12): PeerObservationSignal (1/2), PeerStateSignal (2/1), TaskAnnouncementSignal (2/1), TaskBidSignal (2/1), TaskAssignmentSignal (2/1), PheromoneSignal (2/2), FormationSignal (1/2), ConsensusProposalSignal (2/1), ConsensusVoteSignal (2/1), SwarmAlertSignal (1/1), AgentAnomalySignal (2/1),
StigmergicTraceSignal (2/5). Every peer-bound signal carries a linkQuality indicator per spec §3.

Neurons (15), each paired with an I<Name> interface so processors never depend on the concrete type:

* Layer 0 — PeerObservationNeuron (link-quality filter), MeshRadioNeuron (transport adapter with loss threshold).
* Layer 2 — PeerStateIntegrationNeuron (decay-based local view), RoleAwarenessNeuron (shortage-role bias).
* Layer 3 — StigmergicMemoryNeuron (radius-bounded retrieval + decay eviction), TaskRegistryNeuron.
* Layer 4 — AuctionBiddingNeuron (distance / battery cost), ConsensusParticipantNeuron (unique-voter YES/NO tally), FormationKeepingNeuron, FlockingNeuron (Reynolds rules weighted by link quality).
* Layer 5 — SwarmHarmGateNeuron (regional emission aggregator, tightening multiplier ∈ [1, 5]), AnomalyReportNeuron (single-shot per suspect), IsolationProtocolNeuron (k-witness Byzantine isolation, auto-lift, exponential escalation up to cap).
* Layer 7 — SwarmDensityNeuron, BandwidthBudgetNeuron (token-bucket), EnergyCoordinatorNeuron (defers task to higher-battery peer).

Processors (15), all parameterised by I<Neuron> interfaces:

* PeerObservationSignal → PeerObservationIntegrationProcessor
* PeerStateSignal → PeerStateIntegrationProcessor, PeerStateRoleProcessor, PeerStateEnergyProcessor
* TaskAnnouncementSignal → TaskAnnouncementBidProcessor, TaskAnnouncementRegistryProcessor
* TaskBidSignal → TaskBidRegistryProcessor
* TaskAssignmentSignal → TaskAssignmentRegistryProcessor
* PheromoneSignal → PheromoneDepositProcessor
* StigmergicTraceSignal → StigmergicTraceDepositProcessor
* FormationSignal → FormationKeepingProcessor
* ConsensusProposalSignal → ConsensusProposalProcessor
* ConsensusVoteSignal → ConsensusVoteProcessor
* SwarmAlertSignal → SwarmAlertProcessor
* AgentAnomalySignal → AgentAnomalyIsolationProcessor

SwarmConfig mirrors spec §9 and enforces program-level invariants: setQuorumWitnessCount(<3) throws (Byzantine f=1 minimum), setAnomalyThresholdVotes(<3) throws, isLawsEnabled() and isAffectEnabled() fixed off (spec §12 out-of-scope flags).

SwarmModuleTest adds 26 tests: enum cardinalities, every signal's ProcessingFrequency, link-quality drop, peer-state staleness eviction, shortage-role detection, stigmergic decay + radius retrieval, auction bid distance scaling, consensus quorum on unique YES, formation slot steering, flocking separation, collective-harm aggregation + tightening multiplier, single-shot anomaly reporting, k-witness isolation with auto-lift, density bias, bandwidth budget, energy-aware deferral, config validation, plus 15-processor processors_allInterfaceTyped invariant and per-processor smoke tests.

Full worker suite: 471/471 pass (445 prior + 26 new), no regressions.

https://claude.ai/code/session_018DLgBWsQFe4q32RCbqYsAQ