### PR TITLE
Implement OPC UA bridge per JNEOPALLIUM_OPCUA_INTEGRATION.md

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -1,0 +1,18 @@
+name: maven-verify
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+      - run: mvn -B -U clean verify

--- a/README.md
+++ b/README.md
@@ -180,8 +180,22 @@ An optional, non-blocking extension integrates Large Language Models as an exter
 
 Design principles: all LLM processing runs on the slow loop (never blocking real-time sensorimotor processing), LLM responses are always cross-validated against internal models before use, and the system operates at full capability when the LLM is unavailable. Supports local (Ollama), cloud (OpenAI, Anthropic), and disabled modes.
 
+## OPC UA bridge
+
+Jneopallium can act as a biologically-inspired, safety-gated
+cognitive-control layer for OPC UA industrial systems via Eclipse Milo.
+The bridge subscribes to PLC / SCADA / simulator nodes, emits typed
+`MeasurementSignal` / `AlarmSignal` instances into the neuron network,
+and writes neuron-derived `SetpointSignal` / `ActuatorCommandSignal`
+decisions back to the field — only after passing the harm gate,
+honouring operator override, respecting per-loop SHADOW / ADVISORY /
+AUTONOMOUS mode, and emitting an audit record for every proposed action
+whether applied, clamped, or rejected. See
+[`docs/opcua-bridge-architecture.md`](docs/opcua-bridge-architecture.md).
+
 ## Applications
 
+- **Industrial process control** — Connect to any OPC UA PLC/SCADA via the Eclipse Milo bridge and run neuron-derived setpoints through the safety/interlock chain.
 - **Robotics** — Direct I/O with hardware controllers; model sensorimotor loops at biologically-relevant timescales.
 - **Autonomous mission control** — Decision-making under high latency and mission-flow uncertainty.
 - **Neuroscience research** — Model neural control structures and structural deviations at a chosen level of detail.

--- a/docs/opcua-bridge-architecture.md
+++ b/docs/opcua-bridge-architecture.md
@@ -1,0 +1,129 @@
+# Jneopallium OPC UA bridge — architecture
+
+The bridge connects Jneopallium to any OPC UA server (PLC, SCADA,
+simulator, digital twin) via Eclipse Milo `1.1.1`. It reads field values
+into typed industrial signals, runs them through the existing
+safety-gated cognitive-control pipeline, and writes neuron-derived
+decisions back to the plant — only ever via the safety chain.
+
+## §0 Ground rules (verbatim from the spec)
+
+1. **No raw write to a field actuator from neuron output.** Every write
+   goes through the chain:
+   `PlanningNeuron → SafetyGateNeuron → SafetyMode check → OperatorOverrideSignal check → OpcUaCommandOutputAggregator`.
+   The aggregator itself rejects any `ActuatorCommandSignal` whose
+   `execute=false` (shadow) or whose loop is in shadow mode by config.
+2. **Interlocks have direct authority.** If
+   `InterlockSignal.tripped == true`, the aggregator MUST write the loop
+   to its fail-safe value regardless of anything else in the same tick.
+   This is the only permitted bypass.
+3. **Operator override wins.** When `OperatorOverrideSignal` is active
+   for a tag, the aggregator does not write that tag from any
+   neuron-derived signal for the duration of the override. Override
+   applies to *regulatory* control, not to interlocks.
+4. **Every write produces an audit record.** Each accepted, suppressed,
+   or rejected write emits a transparency-log line that is persisted via
+   `OpcUaTransparencyLogOutput` to a configurable OPC UA audit node *and*
+   a local file. No silent writes.
+5. **Quality propagates.** A `MeasurementSignal` derived from an OPC UA
+   `DataValue` whose `StatusCode` is not `good()` is emitted with
+   `Quality.UNCERTAIN` or `Quality.BAD` — never `GOOD`.
+6. **Wall-clock timestamps come from the OPC UA server.** Use the
+   `sourceTimestamp` from the `DataValue`, falling back to
+   `serverTimestamp`, falling back to `System.currentTimeMillis()` only
+   if both are null.
+
+## Data flow
+
+```
+┌─────────────────────┐    subscriptions     ┌──────────────────────────────┐
+│  OPC UA server      │ ───────────────────► │ MiloOpcUaClientService       │
+│  (PLC / SCADA /     │                      │  • OpcUaClient + transport   │
+│   simulator)        │ ◄─────────────────── │  • OpcUaSubscription         │
+└─────────────────────┘    writeValues()     │  • latest-value cache        │
+                                             │  • alarm queue               │
+                                             └─────┬──────────────┬─────────┘
+                                                   │              │
+                                  ┌────────────────▼─┐   ┌────────▼───────┐
+                                  │ OpcUaMeasurement │   │ OpcUaAlarmInput│
+                                  │ Input            │   │                │
+                                  │  → IInputSignal  │   │  → IInputSignal│
+                                  └────────────────┬─┘   └────────┬───────┘
+                                                   │              │
+                                                   ▼              ▼
+                                  ┌─────────────────────────────────────────┐
+                                  │ Existing Jneopallium pipeline:          │
+                                  │  Sensor → MeasurementValidator → PID →  │
+                                  │  Cascade → MPCPlanning → SafetyGate →   │
+                                  │  Actuator                               │
+                                  └────────────────┬────────────────────────┘
+                                                   │ List<IResult>
+                                                   ▼
+                                  ┌─────────────────────────────────────────┐
+                                  │ OpcUaCommandOutputAggregator            │
+                                  │  1. tripped Interlocks → fail-safe write│
+                                  │  2. record OperatorOverride entries     │
+                                  │  3. for each Setpoint/Actuator command: │
+                                  │     INTERLOCK_HOLD?  → reject + audit   │
+                                  │     OVERRIDE active? → hold + audit     │
+                                  │     SHADOW mode?     → audit only       │
+                                  │     ADVISORY mode?   → require execute  │
+                                  │     clamp [min,max]                     │
+                                  │     rate-limit by rampRateMaxPerSec     │
+                                  │     diff-suppress < ε for < 5 s         │
+                                  │     writeValues() → audit verdict       │
+                                  └────────────────┬────────────────────────┘
+                                                   │
+                                                   ▼
+                                  ┌─────────────────────────────────────────┐
+                                  │ OpcUaTransparencyLogOutput              │
+                                  │  local JSONL  + optional OPC UA mirror  │
+                                  └─────────────────────────────────────────┘
+```
+
+## Package layout
+
+```
+worker/src/main/java/com/rakovpublic/jneuropallium/worker/
+├── net/neuron/impl/industrial/opcua/
+│   ├── OpcUaBridgeConfig.java          ← YAML record schema
+│   ├── OpcUaBridgeConfigLoader.java    ← Jackson-YAML loader
+│   ├── OpcUaNodeBinding.java           ← runtime binding state
+│   ├── OpcUaSignalMapper.java          ← pure mapping functions
+│   └── MiloOpcUaClientService.java     ← Milo connection lifecycle
+├── net/signals/industrial/opcua/       ← reserved
+├── input/opcua/
+│   ├── OpcUaMeasurementInput.java      ← IInitInput → MeasurementSignal
+│   └── OpcUaAlarmInput.java            ← IInitInput → AlarmSignal
+└── output/opcua/
+    ├── OpcUaCommandOutputAggregator.java ← safety-critical
+    ├── OpcUaTransparencyLogOutput.java   ← append-only audit
+    └── OverrideRegistry.java             ← operator override TTL map
+```
+
+## Audit JSON schema (one line per record)
+
+```json
+{
+  "ts": 1740000000000,
+  "run": 12345,
+  "verdict": "APPLIED" | "REJECTED" | "INTERLOCK_TRIP" | "OVERRIDE_HOLD" | "FAILED",
+  "loopId": "FIC-101",
+  "tag": "PLANT.FIC101.SP",
+  "proposed": 47.3,
+  "effective": 45.0,
+  "reason": "RATE_LIMITED",
+  "safetyMode": "AUTONOMOUS"
+}
+```
+
+## Configuration
+
+Configuration is YAML, loaded once at startup via
+`OpcUaBridgeConfigLoader.load(Path)`. Hot-reload is deliberately not
+supported — config changes require a controlled restart of the bridge,
+which is the expected industrial workflow (Management of Change).
+`FAIL_ON_UNKNOWN_PROPERTIES = true` is enforced; a typo'd field is a
+safety incident, not a silent fallback.
+
+See `JNEOPALLIUM_OPCUA_INTEGRATION.md` §4.3 for the canonical example.

--- a/docs/opcua-bridge-demo.md
+++ b/docs/opcua-bridge-demo.md
@@ -1,0 +1,67 @@
+# OPC UA bridge — manual demo (S12)
+
+This is the manual smoke-test against the public Eclipse Milo demo
+server. It is **not** part of CI — run it by hand before any release.
+
+## Prerequisites
+
+* JDK 17 in `JAVA_HOME`.
+* Maven ≥ 3.9.
+* Network access to `opc.tcp://milo.digitalpetri.com:62541/milo`.
+
+## Procedure
+
+1. Build the project from a clean checkout:
+   ```bash
+   mvn -B -U clean verify
+   ```
+2. Drop a config at `/tmp/opcua-bridge-demo.yaml`:
+   ```yaml
+   connection:
+     endpointUrl: "opc.tcp://milo.digitalpetri.com:62541/milo"
+     applicationName: "Jneopallium-OPCUA-Bridge"
+     applicationUri: "urn:rakovpublic:jneopallium:bridge:dev01"
+     requestTimeout: "PT5S"
+     sessionTimeout: "PT2M"
+     keepAliveFailuresAllowed: 3
+   security:
+     policy: NONE
+     mode: NONE
+     auth:
+       type: "Anonymous"
+   reads:
+     - loopId: "DEMO-CLOCK"
+       nodeId: "i=2258"
+       signalTag: "DEMO.CLOCK.UTC"
+       direction: READ
+   writes: []
+   alarms: []
+   audit:
+     localAuditFile: "/tmp/jneopallium-opcua-audit.jsonl"
+     writeRejectedToAudit: true
+   tickInterval: "PT0.25S"
+   ```
+3. Start a small Java program (jshell/REPL or a `main`) that:
+   ```java
+   var cfg = OpcUaBridgeConfigLoader.load(Path.of("/tmp/opcua-bridge-demo.yaml"));
+   try (var svc = new MiloOpcUaClientService(cfg)) {
+       Thread.sleep(2_000);
+       System.out.println("latest = " + svc.latest("DEMO.CLOCK.UTC"));
+   }
+   ```
+4. Within ~2 s the latest-value cache should contain a non-null
+   `DataValue` for `Server_ServerStatus_CurrentTime` (NodeId `i=2258`).
+
+## Acceptance
+
+* The bridge connects, lists endpoints, subscribes to one node, and
+  receives at least one tick before exit.
+* No write happens (writes list is empty).
+* No audit records are produced (no commands ran).
+* The local audit file at `/tmp/jneopallium-opcua-audit.jsonl` is
+  created (or already existed) but contains no new lines.
+
+If any of the above fails, capture the stack trace and the Milo client
+log output before filing an issue. Re-run with
+`-Dorg.slf4j.simpleLogger.defaultLogLevel=debug` for transport-level
+detail.

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -1,93 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.rakovpublic.jneopallium</groupId>
-    <artifactId>master</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <packaging>war</packaging>
     <parent>
         <groupId>com.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
     </parent>
-
+    <artifactId>master</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>war</packaging>
     <name>jneuronnet.master</name>
     <url>https://github.com/rakovpublic/jneopallium</url>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>com.rakovpublic.jneopallium</groupId>
             <artifactId>worker</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
+
+        <!-- Spring Boot 3 (jakarta namespace, requires Java 17) -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>2.5.12</version>
         </dependency>
+        <!-- War packaging needs the servlet container in `provided` scope -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-tomcat</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.25.4</version>
+            <version>${log4j.version}</version>
         </dependency>
+
+        <!-- Tests -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot</artifactId>
-            <version>2.7.18</version>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
         <finalName>jneuronnetmaster</finalName>
-        <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
-            <plugins>
-                <plugin>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.1.0</version>
-                </plugin>
-                <!-- see http://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_war_packaging -->
-                <plugin>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.0.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
-                    <configuration>
-                        <release>11</release>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-war-plugin</artifactId>
-                    <version>3.2.2</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${maven-war-plugin.version}</version>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -2,19 +2,120 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- parent pom -->
     <groupId>com.rakovpublic.jneopallium</groupId>
     <artifactId>wrapper</artifactId>
-    <packaging>pom</packaging>
     <version>1.0</version>
+    <packaging>pom</packaging>
 
-    <!-- sub modules -->
     <modules>
         <module>master</module>
         <module>worker</module>
     </modules>
 
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <!-- Library versions (single source of truth) -->
+        <milo.version>1.1.1</milo.version>
+        <spring-boot.version>3.3.5</spring-boot.version>
+        <jackson.version>2.17.2</jackson.version>
+        <log4j.version>2.25.4</log4j.version>
+        <gson.version>2.11.0</gson.version>
+        <jedis.version>5.2.0</jedis.version>
+        <kafka.version>3.9.2</kafka.version>
+        <protobuf.version>3.25.5</protobuf.version>
+        <grpc.version>1.75.0</grpc.version>
+        <junit.version>5.10.2</junit.version>
+        <mockito.version>5.11.0</mockito.version>
+        <slf4j.version>2.0.16</slf4j.version>
+        <jakarta-annotation.version>2.1.1</jakarta-annotation.version>
+
+        <!-- Plugin versions -->
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <maven-surefire-plugin.version>3.5.0</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.5.0</maven-failsafe-plugin.version>
+        <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
+        <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
+        <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- log4j 2.25.4 must override the older log4j-api version pinned
+                 by spring-boot-dependencies; declare the explicit pins first
+                 so dependencyManagement first-wins keeps them. -->
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j2-impl</artifactId>
+                <version>${log4j.version}</version>
+            </dependency>
+            <!-- Eclipse Milo BOM keeps client/server/stack at one consistent version -->
+            <dependency>
+                <groupId>org.eclipse.milo</groupId>
+                <artifactId>milo-bom</artifactId>
+                <version>${milo.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Spring Boot 3 BOM -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- JUnit BOM -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
+                    <configuration>
+                        <release>${maven.compiler.release}</release>
+                        <compilerArgs>
+                            <arg>-parameters</arg>
+                        </compilerArgs>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-failsafe-plugin.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -1,144 +1,177 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.rakovpublic.jneopallium</groupId>
-    <artifactId>worker</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <properties>
-        <protobuf.version>3.25.5</protobuf.version>
-        <grpc.version>1.75.0</grpc.version>
-    </properties>
+
     <parent>
         <groupId>com.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
     </parent>
+    <artifactId>worker</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
     <dependencies>
+        <!-- Core JSON -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.7.1</version>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.9</version>
+            <version>${gson.version}</version>
+        </dependency>
+
+        <!-- Logging - pin api/core/impl all to ${log4j.version} so the
+             spring-boot-dependencies BOM does not partially downgrade api. -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.25.4</version>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
-            <version>1.2</version>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>${log4j.version}</version>
         </dependency>
+
+        <!-- Annotations (jakarta replaces javax on Java 17+) -->
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.10.2</version>
-            <scope>test</scope>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>${jakarta-annotation.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>5.11.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.11.0</version>
-            <scope>test</scope>
-        </dependency>
+
+        <!-- Storage / messaging -->
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>5.0.2</version>
+            <version>${jedis.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+
+        <!-- gRPC + protobuf (single, consistent protobuf version) -->
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>${protobuf.version}</version>
         </dependency>
-
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
             <version>${grpc.version}</version>
         </dependency>
-
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
             <version>${grpc.version}</version>
         </dependency>
-
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
             <version>${grpc.version}</version>
         </dependency>
+
+        <!-- ============== OPC UA (Phase 2) ============== -->
+        <!-- Versions come from the milo-bom imported in the parent. -->
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <version>3.9.2</version>
+            <groupId>org.eclipse.milo</groupId>
+            <artifactId>milo-sdk-client</artifactId>
+        </dependency>
+        <!-- Server SDK is included so the test harness in Phase 3 can spin up
+             an embedded OPC UA server. Scope is `test` to keep it out of the
+             worker runtime jar. -->
+        <dependency>
+            <groupId>org.eclipse.milo</groupId>
+            <artifactId>milo-sdk-server</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>4.34.0</version>
-            <scope>compile</scope>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <extensions>
-            <!-- Required for ${os.detected.classifier} -->
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.7.1</version>
+                <version>${os-maven-plugin.version}</version>
             </extension>
         </extensions>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <release>11</release>
-
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.5</version>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.6.1</version>
-
+                <version>${protobuf-maven-plugin.version}</version>
                 <configuration>
-                    <protocExecutable>C:\Users\dmytr\Downloads\protoc-34.1-win64\bin\protoc.exe</protocExecutable>
-                    <!-- Protoc version (match your protobuf-java dependency) -->
+                    <!-- Cross-platform: protoc is downloaded for the host OS -->
                     <protocArtifact>
-                        com.google.protobuf:protoc:3.25.8:exe:${os.detected.classifier}
+                        com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
                     </protocArtifact>
-
-                    <!-- THIS IS THE KEY PART FOR SERVICES -->
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>
-                        io.grpc:protoc-gen-grpc-java:1.80.0:exe:${os.detected.classifier}
+                        io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
                     </pluginArtifact>
-
-                    <!-- Optional but recommended -->
                     <clearOutputDirectory>false</clearOutputDirectory>
                 </configuration>
                 <executions>
@@ -153,6 +186,4 @@
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/input/opcua/OpcUaAlarmInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/input/opcua/OpcUaAlarmInput.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.input.opcua;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua.MiloOpcUaClientService;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua.OpcUaSignalMapper;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Drains the alarm queue from {@link MiloOpcUaClientService} and emits
+ * an {@link AlarmSignal} per delivered sample.
+ */
+public final class OpcUaAlarmInput implements IInitInput {
+
+    private final String name;
+    private final ProcessingFrequency freq;
+    private final MiloOpcUaClientService svc;
+
+    public OpcUaAlarmInput(String name, ProcessingFrequency freq, MiloOpcUaClientService svc) {
+        this.name = Objects.requireNonNull(name);
+        this.freq = freq != null ? freq : AlarmSignal.PROCESSING_FREQUENCY;
+        this.svc = Objects.requireNonNull(svc);
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        List<MiloOpcUaClientService.AlarmEvent> drained = svc.drainAlarms();
+        List<IInputSignal> out = new ArrayList<>(drained.size());
+        for (MiloOpcUaClientService.AlarmEvent e : drained) {
+            AlarmSignal s = OpcUaSignalMapper.toAlarm(e.binding(), e.value());
+            s.setInputName(name);
+            out.add(s);
+        }
+        return out;
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() {
+        return new HashMap<>();
+    }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() { return freq; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/input/opcua/OpcUaMeasurementInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/input/opcua/OpcUaMeasurementInput.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.input.opcua;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua.MiloOpcUaClientService;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua.OpcUaNodeBinding;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua.OpcUaSignalMapper;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Snapshot-based {@link IInitInput} that emits {@link MeasurementSignal}s
+ * for the configured read bindings. The heavy lifting (subscriptions,
+ * latest-value cache) lives in {@link MiloOpcUaClientService}.
+ */
+public final class OpcUaMeasurementInput implements IInitInput {
+
+    private final String name;
+    private final ProcessingFrequency freq;
+    private final MiloOpcUaClientService svc;
+    private final List<OpcUaNodeBinding> bindings;
+
+    public OpcUaMeasurementInput(String name,
+                                 ProcessingFrequency freq,
+                                 MiloOpcUaClientService svc,
+                                 List<OpcUaNodeBinding> bindings) {
+        this.name = Objects.requireNonNull(name);
+        this.freq = freq != null ? freq : MeasurementSignal.PROCESSING_FREQUENCY;
+        this.svc = Objects.requireNonNull(svc);
+        this.bindings = List.copyOf(bindings);
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        List<IInputSignal> out = new ArrayList<>(bindings.size());
+        for (OpcUaNodeBinding b : bindings) {
+            DataValue dv = svc.latest(b.signalTag);
+            if (dv == null) continue;
+            MeasurementSignal s = OpcUaSignalMapper.toMeasurement(b, dv);
+            s.setInputName(name);
+            out.add(s);
+        }
+        return out;
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() {
+        return new HashMap<>();
+    }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() { return freq; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/input/opcua/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/input/opcua/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * {@link com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput}
+ * implementations that convert subscribed OPC UA values into Jneopallium
+ * input signals.
+ */
+package com.rakovpublic.jneuropallium.worker.input.opcua;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/opcua/MiloOpcUaClientService.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/opcua/MiloOpcUaClientService.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua;
+
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.identity.AnonymousProvider;
+import org.eclipse.milo.opcua.sdk.client.identity.IdentityProvider;
+import org.eclipse.milo.opcua.sdk.client.identity.UsernameProvider;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.MonitoredItemSynchronizationException;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaMonitoredItem;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.stream.Stream;
+
+/**
+ * Owns the {@link OpcUaClient}, the single {@link OpcUaSubscription} and
+ * the cache of latest {@link DataValue}s. Inputs and the output aggregator
+ * share one instance of this service.
+ *
+ * <p>Reconnect is intentionally simple — Milo's client transparently retries
+ * the channel; on permanent failure we surface a high-priority alarm and
+ * never silently replay buffered writes.
+ */
+public class MiloOpcUaClientService implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(MiloOpcUaClientService.class);
+
+    private final OpcUaBridgeConfig cfg;
+    private final OpcUaClient client;
+    private final OpcUaSubscription subscription;
+    private final Map<String, OpcUaNodeBinding> bindingsBySignalTag = new ConcurrentHashMap<>();
+    private final Map<NodeId, OpcUaNodeBinding> bindingsByNodeId = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, DataValue> latest = new ConcurrentHashMap<>();
+    private final BlockingQueue<AlarmEvent> alarmQueue = new LinkedBlockingQueue<>(10_000);
+
+    public MiloOpcUaClientService(OpcUaBridgeConfig cfg) throws UaException {
+        this.cfg = Objects.requireNonNull(cfg, "cfg");
+        this.client = buildClient(cfg);
+        this.client.connect();
+        double publishingMillis = Math.max(50, cfg.tickInterval().toMillis());
+        this.subscription = new OpcUaSubscription(client, publishingMillis);
+        installListener();
+        subscription.create();
+        registerBindings();
+    }
+
+    /** Test-only ctor: bypasses client construction so logic can be unit-tested. */
+    protected MiloOpcUaClientService(OpcUaBridgeConfig cfg,
+                                     OpcUaClient client,
+                                     OpcUaSubscription subscription) {
+        this.cfg = cfg;
+        this.client = client;
+        this.subscription = subscription;
+    }
+
+    public OpcUaClient getClient() { return client; }
+
+    public DataValue latest(String signalTag) { return latest.get(signalTag); }
+
+    /** Snapshot of all latest read values keyed by signalTag. */
+    public Map<String, DataValue> snapshotLatest() { return Map.copyOf(latest); }
+
+    public OpcUaNodeBinding bindingByNodeId(NodeId id) { return bindingsByNodeId.get(id); }
+
+    public OpcUaNodeBinding bindingBySignalTag(String tag) { return bindingsBySignalTag.get(tag); }
+
+    /**
+     * Synchronous write of one value. Returns the per-node {@link StatusCode}
+     * the server returned, or {@code null} on transport failure.
+     */
+    public StatusCode writeValue(NodeId nodeId, DataValue value) {
+        try {
+            List<StatusCode> results = client.writeValues(List.of(nodeId), List.of(value));
+            return results.isEmpty() ? null : results.get(0);
+        } catch (UaException e) {
+            log.error("OPC UA write failed for nodeId={}: {}", nodeId, e.getMessage());
+            return null;
+        }
+    }
+
+    public List<AlarmEvent> drainAlarms() {
+        List<AlarmEvent> out = new ArrayList<>();
+        alarmQueue.drainTo(out);
+        return out;
+    }
+
+    @Override
+    public void close() {
+        try {
+            if (subscription != null) subscription.delete();
+        } catch (UaException e) {
+            log.warn("Failed to delete subscription: {}", e.getMessage());
+        }
+        try {
+            if (client != null) client.disconnect();
+        } catch (UaException e) {
+            log.warn("Failed to disconnect client: {}", e.getMessage());
+        }
+    }
+
+    /* ============================================================ */
+
+    private static OpcUaClient buildClient(OpcUaBridgeConfig cfg) throws UaException {
+        IdentityProvider identity = identityProvider(cfg.security().auth());
+        return OpcUaClient.create(
+                cfg.connection().endpointUrl(),
+                endpoints -> endpoints.stream().findFirst(),
+                transport -> {},
+                builder -> applyClientConfig(cfg, identity, builder));
+    }
+
+    private static void applyClientConfig(
+            OpcUaBridgeConfig cfg,
+            IdentityProvider identity,
+            org.eclipse.milo.opcua.sdk.client.OpcUaClientConfigBuilder builder) {
+        builder.setApplicationName(
+                org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText.english(
+                        cfg.connection().applicationName()))
+                .setApplicationUri(cfg.connection().applicationUri())
+                .setRequestTimeout(unsignedMillis(cfg.connection().requestTimeout().toMillis()))
+                .setSessionTimeout(unsignedMillis(cfg.connection().sessionTimeout().toMillis()))
+                .setKeepAliveFailuresAllowed(unsigned(cfg.connection().keepAliveFailuresAllowed()))
+                .setIdentityProvider(identity);
+    }
+
+    private static IdentityProvider identityProvider(OpcUaBridgeConfig.SecurityConfig.Authentication a) {
+        if (a instanceof OpcUaBridgeConfig.SecurityConfig.Anonymous) {
+            return new AnonymousProvider();
+        }
+        if (a instanceof OpcUaBridgeConfig.SecurityConfig.UsernamePassword up) {
+            String pw = up.passwordEnv() == null ? ""
+                    : Optional.ofNullable(System.getenv(up.passwordEnv())).orElse("");
+            return new UsernameProvider(up.username() == null ? "" : up.username(), pw);
+        }
+        if (a instanceof OpcUaBridgeConfig.SecurityConfig.X509) {
+            throw new IllegalStateException("X509 identity not yet supported in this bridge build");
+        }
+        throw new IllegalStateException("Unknown authentication: " + a);
+    }
+
+    private static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger unsignedMillis(long ms) {
+        return unsigned((int) Math.max(0, Math.min(ms, Integer.MAX_VALUE)));
+    }
+
+    private static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger unsigned(int v) {
+        return org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint(Math.max(0, v));
+    }
+
+    private void installListener() {
+        subscription.setSubscriptionListener(new OpcUaSubscription.SubscriptionListener() {
+            @Override
+            public void onDataReceived(OpcUaSubscription sub,
+                                       List<OpcUaMonitoredItem> items,
+                                       List<DataValue> values) {
+                int n = Math.min(items.size(), values.size());
+                for (int i = 0; i < n; i++) {
+                    OpcUaMonitoredItem item = items.get(i);
+                    DataValue dv = values.get(i);
+                    NodeId nid = item.getReadValueId().getNodeId();
+                    OpcUaNodeBinding b = bindingsByNodeId.get(nid);
+                    if (b == null) continue;
+                    latest.put(b.signalTag, dv);
+                    b.setLastSeen(dv);
+                    if (isAlarmBinding(b)) {
+                        if (!alarmQueue.offer(new AlarmEvent(b, dv))) {
+                            log.warn("Alarm queue full — dropping alarm for {}", b.signalTag);
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    private void registerBindings() {
+        List<OpcUaMonitoredItem> items = new ArrayList<>();
+        Stream.concat(cfg.reads().stream(), cfg.alarms().stream())
+                .forEach(c -> {
+                    OpcUaNodeBinding b = new OpcUaNodeBinding(c);
+                    bindingsByNodeId.put(b.nodeId, b);
+                    bindingsBySignalTag.put(b.signalTag, b);
+                    OpcUaMonitoredItem mi = OpcUaMonitoredItem.newDataItem(b.nodeId);
+                    items.add(mi);
+                });
+        cfg.writes().forEach(c -> {
+            OpcUaNodeBinding b = new OpcUaNodeBinding(c);
+            bindingsBySignalTag.put(b.signalTag, b);
+            bindingsByNodeId.putIfAbsent(b.nodeId, b);
+        });
+        if (!items.isEmpty()) {
+            subscription.addMonitoredItems(items);
+            try {
+                subscription.synchronizeMonitoredItems();
+            } catch (MonitoredItemSynchronizationException e) {
+                e.getCreateResults().forEach(r ->
+                        log.error("Failed to create MonitoredItem nodeId={} svc={} op={}",
+                                r.monitoredItem().getReadValueId().getNodeId(),
+                                r.serviceResult(),
+                                r.operationResult().orElse(null)));
+                throw new IllegalStateException("Could not subscribe to all bindings", e);
+            }
+        }
+    }
+
+    private boolean isAlarmBinding(OpcUaNodeBinding b) {
+        return cfg.alarms().contains(b.config);
+    }
+
+    /** A delivered alarm sample — paired with its binding for downstream mapping. */
+    public record AlarmEvent(OpcUaNodeBinding binding, DataValue value) {}
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/opcua/OpcUaBridgeConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/opcua/OpcUaBridgeConfig.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.SafetyMode;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Top-level configuration for an OPC UA bridge instance.
+ *
+ * <p>Loaded from YAML at startup; immutable. Hot-reloading is deliberately
+ * unsupported — config changes require a controlled restart of the bridge,
+ * which is the expected industrial workflow (Management of Change).
+ */
+public record OpcUaBridgeConfig(
+        ConnectionConfig connection,
+        SecurityConfig security,
+        List<NodeBindingConfig> reads,
+        List<NodeBindingConfig> writes,
+        List<NodeBindingConfig> alarms,
+        AuditConfig audit,
+        Map<String, SafetyMode> perLoopSafetyMode,
+        Duration tickInterval
+) {
+    public OpcUaBridgeConfig {
+        Objects.requireNonNull(connection, "connection");
+        Objects.requireNonNull(security, "security");
+        reads = reads == null ? List.of() : List.copyOf(reads);
+        writes = writes == null ? List.of() : List.copyOf(writes);
+        alarms = alarms == null ? List.of() : List.copyOf(alarms);
+        perLoopSafetyMode = perLoopSafetyMode == null ? Map.of() : Map.copyOf(perLoopSafetyMode);
+        tickInterval = tickInterval == null ? Duration.ofMillis(250) : tickInterval;
+    }
+
+    public record ConnectionConfig(
+            String endpointUrl,
+            String applicationName,
+            String applicationUri,
+            Duration requestTimeout,
+            Duration sessionTimeout,
+            int keepAliveFailuresAllowed
+    ) {
+        public ConnectionConfig {
+            Objects.requireNonNull(endpointUrl, "endpointUrl");
+            applicationName = applicationName == null ? "Jneopallium-OPCUA-Bridge" : applicationName;
+            applicationUri = applicationUri == null ? "urn:rakovpublic:jneopallium:bridge" : applicationUri;
+            requestTimeout = requestTimeout == null ? Duration.ofSeconds(5) : requestTimeout;
+            sessionTimeout = sessionTimeout == null ? Duration.ofMinutes(2) : sessionTimeout;
+            if (keepAliveFailuresAllowed < 0) keepAliveFailuresAllowed = 3;
+        }
+    }
+
+    public record SecurityConfig(
+            SecurityPolicy policy,
+            MessageSecurityMode mode,
+            String pkiDir,
+            String certAlias,
+            String certPassword,
+            Authentication auth
+    ) {
+        public SecurityConfig {
+            policy = policy == null ? SecurityPolicy.NONE : policy;
+            mode = mode == null ? MessageSecurityMode.NONE : mode;
+            auth = auth == null ? new Anonymous() : auth;
+        }
+
+        public enum SecurityPolicy { NONE, BASIC256SHA256, AES128_SHA256_RSAOAEP, AES256_SHA256_RSAPSS }
+        public enum MessageSecurityMode { NONE, SIGN, SIGN_AND_ENCRYPT }
+
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+        @JsonSubTypes({
+                @JsonSubTypes.Type(value = Anonymous.class, name = "Anonymous"),
+                @JsonSubTypes.Type(value = UsernamePassword.class, name = "UsernamePassword"),
+                @JsonSubTypes.Type(value = X509.class, name = "X509")
+        })
+        public sealed interface Authentication permits Anonymous, UsernamePassword, X509 {}
+
+        public record Anonymous() implements Authentication {}
+        public record UsernamePassword(String username, String passwordEnv) implements Authentication {}
+        public record X509(String certAlias) implements Authentication {}
+    }
+
+    public record NodeBindingConfig(
+            String loopId,
+            String nodeId,
+            String signalTag,
+            Direction direction,
+            Double failSafeValue,
+            Double rampRateMaxPerSec,
+            Double minClampValue,
+            Double maxClampValue
+    ) {
+        public NodeBindingConfig {
+            Objects.requireNonNull(loopId, "loopId");
+            Objects.requireNonNull(nodeId, "nodeId");
+            Objects.requireNonNull(signalTag, "signalTag");
+            direction = direction == null ? Direction.READ : direction;
+        }
+
+        public enum Direction { READ, WRITE, BOTH }
+    }
+
+    public record AuditConfig(
+            String localAuditFile,
+            String opcUaAuditNodeId,
+            boolean writeRejectedToAudit
+    ) {
+        public AuditConfig {
+            Objects.requireNonNull(localAuditFile, "localAuditFile");
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/opcua/OpcUaBridgeConfigLoader.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/opcua/OpcUaBridgeConfigLoader.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+/**
+ * Loads {@link OpcUaBridgeConfig} from YAML.
+ *
+ * <p>{@code FAIL_ON_UNKNOWN_PROPERTIES = true} is deliberate — silently
+ * ignoring a typo'd field in the YAML would be a safety incident waiting
+ * to happen.
+ */
+public final class OpcUaBridgeConfigLoader {
+
+    private OpcUaBridgeConfigLoader() {}
+
+    public static OpcUaBridgeConfig load(Path yaml) throws IOException {
+        return mapper().readValue(yaml.toFile(), OpcUaBridgeConfig.class);
+    }
+
+    public static OpcUaBridgeConfig load(InputStream in) throws IOException {
+        return mapper().readValue(in, OpcUaBridgeConfig.class);
+    }
+
+    public static OpcUaBridgeConfig load(String yaml) throws IOException {
+        return mapper().readValue(yaml, OpcUaBridgeConfig.class);
+    }
+
+    private static ObjectMapper mapper() {
+        return new ObjectMapper(new YAMLFactory())
+                .registerModule(new JavaTimeModule())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/opcua/OpcUaNodeBinding.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/opcua/OpcUaNodeBinding.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua;
+
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+
+/**
+ * Runtime projection of a {@link OpcUaBridgeConfig.NodeBindingConfig} —
+ * holds the parsed {@link NodeId}, the latest cached {@link DataValue}
+ * (for diff-suppression on writes), and the rate-limit history.
+ */
+public final class OpcUaNodeBinding {
+
+    public final String loopId;
+    public final String signalTag;
+    public final NodeId nodeId;
+    public final OpcUaBridgeConfig.NodeBindingConfig config;
+
+    private volatile DataValue lastSeen;
+    private volatile double lastWritten = Double.NaN;
+    private volatile long lastWrittenAt;
+
+    public OpcUaNodeBinding(OpcUaBridgeConfig.NodeBindingConfig cfg) {
+        this.loopId = cfg.loopId();
+        this.signalTag = cfg.signalTag();
+        this.nodeId = NodeId.parse(cfg.nodeId());
+        this.config = cfg;
+    }
+
+    public DataValue getLastSeen() { return lastSeen; }
+    public void setLastSeen(DataValue v) { this.lastSeen = v; }
+
+    public double getLastWritten() { return lastWritten; }
+    public long getLastWrittenAt() { return lastWrittenAt; }
+
+    public synchronized void recordWrite(double value, long ts) {
+        this.lastWritten = value;
+        this.lastWrittenAt = ts;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/opcua/OpcUaSignalMapper.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/opcua/OpcUaSignalMapper.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmPriority;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.Quality;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+
+/**
+ * Pure-function translation between OPC UA {@link DataValue}s and the
+ * Jneopallium industrial signal types. No I/O, no shared state — easy
+ * to unit-test.
+ *
+ * <p>Quality propagates per spec §0.5: a {@code DataValue} whose
+ * {@link StatusCode} is not {@code good()} produces a signal with
+ * {@link Quality#UNCERTAIN} or {@link Quality#BAD} — never {@code GOOD}.
+ *
+ * <p>Wall-clock timestamps come from OPC UA per §0.6:
+ * {@code sourceTime} → {@code serverTime} → local clock.
+ */
+public final class OpcUaSignalMapper {
+
+    private OpcUaSignalMapper() {}
+
+    public static MeasurementSignal toMeasurement(OpcUaNodeBinding b, DataValue dv) {
+        double value = coerceDouble(dv.getValue());
+        Quality q = mapQuality(dv.getStatusCode());
+        long ts = pickTimestamp(dv);
+        return new MeasurementSignal(b.signalTag, value, q, ts);
+    }
+
+    public static AlarmSignal toAlarm(OpcUaNodeBinding b, DataValue dv) {
+        int code = coerceInt(dv.getValue());
+        AlarmPriority pri = mapAlarmPriority(code);
+        long ts = pickTimestamp(dv);
+        return new AlarmSignal(pri, b.signalTag, "OPCUA-" + code, ts);
+    }
+
+    public static DataValue toDataValue(SetpointSignal s) {
+        return DataValue.valueOnly(Variant.ofDouble(s.getSetpoint()));
+    }
+
+    public static DataValue toDataValue(ActuatorCommandSignal s) {
+        return DataValue.valueOnly(Variant.ofDouble(s.getTargetValue()));
+    }
+
+    public static DataValue toDataValue(double value) {
+        return DataValue.valueOnly(Variant.ofDouble(value));
+    }
+
+    static Quality mapQuality(StatusCode sc) {
+        if (sc == null) return Quality.UNCERTAIN;
+        if (sc.isGood()) return Quality.GOOD;
+        if (sc.isBad()) return Quality.BAD;
+        return Quality.UNCERTAIN;
+    }
+
+    static AlarmPriority mapAlarmPriority(int code) {
+        if (code >= 700) return AlarmPriority.URGENT;
+        if (code >= 400) return AlarmPriority.HIGH;
+        if (code >= 100) return AlarmPriority.LOW;
+        return AlarmPriority.JOURNAL;
+    }
+
+    static long pickTimestamp(DataValue dv) {
+        DateTime src = dv.getSourceTime();
+        if (src != null && src.isNotNull()) return src.getJavaTime();
+        DateTime srv = dv.getServerTime();
+        if (srv != null && srv.isNotNull()) return srv.getJavaTime();
+        return System.currentTimeMillis();
+    }
+
+    static double coerceDouble(Variant v) {
+        if (v == null) return Double.NaN;
+        Object o = v.getValue();
+        if (o == null) return Double.NaN;
+        if (o instanceof Number n) return n.doubleValue();
+        if (o instanceof Boolean b) return b ? 1.0 : 0.0;
+        throw new IllegalStateException(
+                "Cannot coerce OPC UA value to double: " + o.getClass().getName());
+    }
+
+    static int coerceInt(Variant v) {
+        if (v == null) return 0;
+        Object o = v.getValue();
+        if (o == null) return 0;
+        if (o instanceof Number n) return n.intValue();
+        if (o instanceof Boolean b) return b ? 1 : 0;
+        throw new IllegalStateException(
+                "Cannot coerce OPC UA value to int: " + o.getClass().getName());
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/opcua/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/opcua/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Eclipse Milo OPC UA bridge for the Jneopallium industrial pipeline.
+ * See {@code JNEOPALLIUM_OPCUA_INTEGRATION.md} and
+ * {@code docs/opcua-bridge-architecture.md}.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/ActuatorCommandSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/ActuatorCommandSignal.java
@@ -5,6 +5,7 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
 
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
@@ -12,7 +13,10 @@ import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
  * signal is logged and compared but not written to the field.
  * ProcessingFrequency: loop=1, epoch=1.
  */
-public class ActuatorCommandSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class ActuatorCommandSignal extends AbstractSignal<Void> implements ISignal<Void>, IResultSignal<Void> {
+
+    @Override public Void getResultObject() { return null; }
+    @Override public Class<Void> getResultObjectClass() { return Void.class; }
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
 

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/AlarmSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/AlarmSignal.java
@@ -6,13 +6,14 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmPriority;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
  * ISA-18.2 alarm with a priority and a condition code.
  * ProcessingFrequency: loop=1, epoch=1.
  */
-public class AlarmSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class AlarmSignal extends AbstractSignal<Void> implements ISignal<Void>, IInputSignal<Void> {
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
 

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/InterlockSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/InterlockSignal.java
@@ -5,6 +5,7 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
 
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 import java.util.ArrayList;
@@ -16,7 +17,10 @@ import java.util.List;
  * a TransparencyLogSignal at the dispatch layer.
  * ProcessingFrequency: loop=1, epoch=1.
  */
-public class InterlockSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class InterlockSignal extends AbstractSignal<Void> implements ISignal<Void>, IResultSignal<Void> {
+
+    @Override public Void getResultObject() { return null; }
+    @Override public Class<Void> getResultObjectClass() { return Void.class; }
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
 

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/MeasurementSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/MeasurementSignal.java
@@ -6,6 +6,7 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.Quality;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
@@ -15,7 +16,7 @@ import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
  * addition to the jneopallium tick.
  * ProcessingFrequency: loop=1, epoch=1.
  */
-public class MeasurementSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class MeasurementSignal extends AbstractSignal<Void> implements ISignal<Void>, IInputSignal<Void> {
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
 

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/OperatorOverrideSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/OperatorOverrideSignal.java
@@ -6,6 +6,7 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.OverrideKind;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
@@ -13,7 +14,10 @@ import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
  * regulatory control; it does not affect interlocks. ProcessingFrequency:
  * loop=1, epoch=1.
  */
-public class OperatorOverrideSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class OperatorOverrideSignal extends AbstractSignal<Void> implements ISignal<Void>, IResultSignal<Void> {
+
+    @Override public Void getResultObject() { return null; }
+    @Override public Class<Void> getResultObjectClass() { return Void.class; }
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
 

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/SetpointSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/SetpointSignal.java
@@ -5,13 +5,17 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
 
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
  * Setpoint update for a control loop with an optional ramp rate.
  * ProcessingFrequency: loop=1, epoch=2.
  */
-public class SetpointSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class SetpointSignal extends AbstractSignal<Void> implements ISignal<Void>, IResultSignal<Void> {
+
+    @Override public Void getResultObject() { return null; }
+    @Override public Class<Void> getResultObjectClass() { return Void.class; }
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
 

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/industrial/opcua/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/industrial/opcua/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * Reserved for future OPC UA-specific signal subtypes. The bridge
+ * currently reuses the generic industrial signals from
+ * {@code com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial}.
+ */
+package com.rakovpublic.jneuropallium.worker.net.signals.industrial.opcua;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/output/opcua/OpcUaCommandOutputAggregator.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/output/opcua/OpcUaCommandOutputAggregator.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.output.opcua;
+
+import com.rakovpublic.jneuropallium.worker.application.IOutputAggregator;
+import com.rakovpublic.jneuropallium.worker.net.layers.IResult;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.SafetyMode;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua.MiloOpcUaClientService;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua.OpcUaBridgeConfig;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua.OpcUaNodeBinding;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua.OpcUaSignalMapper;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.InterlockSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.OperatorOverrideSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+import com.rakovpublic.jneuropallium.worker.util.IContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static com.rakovpublic.jneuropallium.worker.output.opcua.OpcUaTransparencyLogOutput.Verdict;
+
+/**
+ * Safety-critical aggregator that turns neuron output into OPC UA writes.
+ *
+ * <p>Spec §0 ground rules enforced here:
+ * <ol>
+ *   <li>Interlocks have direct authority — fail-safe write first.</li>
+ *   <li>Operator override wins for regulatory control.</li>
+ *   <li>Per-loop {@link SafetyMode} (SHADOW/ADVISORY/AUTONOMOUS) gates writes.</li>
+ *   <li>Every accepted, suppressed, clamped or rejected write produces an audit record.</li>
+ *   <li>Quality and timestamps are not invented at the bridge.</li>
+ * </ol>
+ *
+ * <p>Per-write protections: clamp to [min,max], rate-limit per
+ * {@code rampRateMaxPerSec}, diff-suppress repeats inside 5 s with delta
+ * &lt; 1e-6.
+ */
+public final class OpcUaCommandOutputAggregator implements IOutputAggregator, AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(OpcUaCommandOutputAggregator.class);
+
+    private static final double DIFF_SUPPRESS_EPSILON = 1e-6;
+    private static final long DIFF_SUPPRESS_WINDOW_MS = 5_000L;
+
+    private final OpcUaBridgeConfig cfg;
+    private final MiloOpcUaClientService svc;
+    private final OpcUaTransparencyLogOutput audit;
+    private final OverrideRegistry overrides = new OverrideRegistry();
+    private final Map<String, OpcUaNodeBinding> writeBindings;
+
+    public OpcUaCommandOutputAggregator(OpcUaBridgeConfig cfg,
+                                        MiloOpcUaClientService svc,
+                                        OpcUaTransparencyLogOutput audit) {
+        this.cfg = Objects.requireNonNull(cfg);
+        this.svc = Objects.requireNonNull(svc);
+        this.audit = Objects.requireNonNull(audit);
+        var map = new java.util.HashMap<String, OpcUaNodeBinding>();
+        for (OpcUaBridgeConfig.NodeBindingConfig c : cfg.writes()) {
+            OpcUaNodeBinding b = svc.bindingBySignalTag(c.signalTag());
+            map.put(c.signalTag(), b != null ? b : new OpcUaNodeBinding(c));
+        }
+        this.writeBindings = Map.copyOf(map);
+    }
+
+    @Override
+    public void save(List<IResult> results, long timestamp, long run, IContext context) {
+        Partition p = partition(results);
+
+        java.util.Set<String> heldThisTick = new java.util.HashSet<>();
+        for (InterlockSignal s : p.interlocks) {
+            heldThisTick.addAll(executeInterlock(s, timestamp, run));
+        }
+
+        for (OperatorOverrideSignal o : p.overrides) {
+            overrides.record(o, timestamp);
+        }
+        overrides.expireOlderThan(timestamp);
+
+        for (Command c : p.commands) {
+            try {
+                if (heldThisTick.contains(c.tag())) {
+                    audit.record(Verdict.REJECTED,
+                            bindingLoopId(c.tag()), c.tag(), c.proposed(), null,
+                            "INTERLOCK_HOLD",
+                            currentSafetyMode(c.tag()).name(),
+                            timestamp, run);
+                    continue;
+                }
+                processCommand(c, timestamp, run);
+            } catch (Exception e) {
+                log.error("Command processing failed for tag={}", c.tag(), e);
+                audit.record(Verdict.FAILED, "?", c.tag(), c.proposed(), null,
+                        "EXCEPTION:" + e.getClass().getSimpleName(),
+                        currentSafetyMode(c.tag()).name(),
+                        timestamp, run);
+            }
+        }
+    }
+
+    private String bindingLoopId(String tag) {
+        OpcUaNodeBinding b = writeBindings.get(tag);
+        return b == null ? "?" : b.loopId;
+    }
+
+    /* ============================================================ */
+
+    /** @return signal tags that were tripped to fail-safe — must be held for the rest of the tick. */
+    private java.util.Set<String> executeInterlock(InterlockSignal s, long ts, long run) {
+        java.util.Set<String> held = new java.util.HashSet<>();
+        for (OpcUaNodeBinding b : writeBindings.values()) {
+            if (!matchesInterlock(s, b)) continue;
+            held.add(b.signalTag);
+            Double fs = b.config.failSafeValue();
+            if (fs == null) {
+                audit.record(Verdict.REJECTED, b.loopId, b.signalTag, null, null,
+                        "INTERLOCK_NO_FAILSAFE", currentSafetyMode(b.signalTag).name(), ts, run);
+                continue;
+            }
+            DataValue dv = OpcUaSignalMapper.toDataValue(fs);
+            StatusCode sc = svc.writeValue(b.nodeId, dv);
+            if (sc != null && sc.isGood()) {
+                b.recordWrite(fs, ts);
+                audit.record(Verdict.INTERLOCK_TRIP, b.loopId, b.signalTag, null, fs,
+                        "INTERLOCK:" + s.getInterlockId(),
+                        currentSafetyMode(b.signalTag).name(), ts, run);
+            } else {
+                audit.record(Verdict.FAILED, b.loopId, b.signalTag, null, fs,
+                        "INTERLOCK_WRITE_FAILED:" + (sc == null ? "TRANSPORT" : sc),
+                        currentSafetyMode(b.signalTag).name(), ts, run);
+            }
+        }
+        return held;
+    }
+
+    private boolean matchesInterlock(InterlockSignal s, OpcUaNodeBinding b) {
+        if (s == null || s.getInterlockId() == null) return false;
+        return s.getInterlockId().equals(b.loopId) || s.getInterlockId().equals(b.signalTag);
+    }
+
+    private void processCommand(Command c, long ts, long run) {
+        OpcUaNodeBinding b = writeBindings.get(c.tag());
+        SafetyMode mode = currentSafetyMode(c.tag());
+        if (b == null) {
+            audit.record(Verdict.REJECTED, "?", c.tag(), c.proposed(), null,
+                    "UNKNOWN_TAG", mode.name(), ts, run);
+            return;
+        }
+        // Interlock hold: a tripped interlock for this loop in the same tick wins
+        if (overrides.isActive(c.tag(), ts)) {
+            audit.record(Verdict.OVERRIDE_HOLD, b.loopId, b.signalTag, c.proposed(), null,
+                    "OPERATOR_OVERRIDE", mode.name(), ts, run);
+            return;
+        }
+        switch (mode) {
+            case SHADOW -> {
+                audit.record(Verdict.REJECTED, b.loopId, b.signalTag, c.proposed(), null,
+                        "SHADOW_MODE", mode.name(), ts, run);
+                return;
+            }
+            case ADVISORY -> {
+                if (!c.execute()) {
+                    audit.record(Verdict.REJECTED, b.loopId, b.signalTag, c.proposed(), null,
+                            "ADVISORY_REQUIRES_CONFIRMATION", mode.name(), ts, run);
+                    return;
+                }
+            }
+            case AUTONOMOUS -> { /* fall through */ }
+        }
+
+        // Clamp
+        double effective = c.proposed();
+        String clampReason = null;
+        if (b.config.minClampValue() != null && effective < b.config.minClampValue()) {
+            effective = b.config.minClampValue();
+            clampReason = "CLAMPED_LOW";
+        } else if (b.config.maxClampValue() != null && effective > b.config.maxClampValue()) {
+            effective = b.config.maxClampValue();
+            clampReason = "CLAMPED_HIGH";
+        }
+
+        // Rate limit
+        String rateReason = null;
+        if (b.config.rampRateMaxPerSec() != null && b.getLastWrittenAt() > 0) {
+            double dtSec = Math.max(0.001, (ts - b.getLastWrittenAt()) / 1000.0);
+            double maxStep = b.config.rampRateMaxPerSec() * dtSec;
+            double last = b.getLastWritten();
+            double delta = effective - last;
+            if (Math.abs(delta) > maxStep) {
+                effective = last + Math.signum(delta) * maxStep;
+                rateReason = "RATE_LIMITED";
+            }
+        }
+
+        // Diff-suppress
+        if (b.getLastWrittenAt() > 0
+                && Math.abs(effective - b.getLastWritten()) < DIFF_SUPPRESS_EPSILON
+                && (ts - b.getLastWrittenAt()) < DIFF_SUPPRESS_WINDOW_MS) {
+            audit.record(Verdict.APPLIED, b.loopId, b.signalTag, c.proposed(), effective,
+                    "DIFF_SUPPRESSED", mode.name(), ts, run);
+            return;
+        }
+
+        DataValue dv = OpcUaSignalMapper.toDataValue(effective);
+        StatusCode sc = svc.writeValue(b.nodeId, dv);
+        String reason = clampReason != null ? clampReason
+                : rateReason != null ? rateReason
+                : null;
+        if (sc != null && sc.isGood()) {
+            b.recordWrite(effective, ts);
+            audit.record(Verdict.APPLIED, b.loopId, b.signalTag, c.proposed(), effective,
+                    reason, mode.name(), ts, run);
+        } else {
+            audit.record(Verdict.FAILED, b.loopId, b.signalTag, c.proposed(), effective,
+                    "WRITE_FAILED:" + (sc == null ? "TRANSPORT" : sc),
+                    mode.name(), ts, run);
+        }
+    }
+
+    private SafetyMode currentSafetyMode(String tag) {
+        OpcUaNodeBinding b = writeBindings.get(tag);
+        if (b != null) {
+            SafetyMode m = cfg.perLoopSafetyMode().get(b.loopId);
+            if (m != null) return m;
+        }
+        return SafetyMode.SHADOW;
+    }
+
+    private Partition partition(List<IResult> results) {
+        List<InterlockSignal> interlocks = new ArrayList<>();
+        List<OperatorOverrideSignal> overridesList = new ArrayList<>();
+        List<Command> commands = new ArrayList<>();
+        if (results == null) return new Partition(interlocks, overridesList, commands);
+        for (IResult r : results) {
+            IResultSignal sig = r.getResult();
+            if (sig instanceof InterlockSignal il) {
+                if (il.isTripped()) interlocks.add(il);
+            } else if (sig instanceof OperatorOverrideSignal ov) {
+                overridesList.add(ov);
+            } else if (sig instanceof SetpointSignal sp) {
+                commands.add(new Command(sp.getTag(), sp.getSetpoint(), true));
+            } else if (sig instanceof ActuatorCommandSignal ac) {
+                commands.add(new Command(ac.getTag(), ac.getTargetValue(), ac.isExecute()));
+            }
+        }
+        return new Partition(interlocks, overridesList, commands);
+    }
+
+    @Override
+    public void close() {
+        // ownership of svc / audit is external
+    }
+
+    /* === helper types === */
+
+    private record Partition(List<InterlockSignal> interlocks,
+                             List<OperatorOverrideSignal> overrides,
+                             List<Command> commands) {}
+
+    private record Command(String tag, double proposed, boolean execute) {}
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/output/opcua/OpcUaTransparencyLogOutput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/output/opcua/OpcUaTransparencyLogOutput.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.output.opcua;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua.MiloOpcUaClientService;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua.OpcUaBridgeConfig;
+import com.rakovpublic.jneuropallium.worker.net.layers.IResult;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Append-only audit log. One JSONL record per accepted, suppressed,
+ * clamped, rate-limited or rejected write. The local file write happens
+ * on a single-writer thread to guarantee ordering. The optional OPC UA
+ * audit-node mirror is best-effort — local file always wins.
+ */
+public final class OpcUaTransparencyLogOutput implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(OpcUaTransparencyLogOutput.class);
+
+    public enum Verdict { APPLIED, REJECTED, INTERLOCK_TRIP, OVERRIDE_HOLD, FAILED }
+
+    private final OpcUaBridgeConfig.AuditConfig cfg;
+    private final MiloOpcUaClientService svc;
+    private final NodeId opcUaAuditNode;
+    private final Path file;
+    private final LinkedBlockingQueue<String> queue = new LinkedBlockingQueue<>(50_000);
+    private final Thread writerThread;
+    private final AtomicBoolean running = new AtomicBoolean(true);
+    private final AtomicBoolean fileHealthy = new AtomicBoolean(true);
+
+    public OpcUaTransparencyLogOutput(OpcUaBridgeConfig.AuditConfig cfg,
+                                      MiloOpcUaClientService svc) {
+        this.cfg = Objects.requireNonNull(cfg);
+        this.svc = svc;
+        this.file = Path.of(cfg.localAuditFile());
+        this.opcUaAuditNode = cfg.opcUaAuditNodeId() == null
+                ? null
+                : NodeId.parse(cfg.opcUaAuditNodeId());
+        try {
+            if (file.getParent() != null) Files.createDirectories(file.getParent());
+            if (!Files.exists(file)) Files.createFile(file);
+        } catch (IOException e) {
+            log.error("Audit file unavailable at {}: {}", file, e.getMessage());
+            fileHealthy.set(false);
+        }
+        this.writerThread = new Thread(this::drainLoop, "OpcUaAuditWriter");
+        this.writerThread.setDaemon(true);
+        this.writerThread.start();
+    }
+
+    public synchronized void record(Verdict verdict,
+                                    String loopId,
+                                    String tag,
+                                    Double proposed,
+                                    Double effective,
+                                    String reason,
+                                    String safetyMode,
+                                    long ts,
+                                    long run) {
+        if (!cfg.writeRejectedToAudit() && verdict == Verdict.REJECTED) return;
+        StringBuilder sb = new StringBuilder(192);
+        sb.append('{');
+        appendNum(sb, "ts", ts).append(',');
+        appendNum(sb, "run", run).append(',');
+        appendStr(sb, "verdict", verdict.name()).append(',');
+        appendStr(sb, "loopId", loopId).append(',');
+        appendStr(sb, "tag", tag).append(',');
+        appendOptionalNum(sb, "proposed", proposed).append(',');
+        appendOptionalNum(sb, "effective", effective).append(',');
+        appendStr(sb, "reason", reason).append(',');
+        appendStr(sb, "safetyMode", safetyMode);
+        sb.append('}').append('\n');
+        String line = sb.toString();
+        // Local file write is synchronous so audit ordering matches call order
+        // and tests don't need to flush a background thread.
+        writeLocal(line);
+        // Mirror to OPC UA on the writer thread (best-effort, must never block
+        // the local write).
+        if (!queue.offer(line)) {
+            log.warn("Audit mirror queue full — dropping mirror for {}", tag);
+        }
+    }
+
+    public void recordRejection(IResult r, String reason, long ts, long run) {
+        record(Verdict.REJECTED, "?", String.valueOf(r), null, null, reason, null, ts, run);
+    }
+
+    public boolean isHealthy() { return fileHealthy.get(); }
+
+    @Override
+    public void close() {
+        running.set(false);
+        writerThread.interrupt();
+        try {
+            writerThread.join(2000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void drainLoop() {
+        while (running.get() || !queue.isEmpty()) {
+            String line;
+            try {
+                line = queue.poll(200, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                continue;
+            }
+            if (line == null) continue;
+            // Local write was already done synchronously in record(); only
+            // the OPC UA mirror runs here.
+            mirrorToOpcUa(line);
+        }
+    }
+
+    private void writeLocal(String line) {
+        if (!fileHealthy.get()) return;
+        try {
+            Files.writeString(file, line, StandardCharsets.UTF_8,
+                    new OpenOption[]{StandardOpenOption.APPEND, StandardOpenOption.CREATE});
+        } catch (IOException e) {
+            if (fileHealthy.compareAndSet(true, false)) {
+                log.error("Audit file write failed at {}: {} — bridge will continue but health is degraded",
+                        file, e.getMessage());
+            }
+        }
+    }
+
+    private void mirrorToOpcUa(String line) {
+        if (svc == null || opcUaAuditNode == null) return;
+        try {
+            DataValue dv = DataValue.valueOnly(Variant.of(line.endsWith("\n")
+                    ? line.substring(0, line.length() - 1) : line));
+            svc.writeValue(opcUaAuditNode, dv);
+        } catch (Exception e) {
+            log.debug("OPC UA audit mirror write failed: {}", e.getMessage());
+        }
+    }
+
+    private static StringBuilder appendStr(StringBuilder sb, String k, String v) {
+        sb.append('"').append(k).append("\":");
+        if (v == null) sb.append("null");
+        else { sb.append('"'); escape(sb, v); sb.append('"'); }
+        return sb;
+    }
+
+    private static StringBuilder appendNum(StringBuilder sb, String k, long v) {
+        return sb.append('"').append(k).append("\":").append(v);
+    }
+
+    private static StringBuilder appendOptionalNum(StringBuilder sb, String k, Double v) {
+        sb.append('"').append(k).append("\":");
+        if (v == null || Double.isNaN(v) || Double.isInfinite(v)) sb.append("null");
+        else sb.append(v);
+        return sb;
+    }
+
+    private static void escape(StringBuilder sb, String s) {
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '\\', '"' -> { sb.append('\\').append(c); }
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                default -> {
+                    if (c < 0x20) sb.append(String.format("\\u%04x", (int) c));
+                    else sb.append(c);
+                }
+            }
+        }
+    }
+
+    /** Test-only: blocks until the writer queue is drained. */
+    public void flush() {
+        long deadline = System.currentTimeMillis() + 2000;
+        while (!queue.isEmpty() && System.currentTimeMillis() < deadline) {
+            try { Thread.sleep(20); } catch (InterruptedException e) { Thread.currentThread().interrupt(); break; }
+        }
+    }
+
+    /** Test-only: List of audit JSONL lines for inspection. */
+    public List<String> readAllLines() {
+        if (!fileHealthy.get()) return List.of();
+        try { return Files.readAllLines(file, StandardCharsets.UTF_8); }
+        catch (IOException e) { return List.of(); }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/output/opcua/OverrideRegistry.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/output/opcua/OverrideRegistry.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.output.opcua;
+
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.OperatorOverrideSignal;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory map of active operator overrides keyed by tag. Each entry has
+ * a wall-clock expiry; {@link #expireOlderThan} drops entries whose
+ * deadline has passed.
+ */
+public final class OverrideRegistry {
+
+    private static final long DEFAULT_DURATION_MILLIS = 5 * 60_000L;
+
+    private final Map<String, Entry> active = new ConcurrentHashMap<>();
+
+    public void record(OperatorOverrideSignal s, long ts) {
+        if (s == null || s.getTag() == null) return;
+        active.put(s.getTag(), new Entry(s, ts + DEFAULT_DURATION_MILLIS));
+    }
+
+    public boolean isActive(String tag, long now) {
+        Entry e = active.get(tag);
+        if (e == null) return false;
+        if (e.expiresAt < now) { active.remove(tag); return false; }
+        return true;
+    }
+
+    public OperatorOverrideSignal active(String tag) {
+        Entry e = active.get(tag);
+        return e == null ? null : e.signal;
+    }
+
+    public void expireOlderThan(long now) {
+        active.values().removeIf(e -> e.expiresAt < now);
+    }
+
+    public int size() { return active.size(); }
+
+    private record Entry(OperatorOverrideSignal signal, long expiresAt) {}
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/output/opcua/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/output/opcua/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Safety-gated {@link com.rakovpublic.jneuropallium.worker.application.IOutputAggregator}
+ * implementations that turn neuron decisions into OPC UA writes — never
+ * bypassing interlocks, always honouring operator override, always
+ * emitting an audit record.
+ */
+package com.rakovpublic.jneuropallium.worker.output.opcua;

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/opcua/OpcUaBridgeConfigLoaderTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/opcua/OpcUaBridgeConfigLoaderTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua;
+
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.SafetyMode;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OpcUaBridgeConfigLoaderTest {
+
+    private static final String GOOD_YAML = """
+            connection:
+              endpointUrl: "opc.tcp://example:4840"
+              applicationName: "Test-Bridge"
+              applicationUri: "urn:test:bridge"
+              requestTimeout: "PT5S"
+              sessionTimeout: "PT2M"
+              keepAliveFailuresAllowed: 3
+            security:
+              policy: NONE
+              mode: NONE
+              auth:
+                type: "Anonymous"
+            reads:
+              - loopId: "TIC-101"
+                nodeId: "ns=2;s=Plant.Temperature"
+                signalTag: "PLANT.TIC101.PV"
+                direction: READ
+            writes:
+              - loopId: "FIC-101"
+                nodeId: "ns=2;s=Plant.TargetMotorSpeed"
+                signalTag: "PLANT.FIC101.SP"
+                direction: WRITE
+                failSafeValue: 0.0
+                rampRateMaxPerSec: 5.0
+                minClampValue: 0.0
+                maxClampValue: 100.0
+            alarms:
+              - loopId: "PLANT-ALARMS"
+                nodeId: "ns=2;s=Plant.Alarm"
+                signalTag: "PLANT.ALARM"
+                direction: READ
+            audit:
+              localAuditFile: "/tmp/audit.jsonl"
+              writeRejectedToAudit: true
+            perLoopSafetyMode:
+              TIC-101: SHADOW
+              FIC-101: ADVISORY
+            tickInterval: "PT0.25S"
+            """;
+
+    @Test
+    void loadsExampleYaml() throws IOException {
+        OpcUaBridgeConfig cfg = OpcUaBridgeConfigLoader.load(GOOD_YAML);
+        assertEquals("opc.tcp://example:4840", cfg.connection().endpointUrl());
+        assertEquals(Duration.ofSeconds(5), cfg.connection().requestTimeout());
+        assertEquals(Duration.ofMinutes(2), cfg.connection().sessionTimeout());
+        assertEquals(3, cfg.connection().keepAliveFailuresAllowed());
+        assertEquals(1, cfg.reads().size());
+        assertEquals("PLANT.TIC101.PV", cfg.reads().get(0).signalTag());
+        assertEquals(1, cfg.writes().size());
+        assertEquals(0.0, cfg.writes().get(0).failSafeValue());
+        assertEquals(5.0, cfg.writes().get(0).rampRateMaxPerSec());
+        assertEquals(0.0, cfg.writes().get(0).minClampValue());
+        assertEquals(100.0, cfg.writes().get(0).maxClampValue());
+        assertEquals(SafetyMode.SHADOW, cfg.perLoopSafetyMode().get("TIC-101"));
+        assertEquals(SafetyMode.ADVISORY, cfg.perLoopSafetyMode().get("FIC-101"));
+        assertEquals(Duration.ofMillis(250), cfg.tickInterval());
+        assertInstanceOf(OpcUaBridgeConfig.SecurityConfig.Anonymous.class, cfg.security().auth());
+    }
+
+    @Test
+    void unknownPropertyIsRejected() {
+        // Add a wholly-unknown field at the top level so neither the typo
+        // path (which would surface as a constructor failure on a record)
+        // nor the unknown-field path is masked.
+        String bad = GOOD_YAML.replace(
+                "tickInterval: \"PT0.25S\"",
+                "tickInterval: \"PT0.25S\"\nthisFieldDoesNotExist: 42");
+        Throwable thrown = assertThrows(Throwable.class,
+                () -> OpcUaBridgeConfigLoader.load(bad),
+                "FAIL_ON_UNKNOWN_PROPERTIES must be true");
+        assertTrue(thrown instanceof UnrecognizedPropertyException
+                        || (thrown.getCause() instanceof UnrecognizedPropertyException),
+                "expected UnrecognizedPropertyException, got " + thrown);
+    }
+
+    @Test
+    void usernamePasswordAuthRoundTrips() throws IOException {
+        String yaml = GOOD_YAML.replace(
+                "auth:\n    type: \"Anonymous\"",
+                "auth:\n    type: \"UsernamePassword\"\n    username: \"User\"\n    passwordEnv: \"OPCUA_USER_PASSWORD\"");
+        OpcUaBridgeConfig cfg = OpcUaBridgeConfigLoader.load(yaml);
+        assertInstanceOf(OpcUaBridgeConfig.SecurityConfig.UsernamePassword.class, cfg.security().auth());
+        OpcUaBridgeConfig.SecurityConfig.UsernamePassword up =
+                (OpcUaBridgeConfig.SecurityConfig.UsernamePassword) cfg.security().auth();
+        assertEquals("User", up.username());
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/opcua/OpcUaSignalMapperTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/net/neuron/impl/industrial/opcua/OpcUaSignalMapperTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmPriority;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.Quality;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OpcUaSignalMapperTest {
+
+    private static OpcUaNodeBinding binding(String tag) {
+        return new OpcUaNodeBinding(new OpcUaBridgeConfig.NodeBindingConfig(
+                "LOOP-1", "ns=2;s=" + tag, tag,
+                OpcUaBridgeConfig.NodeBindingConfig.Direction.READ,
+                null, null, null, null));
+    }
+
+    @Test
+    void measurementWithGoodStatusCarriesGoodQuality() {
+        DataValue dv = new DataValue(
+                Variant.ofDouble(42.5),
+                StatusCode.GOOD,
+                new DateTime(Instant.ofEpochMilli(1_700_000_000_000L)));
+        MeasurementSignal s = OpcUaSignalMapper.toMeasurement(binding("T1"), dv);
+        assertEquals(42.5, s.getMeasurement(), 1e-9);
+        assertEquals(Quality.GOOD, s.getQuality());
+        assertEquals(1_700_000_000_000L, s.getTimestamp());
+        assertEquals("T1", s.getTag());
+    }
+
+    @Test
+    void badStatusYieldsBadQuality() {
+        DataValue dv = new DataValue(Variant.ofDouble(0.0), StatusCode.BAD);
+        MeasurementSignal s = OpcUaSignalMapper.toMeasurement(binding("T1"), dv);
+        assertEquals(Quality.BAD, s.getQuality(), "BAD must propagate, never become GOOD");
+    }
+
+    @Test
+    void uncertainStatusYieldsUncertainQuality() {
+        DataValue dv = new DataValue(Variant.ofDouble(0.0), StatusCode.UNCERTAIN);
+        MeasurementSignal s = OpcUaSignalMapper.toMeasurement(binding("T1"), dv);
+        assertEquals(Quality.UNCERTAIN, s.getQuality());
+    }
+
+    @Test
+    void timestampFallsBackToServerThenLocal() {
+        long before = System.currentTimeMillis();
+        DataValue dvServer = new DataValue(
+                Variant.ofDouble(1.0),
+                StatusCode.GOOD,
+                null,
+                new DateTime(Instant.ofEpochMilli(1_700_000_000_000L)));
+        MeasurementSignal s1 = OpcUaSignalMapper.toMeasurement(binding("T"), dvServer);
+        assertEquals(1_700_000_000_000L, s1.getTimestamp());
+
+        DataValue dvNone = new DataValue(Variant.ofDouble(1.0), StatusCode.GOOD, null, null);
+        MeasurementSignal s2 = OpcUaSignalMapper.toMeasurement(binding("T"), dvNone);
+        assertTrue(s2.getTimestamp() >= before);
+    }
+
+    @Test
+    void alarmPriorityMapsByCode() {
+        assertEquals(AlarmPriority.JOURNAL, OpcUaSignalMapper.mapAlarmPriority(50));
+        assertEquals(AlarmPriority.LOW, OpcUaSignalMapper.mapAlarmPriority(150));
+        assertEquals(AlarmPriority.HIGH, OpcUaSignalMapper.mapAlarmPriority(500));
+        assertEquals(AlarmPriority.URGENT, OpcUaSignalMapper.mapAlarmPriority(900));
+    }
+
+    @Test
+    void alarmSignalCarriesConditionCode() {
+        DataValue dv = new DataValue(
+                Variant.ofInt32(800),
+                StatusCode.GOOD,
+                new DateTime(1L));
+        AlarmSignal s = OpcUaSignalMapper.toAlarm(binding("PLANT.ALARM"), dv);
+        assertEquals(AlarmPriority.URGENT, s.getPriority());
+        assertEquals("OPCUA-800", s.getConditionCode());
+    }
+
+    @Test
+    void coerceDoubleAcceptsBoolean() {
+        DataValue dv = new DataValue(Variant.ofBoolean(true), StatusCode.GOOD);
+        MeasurementSignal s = OpcUaSignalMapper.toMeasurement(binding("X"), dv);
+        assertEquals(1.0, s.getMeasurement(), 0.0);
+    }
+
+    @Test
+    void nullVariantBecomesNaN() {
+        DataValue dv = new DataValue(Variant.NULL_VALUE, StatusCode.GOOD);
+        MeasurementSignal s = OpcUaSignalMapper.toMeasurement(binding("X"), dv);
+        assertTrue(Double.isNaN(s.getMeasurement()));
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/output/opcua/FakeResult.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/output/opcua/FakeResult.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.output.opcua;
+
+import com.rakovpublic.jneuropallium.worker.net.layers.IResult;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+
+/** Test-only {@link IResult} wrapper around any {@link IResultSignal}. */
+final class FakeResult implements IResult<IResultSignal> {
+
+    private final IResultSignal signal;
+    private final Long neuronId;
+
+    FakeResult(IResultSignal signal) { this(signal, 1L); }
+
+    FakeResult(IResultSignal signal, Long neuronId) {
+        this.signal = signal;
+        this.neuronId = neuronId;
+    }
+
+    @Override public IResultSignal getResult() { return signal; }
+    @Override public Long getNeuronId() { return neuronId; }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/output/opcua/OpcUaCommandOutputAggregatorTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/output/opcua/OpcUaCommandOutputAggregatorTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.output.opcua;
+
+import com.rakovpublic.jneuropallium.worker.net.layers.IResult;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.OverrideKind;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.SafetyMode;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua.MiloOpcUaClientService;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua.OpcUaBridgeConfig;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.opcua.OpcUaNodeBinding;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.InterlockSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.OperatorOverrideSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Exercises the §0 ground rules in isolation: the OPC UA client is a
+ * fake that records writes; no embedded server is required.
+ *
+ * <p>Covers: S3 (SHADOW reject), S4 (AUTONOMOUS apply), S5 (rate limit),
+ * S6 (interlock priority), S7 (operator override), S9 (clamp),
+ * S10 (unknown tag).
+ */
+class OpcUaCommandOutputAggregatorTest {
+
+    private FakeMiloService svc;
+    private OpcUaTransparencyLogOutput audit;
+    private OpcUaCommandOutputAggregator agg;
+    private Path auditFile;
+
+    @BeforeEach
+    void setUp(@TempDir Path tmp) {
+        auditFile = tmp.resolve("audit.jsonl");
+        svc = new FakeMiloService();
+        OpcUaBridgeConfig cfg = baseConfig(auditFile);
+        audit = new OpcUaTransparencyLogOutput(cfg.audit(), null);
+        agg = new OpcUaCommandOutputAggregator(cfg, svc, audit);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (audit != null) audit.close();
+    }
+
+    private static OpcUaBridgeConfig baseConfig(Path auditFile) {
+        OpcUaBridgeConfig.NodeBindingConfig fic = new OpcUaBridgeConfig.NodeBindingConfig(
+                "FIC-101", "ns=2;s=Plant.TargetMotorSpeed", "PLANT.FIC101.SP",
+                OpcUaBridgeConfig.NodeBindingConfig.Direction.WRITE,
+                0.0, 5.0, 0.0, 100.0);
+        OpcUaBridgeConfig.NodeBindingConfig tic = new OpcUaBridgeConfig.NodeBindingConfig(
+                "TIC-101", "ns=2;s=Plant.TargetTemp", "PLANT.TIC101.SP",
+                OpcUaBridgeConfig.NodeBindingConfig.Direction.WRITE,
+                null, null, null, null);
+        return new OpcUaBridgeConfig(
+                new OpcUaBridgeConfig.ConnectionConfig("opc.tcp://x", null, null,
+                        Duration.ofSeconds(1), Duration.ofSeconds(60), 3),
+                new OpcUaBridgeConfig.SecurityConfig(
+                        OpcUaBridgeConfig.SecurityConfig.SecurityPolicy.NONE,
+                        OpcUaBridgeConfig.SecurityConfig.MessageSecurityMode.NONE,
+                        null, null, null,
+                        new OpcUaBridgeConfig.SecurityConfig.Anonymous()),
+                List.of(),
+                List.of(fic, tic),
+                List.of(),
+                new OpcUaBridgeConfig.AuditConfig(auditFile.toString(), null, true),
+                Map.of("FIC-101", SafetyMode.AUTONOMOUS, "TIC-101", SafetyMode.SHADOW),
+                Duration.ofMillis(250));
+    }
+
+    /* ---------- S3: SHADOW mode rejects ---------- */
+    @Test
+    void shadowModeRejectsSetpoint() {
+        SetpointSignal sp = new SetpointSignal("PLANT.TIC101.SP", 50.0, 0.0, "test");
+        agg.save(List.of(new FakeResult(sp)), 1_000L, 1, null);
+        audit.flush();
+        assertEquals(0, svc.writes.size(), "SHADOW must not produce a field write");
+        assertContains(auditFile(), "\"verdict\":\"REJECTED\"");
+        assertContains(auditFile(), "SHADOW_MODE");
+    }
+
+    /* ---------- S4: AUTONOMOUS applies ---------- */
+    @Test
+    void autonomousAppliesSetpointWithinBounds() {
+        SetpointSignal sp = new SetpointSignal("PLANT.FIC101.SP", 50.0, 0.0, "test");
+        agg.save(List.of(new FakeResult(sp)), 1_000L, 1, null);
+        audit.flush();
+        assertEquals(1, svc.writes.size());
+        assertEquals(50.0, svc.lastDouble(), 1e-9);
+        assertContains(auditFile(), "\"verdict\":\"APPLIED\"");
+    }
+
+    /* ---------- S5: rate limit ---------- */
+    @Test
+    void rateLimiterClampsBigStep() {
+        SetpointSignal first = new SetpointSignal("PLANT.FIC101.SP", 30.0, 0.0, "test");
+        agg.save(List.of(new FakeResult(first)), 1_000L, 1, null);
+        SetpointSignal second = new SetpointSignal("PLANT.FIC101.SP", 50.0, 0.0, "test");
+        agg.save(List.of(new FakeResult(second)), 1_500L, 2, null);
+        audit.flush();
+        assertEquals(2, svc.writes.size());
+        // dt=0.5s, ramp=5/s -> max step = 2.5; 30 -> 32.5
+        assertEquals(32.5, svc.lastDouble(), 1e-6);
+        assertContains(auditFile(), "RATE_LIMITED");
+    }
+
+    /* ---------- S6: interlock priority ---------- */
+    @Test
+    void interlockTripWritesFailSafeAndDropsConcurrentSetpoint() {
+        SetpointSignal sp = new SetpointSignal("PLANT.FIC101.SP", 80.0, 0.0, "test");
+        InterlockSignal il = new InterlockSignal("FIC-101", true, List.of("HIGH_PRESSURE"));
+        agg.save(List.of(new FakeResult(il), new FakeResult(sp)), 1_000L, 1, null);
+        audit.flush();
+        assertEquals(1, svc.writes.size(), "Only the fail-safe write should reach the field");
+        assertEquals(0.0, svc.lastDouble(), 1e-9);
+        assertContains(auditFile(), "\"verdict\":\"INTERLOCK_TRIP\"");
+        assertContains(auditFile(), "INTERLOCK_HOLD");
+        // After the trip the loop is held. The concurrent setpoint must not write.
+    }
+
+    /* ---------- S7: operator override holds ---------- */
+    @Test
+    void operatorOverrideSuppressesSetpoint() {
+        OperatorOverrideSignal ov = new OperatorOverrideSignal(
+                "PLANT.FIC101.SP", OverrideKind.MANUAL, "op1", "manual", 47.0);
+        SetpointSignal sp = new SetpointSignal("PLANT.FIC101.SP", 80.0, 0.0, "test");
+        agg.save(List.of(new FakeResult(ov), new FakeResult(sp)), 1_000L, 1, null);
+        audit.flush();
+        assertEquals(0, svc.writes.size(), "Override holds — no field write");
+        assertContains(auditFile(), "\"verdict\":\"OVERRIDE_HOLD\"");
+    }
+
+    /* ---------- S9: clamp ---------- */
+    @Test
+    void clampCapsAtMax() {
+        SetpointSignal sp = new SetpointSignal("PLANT.FIC101.SP", 150.0, 0.0, "test");
+        agg.save(List.of(new FakeResult(sp)), 1_000L, 1, null);
+        audit.flush();
+        assertEquals(100.0, svc.lastDouble(), 1e-9);
+        assertContains(auditFile(), "CLAMPED_HIGH");
+    }
+
+    @Test
+    void clampCapsAtMin() {
+        SetpointSignal sp = new SetpointSignal("PLANT.FIC101.SP", -5.0, 0.0, "test");
+        agg.save(List.of(new FakeResult(sp)), 1_000L, 1, null);
+        audit.flush();
+        assertEquals(0.0, svc.lastDouble(), 1e-9);
+        assertContains(auditFile(), "CLAMPED_LOW");
+    }
+
+    /* ---------- S10: unknown tag ---------- */
+    @Test
+    void unknownTagIsRejected() {
+        SetpointSignal sp = new SetpointSignal("NOT_CONFIGURED", 5.0, 0.0, "test");
+        agg.save(List.of(new FakeResult(sp)), 1_000L, 1, null);
+        audit.flush();
+        assertEquals(0, svc.writes.size());
+        assertContains(auditFile(), "UNKNOWN_TAG");
+    }
+
+    @Test
+    void shadowOnlyActuatorCommandIsRejected() {
+        ActuatorCommandSignal a = new ActuatorCommandSignal("PLANT.TIC101.SP", 10.0, 0.0, true);
+        agg.save(List.of(new FakeResult(a)), 1_000L, 1, null);
+        audit.flush();
+        assertEquals(0, svc.writes.size());
+        assertContains(auditFile(), "SHADOW_MODE");
+    }
+
+    @Test
+    void diffSuppressionSkipsSecondWriteWithinWindow() {
+        SetpointSignal sp = new SetpointSignal("PLANT.FIC101.SP", 50.0, 0.0, "test");
+        agg.save(List.of(new FakeResult(sp)), 1_000L, 1, null);
+        agg.save(List.of(new FakeResult(sp)), 1_500L, 2, null);
+        audit.flush();
+        assertEquals(1, svc.writes.size(), "Repeat write within 5s window must be diff-suppressed");
+        assertContains(auditFile(), "DIFF_SUPPRESSED");
+    }
+
+    /* ============== helpers ============== */
+
+    private String auditFile() {
+        try { return java.nio.file.Files.readString(auditFile); }
+        catch (java.io.IOException e) { return ""; }
+    }
+
+    private static void assertContains(String haystack, String needle) {
+        assertTrue(haystack.contains(needle),
+                "expected audit log to contain `" + needle + "`, got:\n" + haystack);
+    }
+
+    /* In-memory MiloOpcUaClientService stand-in. */
+    static final class FakeMiloService extends MiloOpcUaClientService {
+        final java.util.List<Map.Entry<NodeId, DataValue>> writes = new java.util.ArrayList<>();
+        final ConcurrentHashMap<String, OpcUaNodeBinding> bindings = new ConcurrentHashMap<>();
+
+        FakeMiloService() { super(null, null, null); }
+
+        @Override
+        public StatusCode writeValue(NodeId nodeId, DataValue value) {
+            writes.add(Map.entry(nodeId, value));
+            return StatusCode.GOOD;
+        }
+
+        @Override
+        public OpcUaNodeBinding bindingBySignalTag(String tag) {
+            return bindings.get(tag);
+        }
+
+        double lastDouble() {
+            DataValue dv = writes.get(writes.size() - 1).getValue();
+            Object v = dv.getValue().getValue();
+            return ((Number) v).doubleValue();
+        }
+    }
+}

--- a/worker/src/test/resources/opcua/example-bridge.yaml
+++ b/worker/src/test/resources/opcua/example-bridge.yaml
@@ -1,0 +1,51 @@
+connection:
+  endpointUrl: "opc.tcp://milo.digitalpetri.com:62541/milo"
+  applicationName: "Jneopallium-OPCUA-Bridge"
+  applicationUri: "urn:rakovpublic:jneopallium:bridge:dev01"
+  requestTimeout: "PT5S"
+  sessionTimeout: "PT2M"
+  keepAliveFailuresAllowed: 3
+
+security:
+  policy: BASIC256SHA256
+  mode: SIGN_AND_ENCRYPT
+  pkiDir: "/var/lib/jneopallium/opcua-pki"
+  certAlias: "bridge-cert"
+  certPassword: "${OPCUA_CERT_PASSWORD}"
+  auth:
+    type: "UsernamePassword"
+    username: "User"
+    passwordEnv: "OPCUA_USER_PASSWORD"
+
+reads:
+  - loopId: "TIC-101"
+    nodeId: "ns=2;s=Plant.Temperature"
+    signalTag: "PLANT.TIC101.PV"
+    direction: READ
+
+writes:
+  - loopId: "FIC-101"
+    nodeId: "ns=2;s=Plant.TargetMotorSpeed"
+    signalTag: "PLANT.FIC101.SP"
+    direction: WRITE
+    failSafeValue: 0.0
+    rampRateMaxPerSec: 5.0
+    minClampValue: 0.0
+    maxClampValue: 100.0
+
+alarms:
+  - loopId: "PLANT-ALARMS"
+    nodeId: "ns=2;s=Plant.Alarm"
+    signalTag: "PLANT.ALARM"
+    direction: READ
+
+audit:
+  localAuditFile: "/var/log/jneopallium/opcua-audit.jsonl"
+  opcUaAuditNodeId: "ns=2;s=Plant.JneopalliumAuditLog"
+  writeRejectedToAudit: true
+
+perLoopSafetyMode:
+  TIC-101: SHADOW
+  FIC-101: ADVISORY
+
+tickInterval: "PT0.25S"


### PR DESCRIPTION
Phase 1 — Java 17 / Spring Boot 3 migration:
* Promote parent pom into a real reactor with milo-bom, spring-boot 3.3.5 BOM, junit-bom and explicit log4j 2.25.4 pins (the spring-boot BOM otherwise downgrades log4j-api to 2.23.1, which crashes log4j-core 2.25.4's LoggerContext static initializer).
* worker/pom.xml: drop the duplicate protobuf-java 4.34.0 dependency, remove the hardcoded Windows protocExecutable path, replace javax.annotation-api with jakarta.annotation-api, add Milo SDK client (compile) and server (test) and Jackson YAML/jsr310 modules.
* master/pom.xml: migrate Spring Boot 2.5.12/2.7.18 (mixed, EOL) to Spring Boot 3.3.5; add provided-scope spring-boot-starter-tomcat for war packaging.

Phase 2 — bridge implementation:
* OpcUaBridgeConfig (Java record) + Jackson-YAML loader with FAIL_ON_UNKNOWN_PROPERTIES=true.
* OpcUaNodeBinding holds parsed NodeId + last-written history for rate-limit / diff-suppression.
* OpcUaSignalMapper translates DataValue ↔ MeasurementSignal / AlarmSignal / SetpointSignal / ActuatorCommandSignal. Quality propagates per spec §0.5 (BAD/UNCERTAIN never become GOOD); the timestamp falls back sourceTime → serverTime → local clock per §0.6.
* MiloOpcUaClientService owns the OpcUaClient, the single OpcUaSubscription, the latest-value cache and the alarm queue.
* OpcUaMeasurementInput / OpcUaAlarmInput implement IInitInput.
* OpcUaCommandOutputAggregator enforces all §0 ground rules: interlocks first (writes fail-safe + holds the loop for the rest of the tick), operator override holds, per-loop SafetyMode gate (SHADOW=audit only, ADVISORY=requires execute, AUTONOMOUS=apply), clamp to [min,max], rate-limit by rampRateMaxPerSec, diff-suppress within 5 s.
* OpcUaTransparencyLogOutput writes one JSONL line per accepted, suppressed, clamped, rate-limited or rejected write. Local file write is synchronous (audit ordering must match call order); the optional OPC UA mirror runs on a single writer thread, best-effort.
* Add IInputSignal marker to MeasurementSignal/AlarmSignal and IResultSignal marker to SetpointSignal/ActuatorCommandSignal/ InterlockSignal/OperatorOverrideSignal — required so they can flow through the existing IInitInput / IOutputAggregator contracts. No method changes; no behavioural changes.

Phase 3 — tests, CI, docs:
* Unit tests for the loader (round-trip, unknown-property rejection, username/password auth), the mapper (quality + timestamp + alarm priority), and the aggregator scenarios S3, S4, S5, S6, S7, S9, S10 plus the SHADOW-actuator and diff-suppress paths. 21 new tests, all green.
* docs/opcua-bridge-architecture.md with §0 ground rules verbatim and the data-flow diagram; docs/opcua-bridge-demo.md with the manual S12 procedure against the public Milo demo server.
* GitHub Actions workflow .github/workflows/maven-verify.yml runs `mvn -B -U clean verify` on JDK 17 Temurin.
* README gets the operator-facing OPC UA bridge summary.

`mvn -B -U clean verify` is green from a clean checkout on JDK 17.

https://claude.ai/code/session_01GSxDw5eRubLW9DkDWTkpf7