### PR TITLE
Implement OpenTelemetry bridge (09-OPENTELEMETRY.md)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,8 @@
         <mockito.version>5.11.0</mockito.version>
         <slf4j.version>2.0.16</slf4j.version>
         <jakarta-annotation.version>2.1.1</jakarta-annotation.version>
+        <opentelemetry.version>1.43.0</opentelemetry.version>
+        <opentelemetry-instrumentation.version>2.9.0</opentelemetry-instrumentation.version>
 
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
@@ -69,6 +71,18 @@
                 <groupId>org.eclipse.milo</groupId>
                 <artifactId>milo-bom</artifactId>
                 <version>${milo.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- OpenTelemetry BOM (09-OPENTELEMETRY.md §10 R3 — pin all
+                 -api/-sdk/-exporter artifacts to one consistent version to
+                 avoid shading conflicts). Imported BEFORE spring-boot so the
+                 first-wins resolution keeps OTel at ${opentelemetry.version}
+                 instead of the older version pinned by Spring Boot. -->
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>${opentelemetry.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -95,6 +95,32 @@
             <version>${grpc.version}</version>
         </dependency>
 
+        <!-- ============== OpenTelemetry (Bridge 09) ==============
+             Versions are pulled from the opentelemetry-bom imported in the
+             parent. Export-only — no input/aggregator surface. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+        </dependency>
+        <!-- In-memory exporters used by the unit tests for traces/metrics/logs. -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- ============== OPC UA (Phase 2) ============== -->
         <!-- Versions come from the milo-bom imported in the parent. -->
         <dependency>

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/NoopOtelInstrumentation.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/NoopOtelInstrumentation.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.otel;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Zero-cost {@link OtelInstrumentation} (09-OPENTELEMETRY.md §5). This is the
+ * default implementation when the bridge is not enabled, ensuring deployments
+ * that don't want OTel pay no observability cost.
+ *
+ * <p>Every method is a static-noop — JIT can inline-elide entirely. The
+ * bridge's §10 R1 budget (&lt; 5 % overhead vs noop) is measured against this
+ * baseline.
+ */
+public final class NoopOtelInstrumentation implements OtelInstrumentation {
+
+    public static final NoopOtelInstrumentation INSTANCE = new NoopOtelInstrumentation();
+
+    private NoopOtelInstrumentation() {}
+
+    @Override public Scope tickSpan(long run)            { return Scope.NOOP; }
+    @Override public Scope layerSpan(String layerName)   { return Scope.NOOP; }
+    @Override public void observe(ISignal<?> signal, String layerName) {}
+    @Override public void harmVeto(String reason, String evidenceNeurons) {}
+    @Override public void loopIntervention(String loopId, String reason) {}
+    @Override public void aggregatorVerdict(String bridge, String tag, String verdict,
+                                            String reason, Double proposed, Double effective) {}
+    @Override public void audit(BridgeAuditRecord record) {}
+    @Override public void recordEnergy(double value)     {}
+    @Override public void recordLoopAmplitude(String loopId, double amplitude) {}
+    @Override public void forceSample(String cause)      {}
+    @Override public void close()                        {}
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/OtelBridgeConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/OtelBridgeConfig.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.otel;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Top-level configuration for the OpenTelemetry bridge (09-OPENTELEMETRY.md §6).
+ *
+ * <p>Loaded from YAML at startup via {@link OtelBridgeConfigLoader}. Immutable.
+ *
+ * <p>The OTel bridge is <strong>export-only</strong> (§3) — there is no input
+ * surface, no aggregator, no read API. This config therefore only describes
+ * how observability data leaves the worker.
+ */
+public record OtelBridgeConfig(
+        String serviceName,
+        String serviceVersion,
+        String serviceInstanceId,
+        ExporterConfig exporter,
+        Map<String, String> resourceAttributes,
+        MetricsConfig metrics,
+        TracesConfig traces,
+        LogsConfig logs,
+        RedactionConfig redaction
+) {
+    public OtelBridgeConfig {
+        Objects.requireNonNull(serviceName, "serviceName");
+        Objects.requireNonNull(exporter, "exporter");
+        serviceVersion = serviceVersion == null ? "unknown" : serviceVersion;
+        serviceInstanceId = serviceInstanceId == null ? "unknown" : serviceInstanceId;
+        resourceAttributes = resourceAttributes == null ? Map.of() : Map.copyOf(resourceAttributes);
+        metrics = metrics == null ? MetricsConfig.defaults() : metrics;
+        traces = traces == null ? TracesConfig.defaults() : traces;
+        logs = logs == null ? LogsConfig.defaults() : logs;
+        redaction = redaction == null ? RedactionConfig.defaults() : redaction;
+    }
+
+    /** §6 — exporter wiring. */
+    public record ExporterConfig(
+            ExporterType type,
+            String endpoint,
+            long timeoutMs,
+            Map<String, String> headers
+    ) {
+        public ExporterConfig {
+            Objects.requireNonNull(type, "type");
+            if (timeoutMs <= 0) timeoutMs = 10_000L;
+            headers = headers == null ? Map.of() : Map.copyOf(headers);
+        }
+
+        /**
+         * Exporter transport (§6). {@code NONE} disables export entirely
+         * (the SDK is still wired so {@link OtelInstrumentation} is active,
+         * but spans/metrics/logs are dropped before leaving the process —
+         * useful for benchmarks and tests).
+         */
+        public enum ExporterType {
+            OTLP_GRPC,
+            OTLP_HTTP,
+            PROMETHEUS_PUSH,
+            NONE
+        }
+    }
+
+    /** §6 — metrics knobs. */
+    public record MetricsConfig(
+            boolean enabled,
+            long intervalMs
+    ) {
+        public MetricsConfig {
+            if (intervalMs <= 0) intervalMs = 10_000L;
+        }
+        public static MetricsConfig defaults() { return new MetricsConfig(true, 10_000L); }
+    }
+
+    /** §6 — tracing knobs. */
+    public record TracesConfig(
+            boolean enabled,
+            double samplerRatio
+    ) {
+        public TracesConfig {
+            if (samplerRatio < 0.0 || samplerRatio > 1.0) {
+                throw new IllegalArgumentException("samplerRatio must be in [0,1]: " + samplerRatio);
+            }
+        }
+        public static TracesConfig defaults() { return new TracesConfig(true, 0.1); }
+    }
+
+    /** §6 — log export knobs. */
+    public record LogsConfig(
+            boolean enabled
+    ) {
+        public static LogsConfig defaults() { return new LogsConfig(true); }
+    }
+
+    /**
+     * §6 / §10 R2 — sensitive-data scrubbing. Applied to attribute values and
+     * log bodies before they leave the SDK.
+     */
+    public record RedactionConfig(
+            @JsonProperty("redactSignalTags") boolean redactSignalTags,
+            @JsonProperty("redactPatterns") List<String> redactPatterns
+    ) {
+        public RedactionConfig {
+            redactPatterns = redactPatterns == null ? List.of() : List.copyOf(redactPatterns);
+        }
+        public static RedactionConfig defaults() { return new RedactionConfig(false, List.of()); }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/OtelBridgeConfigLoader.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/OtelBridgeConfigLoader.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.otel;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+/**
+ * Loads {@link OtelBridgeConfig} from YAML (09-OPENTELEMETRY.md §6).
+ *
+ * <p>{@code FAIL_ON_UNKNOWN_PROPERTIES = true} per 00-FRAMEWORK §3 — a
+ * typo'd field on a safety-critical bridge must be caught at load, not
+ * silently ignored. The OTel bridge is export-only but its redaction
+ * config is itself security-relevant, so the same strict load contract
+ * applies.
+ */
+public final class OtelBridgeConfigLoader {
+
+    private OtelBridgeConfigLoader() {}
+
+    public static OtelBridgeConfig load(Path yaml) throws IOException {
+        return mapper().readValue(yaml.toFile(), OtelBridgeConfig.class);
+    }
+
+    public static OtelBridgeConfig load(InputStream in) throws IOException {
+        return mapper().readValue(in, OtelBridgeConfig.class);
+    }
+
+    public static OtelBridgeConfig load(String yamlContent) throws IOException {
+        return mapper().readValue(yamlContent, OtelBridgeConfig.class);
+    }
+
+    private static ObjectMapper mapper() {
+        return new ObjectMapper(new YAMLFactory())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/OtelBridgeFactory.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/OtelBridgeFactory.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.otel;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
+import io.opentelemetry.exporter.otlp.logs.OtlpGrpcLogRecordExporter;
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+import io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * Wires the OpenTelemetry SDK from an {@link OtelBridgeConfig}
+ * (09-OPENTELEMETRY.md §6).
+ *
+ * <p>Behaviour:
+ * <ul>
+ *   <li>{@link OtelBridgeConfig.ExporterConfig.ExporterType#NONE} returns the
+ *       {@link NoopOtelInstrumentation}, so callers can use the same
+ *       {@link OtelInstrumentation} reference unconditionally.</li>
+ *   <li>Otherwise the SDK is built with a {@link Sampler#parentBasedTraceIdRatio
+ *       parent-based ratio sampler} per §6 {@code samplerRatio}, and OTLP
+ *       gRPC/HTTP exporters per §6 {@code exporter.type}.</li>
+ *   <li>Resource attributes pull in {@code serviceName}, {@code serviceVersion},
+ *       {@code serviceInstanceId} plus everything under
+ *       {@code resourceAttributes:}.</li>
+ * </ul>
+ */
+public final class OtelBridgeFactory {
+
+    private OtelBridgeFactory() {}
+
+    public static OtelInstrumentation create(OtelBridgeConfig config) {
+        if (config == null
+                || config.exporter().type() == OtelBridgeConfig.ExporterConfig.ExporterType.NONE
+                || (!config.traces().enabled()
+                    && !config.metrics().enabled()
+                    && !config.logs().enabled())) {
+            return NoopOtelInstrumentation.INSTANCE;
+        }
+        OpenTelemetrySdk sdk = buildSdk(config);
+        return new SdkOtelInstrumentation(sdk, sdk, config);
+    }
+
+    /**
+     * Build an OTel SDK from the bridge config. Visible for testing so unit
+     * tests can plug in {@code InMemorySpanExporter} via
+     * {@link #buildSdk(OtelBridgeConfig, SpanExporter, MetricExporter, LogRecordExporter)}.
+     */
+    public static OpenTelemetrySdk buildSdk(OtelBridgeConfig config) {
+        return buildSdk(config,
+                spanExporter(config),
+                metricExporter(config),
+                logExporter(config));
+    }
+
+    public static OpenTelemetrySdk buildSdk(OtelBridgeConfig config,
+                                            SpanExporter spanExporter,
+                                            MetricExporter metricExporter,
+                                            LogRecordExporter logExporter) {
+        Resource resource = buildResource(config);
+
+        SdkTracerProvider tracerProvider = null;
+        if (config.traces().enabled() && spanExporter != null) {
+            tracerProvider = SdkTracerProvider.builder()
+                    .setResource(resource)
+                    .setSampler(Sampler.parentBased(
+                            Sampler.traceIdRatioBased(config.traces().samplerRatio())))
+                    .addSpanProcessor(BatchSpanProcessor.builder(spanExporter).build())
+                    .build();
+        }
+
+        SdkMeterProvider meterProvider = null;
+        if (config.metrics().enabled() && metricExporter != null) {
+            meterProvider = SdkMeterProvider.builder()
+                    .setResource(resource)
+                    .registerMetricReader(PeriodicMetricReader.builder(metricExporter)
+                            .setInterval(Duration.ofMillis(config.metrics().intervalMs()))
+                            .build())
+                    .build();
+        }
+
+        SdkLoggerProvider loggerProvider = null;
+        if (config.logs().enabled() && logExporter != null) {
+            loggerProvider = SdkLoggerProvider.builder()
+                    .setResource(resource)
+                    .addLogRecordProcessor(BatchLogRecordProcessor.builder(logExporter).build())
+                    .build();
+        }
+
+        var b = OpenTelemetrySdk.builder();
+        if (tracerProvider != null) b.setTracerProvider(tracerProvider);
+        if (meterProvider != null)  b.setMeterProvider(meterProvider);
+        if (loggerProvider != null) b.setLoggerProvider(loggerProvider);
+        return b.build();
+    }
+
+    /**
+     * Convenience for tests that want to drive a {@link SdkOtelInstrumentation}
+     * directly (no exporters needed). Falls through to the same builder above.
+     */
+    public static OtelInstrumentation forTesting(OtelBridgeConfig config,
+                                                 OpenTelemetrySdk sdk) {
+        return new SdkOtelInstrumentation(sdk, sdk, config);
+    }
+
+    private static Resource buildResource(OtelBridgeConfig config) {
+        AttributesBuilder b = Attributes.builder()
+                .put(AttributeKey.stringKey("service.name"), config.serviceName())
+                .put(AttributeKey.stringKey("service.version"), config.serviceVersion())
+                .put(AttributeKey.stringKey("service.instance.id"), config.serviceInstanceId());
+        for (Map.Entry<String, String> e : config.resourceAttributes().entrySet()) {
+            b.put(AttributeKey.stringKey(e.getKey()), e.getValue());
+        }
+        return Resource.getDefault().merge(Resource.create(b.build()));
+    }
+
+    private static SpanExporter spanExporter(OtelBridgeConfig config) {
+        if (!config.traces().enabled()) return null;
+        return switch (config.exporter().type()) {
+            case OTLP_GRPC -> {
+                var b = OtlpGrpcSpanExporter.builder()
+                        .setTimeout(Duration.ofMillis(config.exporter().timeoutMs()));
+                if (config.exporter().endpoint() != null) b.setEndpoint(config.exporter().endpoint());
+                config.exporter().headers().forEach(b::addHeader);
+                yield b.build();
+            }
+            case OTLP_HTTP -> {
+                var b = OtlpHttpSpanExporter.builder()
+                        .setTimeout(Duration.ofMillis(config.exporter().timeoutMs()));
+                if (config.exporter().endpoint() != null) b.setEndpoint(config.exporter().endpoint());
+                config.exporter().headers().forEach(b::addHeader);
+                yield b.build();
+            }
+            // Prometheus push isn't a span exporter; spans go nowhere in this
+            // mode. Returning null disables the tracer provider entirely.
+            case PROMETHEUS_PUSH, NONE -> null;
+        };
+    }
+
+    private static MetricExporter metricExporter(OtelBridgeConfig config) {
+        if (!config.metrics().enabled()) return null;
+        return switch (config.exporter().type()) {
+            case OTLP_GRPC -> {
+                var b = OtlpGrpcMetricExporter.builder()
+                        .setTimeout(Duration.ofMillis(config.exporter().timeoutMs()));
+                if (config.exporter().endpoint() != null) b.setEndpoint(config.exporter().endpoint());
+                config.exporter().headers().forEach(b::addHeader);
+                yield b.build();
+            }
+            case OTLP_HTTP, PROMETHEUS_PUSH -> {
+                var b = OtlpHttpMetricExporter.builder()
+                        .setTimeout(Duration.ofMillis(config.exporter().timeoutMs()));
+                if (config.exporter().endpoint() != null) b.setEndpoint(config.exporter().endpoint());
+                config.exporter().headers().forEach(b::addHeader);
+                yield b.build();
+            }
+            case NONE -> null;
+        };
+    }
+
+    private static LogRecordExporter logExporter(OtelBridgeConfig config) {
+        if (!config.logs().enabled()) return null;
+        return switch (config.exporter().type()) {
+            case OTLP_GRPC -> {
+                var b = OtlpGrpcLogRecordExporter.builder()
+                        .setTimeout(Duration.ofMillis(config.exporter().timeoutMs()));
+                if (config.exporter().endpoint() != null) b.setEndpoint(config.exporter().endpoint());
+                config.exporter().headers().forEach(b::addHeader);
+                yield b.build();
+            }
+            case OTLP_HTTP -> {
+                var b = OtlpHttpLogRecordExporter.builder()
+                        .setTimeout(Duration.ofMillis(config.exporter().timeoutMs()));
+                if (config.exporter().endpoint() != null) b.setEndpoint(config.exporter().endpoint());
+                config.exporter().headers().forEach(b::addHeader);
+                yield b.build();
+            }
+            case PROMETHEUS_PUSH, NONE -> null;
+        };
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/OtelInstrumentation.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/OtelInstrumentation.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.otel;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+/**
+ * Instrumentation surface (09-OPENTELEMETRY.md §5) — the only entry-point the
+ * rest of the worker calls into the OTel bridge.
+ *
+ * <p><strong>Export-only.</strong> No method on this interface accepts data
+ * <em>back</em> from OTel into Jneopallium signals (§3). Audit-trail integrity
+ * depends on this being asymmetric.
+ *
+ * <p>Two implementations exist:
+ * <ul>
+ *   <li>{@link NoopOtelInstrumentation} — default; zero observability cost,
+ *       used in deployments that don't enable OTel.</li>
+ *   <li>{@link SdkOtelInstrumentation} — backed by the OpenTelemetry Java SDK;
+ *       wired only when the bridge is enabled.</li>
+ * </ul>
+ *
+ * <p>All methods are thread-safe and non-blocking on the critical path. They
+ * MUST NOT throw — exporter failures are absorbed inside the implementation.
+ */
+public interface OtelInstrumentation {
+
+    /**
+     * Wrap one tick. The returned {@link Scope} closes the underlying span
+     * (and detaches it from the current context) when {@code close()} is
+     * invoked, so callers should use try-with-resources:
+     * <pre>{@code
+     * try (OtelInstrumentation.Scope ignored = otel.tickSpan(runId)) {
+     *     // execute the tick
+     * }
+     * }</pre>
+     *
+     * @param run monotonic run / tick identifier (becomes a span attribute)
+     */
+    Scope tickSpan(long run);
+
+    /**
+     * Wrap one layer's processing as a child span of the current tick span.
+     * Returns a no-op scope if no tick span is active on the current thread.
+     */
+    Scope layerSpan(String layerName);
+
+    /**
+     * Record one signal observation under the current scope (§5). The
+     * implementation may add it as an event/attribute on the active span and
+     * increment a per-class counter.
+     */
+    void observe(ISignal<?> signal, String layerName);
+
+    /**
+     * Record one harm veto (§5, §9 S8). Increments the
+     * {@code jneo.harm_veto.count} counter and forces the current tick span
+     * to be sampled (§9 S9 — always-sample-on-veto).
+     */
+    void harmVeto(String reason, String evidenceNeurons);
+
+    /**
+     * Record one loop intervention (§8 phase 2). Increments
+     * {@code jneo.loop_intervention.count}.
+     */
+    void loopIntervention(String loopId, String reason);
+
+    /**
+     * Record an aggregator verdict (§5). The verdict is added as attributes on
+     * the active span and the bridge counter
+     * {@code jneo.aggregator.verdict.count} is incremented with
+     * {@code bridge=…, verdict=…} attributes.
+     */
+    void aggregatorVerdict(String bridge,
+                           String tag,
+                           String verdict,
+                           String reason,
+                           Double proposed,
+                           Double effective);
+
+    /**
+     * Record one {@link BridgeAuditRecord} as a structured log record (§5,
+     * §8 phase 1) and tick the {@code jneo.audit.applied.count} (or
+     * {@code .rejected.count}) counter.
+     */
+    void audit(BridgeAuditRecord record);
+
+    /**
+     * Record an energy gauge observation (§1 mapping table —
+     * {@code EnergySignal} → gauge metric). Implementations route this to the
+     * {@code jneo.energy} async gauge.
+     */
+    void recordEnergy(double value);
+
+    /**
+     * Record a loop amplitude gauge observation (§1 mapping —
+     * {@code LoopAlertSignal} → gauge). Routed to {@code jneo.loop.amplitude}.
+     */
+    void recordLoopAmplitude(String loopId, double amplitude);
+
+    /**
+     * Force the active tick span to be sampled regardless of the configured
+     * sampler ratio (§8 phase 3 — always-sample-on-incident hook). Safe to
+     * call when no tick span is active (becomes a no-op).
+     */
+    void forceSample(String cause);
+
+    /**
+     * Release any underlying SDK resources. After {@code close()}, all
+     * methods become no-ops. Idempotent.
+     */
+    void close();
+
+    /**
+     * AutoCloseable scope returned by {@link #tickSpan(long)} and
+     * {@link #layerSpan(String)}. Closing detaches the span and ends it.
+     */
+    interface Scope extends AutoCloseable {
+        @Override void close();
+
+        /** No-op scope, exported so callers can be branch-free. */
+        Scope NOOP = () -> {};
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/OtelLayerTracer.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/OtelLayerTracer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.otel;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+
+/**
+ * Per-layer span helper (09-OPENTELEMETRY.md §5, §7).
+ *
+ * <p>The {@code jneo.tick} parent span is started by
+ * {@link SdkOtelInstrumentation#tickSpan(long)}; this helper starts and
+ * activates the child {@code jneo.layer.<name>} span underneath it.
+ */
+final class OtelLayerTracer {
+
+    private final Tracer tracer;
+
+    OtelLayerTracer(Tracer tracer) {
+        this.tracer = tracer;
+    }
+
+    /**
+     * Start a child layer span. If no parent is active on the current thread,
+     * the span is still created (root) — the caller decides whether that is
+     * meaningful by checking the active context first.
+     */
+    SpanScope start(String layerName) {
+        Span span = tracer.spanBuilder("jneo.layer." + layerName)
+                .setAttribute(OtelMeterRegistry.LAYER, layerName)
+                .startSpan();
+        var ctx = Context.current().with(span);
+        var scope = ctx.makeCurrent();
+        return new SpanScope(span, scope);
+    }
+
+    /**
+     * Pair of (span, context-scope). Closing detaches the context first,
+     * then ends the span — the same order
+     * {@link io.opentelemetry.api.trace.Span#end()} requires when used with
+     * try-with-resources.
+     */
+    static final class SpanScope implements AutoCloseable {
+        final Span span;
+        private final io.opentelemetry.context.Scope scope;
+        private boolean closed;
+
+        SpanScope(Span span, io.opentelemetry.context.Scope scope) {
+            this.span = span;
+            this.scope = scope;
+        }
+
+        @Override
+        public void close() {
+            if (closed) return;
+            closed = true;
+            try { scope.close(); } finally { span.end(); }
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/OtelMeterRegistry.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/OtelMeterRegistry.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.otel;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.ObservableDoubleGauge;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.DoubleAdder;
+
+/**
+ * Named counters / gauges / histograms for the OTel bridge
+ * (09-OPENTELEMETRY.md §7, §8 phase 2).
+ *
+ * <p>All instruments are created lazily and cached so the hot path is
+ * lock-free (§10 R1).
+ */
+final class OtelMeterRegistry implements AutoCloseable {
+
+    static final AttributeKey<String> BRIDGE      = AttributeKey.stringKey("jneo.bridge");
+    static final AttributeKey<String> VERDICT     = AttributeKey.stringKey("jneo.verdict");
+    static final AttributeKey<String> REASON      = AttributeKey.stringKey("jneo.reason");
+    static final AttributeKey<String> TAG         = AttributeKey.stringKey("jneo.tag");
+    static final AttributeKey<String> LOOP_ID     = AttributeKey.stringKey("jneo.loop_id");
+    static final AttributeKey<String> SIGNAL_TYPE = AttributeKey.stringKey("jneo.signal_type");
+    static final AttributeKey<String> LAYER       = AttributeKey.stringKey("jneo.layer");
+
+    private final Meter meter;
+
+    final LongCounter harmVetoCount;
+    final LongCounter loopInterventionCount;
+    final LongCounter auditAppliedCount;
+    final LongCounter auditRejectedCount;
+    final LongCounter auditFailedCount;
+    final LongCounter aggregatorVerdictCount;
+    final LongCounter signalObservedCount;
+    final DoubleHistogram setpointDelta;
+
+    /** Latest energy observation, exposed via an async gauge. */
+    private final DoubleAdder lastEnergy = new DoubleAdder();
+    /** Latest loop-amplitude per loopId, exposed via an async multi-key gauge. */
+    private final ConcurrentMap<String, Double> loopAmplitudes = new ConcurrentHashMap<>();
+
+    private final ObservableDoubleGauge energyGauge;
+    private final ObservableDoubleGauge loopAmplitudeGauge;
+
+    OtelMeterRegistry(Meter meter) {
+        this.meter = meter;
+
+        this.harmVetoCount = meter.counterBuilder("jneo.harm_veto.count")
+                .setDescription("Count of HarmVetoSignal events emitted by the worker")
+                .setUnit("1")
+                .build();
+
+        this.loopInterventionCount = meter.counterBuilder("jneo.loop_intervention.count")
+                .setDescription("Count of LoopInterventionSignal events emitted")
+                .setUnit("1")
+                .build();
+
+        this.auditAppliedCount = meter.counterBuilder("jneo.audit.applied.count")
+                .setDescription("Count of bridge audit records with verdict=APPLIED")
+                .setUnit("1")
+                .build();
+
+        this.auditRejectedCount = meter.counterBuilder("jneo.audit.rejected.count")
+                .setDescription("Count of bridge audit records with verdict=REJECTED")
+                .setUnit("1")
+                .build();
+
+        this.auditFailedCount = meter.counterBuilder("jneo.audit.failed.count")
+                .setDescription("Count of bridge audit records with verdict=FAILED, INTERLOCK_TRIP or OVERRIDE_HOLD")
+                .setUnit("1")
+                .build();
+
+        this.aggregatorVerdictCount = meter.counterBuilder("jneo.aggregator.verdict.count")
+                .setDescription("Bridge aggregator verdicts, attributed by bridge + verdict")
+                .setUnit("1")
+                .build();
+
+        this.signalObservedCount = meter.counterBuilder("jneo.signal.observed.count")
+                .setDescription("Signal observations recorded by the OTel instrumentation, by signal type")
+                .setUnit("1")
+                .build();
+
+        this.setpointDelta = meter.histogramBuilder("jneo.aggregator.setpoint.delta")
+                .setDescription("Difference between proposed and effective setpoint per aggregator write")
+                .setUnit("1")
+                .build();
+
+        this.energyGauge = meter.gaugeBuilder("jneo.energy")
+                .setDescription("Current EnergySignal value")
+                .setUnit("1")
+                .buildWithCallback(measurement -> measurement.record(lastEnergy.sum()));
+
+        this.loopAmplitudeGauge = meter.gaugeBuilder("jneo.loop.amplitude")
+                .setDescription("Current LoopAlertSignal amplitude, per loopId")
+                .setUnit("1")
+                .buildWithCallback(measurement -> {
+                    for (var e : loopAmplitudes.entrySet()) {
+                        measurement.record(e.getValue(), Attributes.of(LOOP_ID, e.getKey()));
+                    }
+                });
+    }
+
+    void setEnergy(double value) {
+        lastEnergy.reset();
+        lastEnergy.add(value);
+    }
+
+    void setLoopAmplitude(String loopId, double amplitude) {
+        if (loopId == null) loopId = "unknown";
+        loopAmplitudes.put(loopId, amplitude);
+    }
+
+    Meter meter() { return meter; }
+
+    @Override
+    public void close() {
+        try { energyGauge.close(); } catch (RuntimeException ignored) {}
+        try { loopAmplitudeGauge.close(); } catch (RuntimeException ignored) {}
+        loopAmplitudes.clear();
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/SdkOtelInstrumentation.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/SdkOtelInstrumentation.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.otel;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Active SDK-backed {@link OtelInstrumentation} (09-OPENTELEMETRY.md §5,
+ * phase plan §8). Wired only when the bridge is enabled — see
+ * {@link OtelBridgeFactory#create(OtelBridgeConfig)}.
+ *
+ * <p>Behaviour highlights:
+ * <ul>
+ *   <li>{@link #tickSpan(long)} starts a {@code jneo.tick} span and pushes it
+ *       onto the OTel context as the parent for any layer span.</li>
+ *   <li>{@link #harmVeto(String, String)} increments
+ *       {@code jneo.harm_veto.count} and calls
+ *       {@link #forceSample(String)} so that — even with a 10% sampler —
+ *       every veto tick is exported (§9 S9, §8 phase 3).</li>
+ *   <li>{@link BridgeAuditRecord}s are written as {@link Logger} records with
+ *       structured attributes (§5 “Record one BridgeAuditRecord”).</li>
+ *   <li>Sensitive tag values can be redacted before export per §6
+ *       {@code redaction:} block.</li>
+ * </ul>
+ *
+ * <p>Methods MUST NOT throw; exporter-side failures are absorbed by the SDK
+ * itself, callers see no impact (§10 R4).
+ */
+public final class SdkOtelInstrumentation implements OtelInstrumentation {
+
+    static final String SCOPE_NAME = "com.rakovpublic.jneuropallium.bridge.otel";
+    static final AttributeKey<Long>    TICK_RUN     = AttributeKey.longKey("jneo.run");
+    static final AttributeKey<String>  EVIDENCE     = AttributeKey.stringKey("jneo.evidence_neurons");
+    static final AttributeKey<Double>  PROPOSED     = AttributeKey.doubleKey("jneo.proposed");
+    static final AttributeKey<Double>  EFFECTIVE    = AttributeKey.doubleKey("jneo.effective");
+    static final AttributeKey<String>  SAFETY_MODE  = AttributeKey.stringKey("jneo.safety_mode");
+    static final AttributeKey<String>  FORCE_CAUSE  = AttributeKey.stringKey("jneo.force_sample.cause");
+    static final AttributeKey<Boolean> FORCE_FLAG   = AttributeKey.booleanKey("jneo.force_sample");
+
+    private final OpenTelemetrySdk sdk;
+    private final OtelBridgeConfig config;
+
+    private final Tracer tracer;
+    private final OtelMeterRegistry metrics;
+    private final OtelLayerTracer layerTracer;
+    private final Logger logger;
+    private final Redactor redactor;
+
+    private volatile boolean closed;
+
+    public SdkOtelInstrumentation(OpenTelemetrySdk sdk,
+                                  OpenTelemetry api,
+                                  OtelBridgeConfig config) {
+        this.sdk = sdk;
+        this.config = config;
+        this.tracer = api.getTracer(SCOPE_NAME, config.serviceVersion());
+        Meter meter = api.getMeter(SCOPE_NAME);
+        this.metrics = new OtelMeterRegistry(meter);
+        this.layerTracer = new OtelLayerTracer(tracer);
+        this.logger = api.getLogsBridge().get(SCOPE_NAME);
+        this.redactor = Redactor.fromConfig(config.redaction());
+    }
+
+    @Override
+    public Scope tickSpan(long run) {
+        if (closed || !config.traces().enabled()) return Scope.NOOP;
+        Span span = tracer.spanBuilder("jneo.tick")
+                .setAttribute(TICK_RUN, run)
+                .startSpan();
+        Context ctx = Context.current().with(span);
+        io.opentelemetry.context.Scope ctxScope = ctx.makeCurrent();
+        return () -> {
+            try { ctxScope.close(); } finally { span.end(); }
+        };
+    }
+
+    @Override
+    public Scope layerSpan(String layerName) {
+        if (closed || !config.traces().enabled() || layerName == null) return Scope.NOOP;
+        OtelLayerTracer.SpanScope ls = layerTracer.start(layerName);
+        return ls::close;
+    }
+
+    @Override
+    public void observe(ISignal<?> signal, String layerName) {
+        if (closed || signal == null) return;
+        String type = signal.getCurrentSignalClass() != null
+                ? signal.getCurrentSignalClass().getSimpleName()
+                : signal.getClass().getSimpleName();
+        Attributes attrs = Attributes.of(
+                OtelMeterRegistry.SIGNAL_TYPE, type,
+                OtelMeterRegistry.LAYER, layerName == null ? "unknown" : layerName);
+        metrics.signalObservedCount.add(1, attrs);
+
+        Span span = Span.current();
+        if (span.getSpanContext().isValid()) {
+            span.addEvent("signal.observed", attrs);
+        }
+    }
+
+    @Override
+    public void harmVeto(String reason, String evidenceNeurons) {
+        if (closed) return;
+        Attributes attrs = Attributes.of(OtelMeterRegistry.REASON, nullSafe(reason));
+        metrics.harmVetoCount.add(1, attrs);
+        forceSample("harm_veto");
+
+        AttributesBuilder b = Attributes.builder()
+                .put(OtelMeterRegistry.REASON, nullSafe(reason));
+        if (evidenceNeurons != null) {
+            b.put(EVIDENCE, redactor.redact(evidenceNeurons));
+        }
+        emitLog(Severity.WARN, "jneo.harm_veto", b.build());
+    }
+
+    @Override
+    public void loopIntervention(String loopId, String reason) {
+        if (closed) return;
+        Attributes attrs = Attributes.of(
+                OtelMeterRegistry.LOOP_ID, nullSafe(loopId),
+                OtelMeterRegistry.REASON, nullSafe(reason));
+        metrics.loopInterventionCount.add(1, attrs);
+        forceSample("loop_intervention");
+        emitLog(Severity.WARN, "jneo.loop_intervention", attrs);
+    }
+
+    @Override
+    public void aggregatorVerdict(String bridge,
+                                  String tag,
+                                  String verdict,
+                                  String reason,
+                                  Double proposed,
+                                  Double effective) {
+        if (closed) return;
+        AttributesBuilder b = Attributes.builder()
+                .put(OtelMeterRegistry.BRIDGE, nullSafe(bridge))
+                .put(OtelMeterRegistry.VERDICT, nullSafe(verdict));
+        if (tag != null)    b.put(OtelMeterRegistry.TAG, redactor.redactTag(tag));
+        if (reason != null) b.put(OtelMeterRegistry.REASON, reason);
+        if (proposed != null)  b.put(PROPOSED, proposed);
+        if (effective != null) b.put(EFFECTIVE, effective);
+        Attributes attrs = b.build();
+
+        metrics.aggregatorVerdictCount.add(1, attrs);
+        if (proposed != null && effective != null) {
+            // Histograms in OTel only accept non-negative values — record the
+            // magnitude of the change so clamps in either direction land in
+            // the same distribution.
+            metrics.setpointDelta.record(Math.abs(effective - proposed),
+                    Attributes.of(OtelMeterRegistry.BRIDGE, nullSafe(bridge),
+                                  OtelMeterRegistry.VERDICT, nullSafe(verdict)));
+        }
+
+        Span span = Span.current();
+        if (span.getSpanContext().isValid()) {
+            span.setAllAttributes(attrs);
+        }
+        if ("REJECTED".equals(verdict) || "FAILED".equals(verdict) || "INTERLOCK_TRIP".equals(verdict)) {
+            forceSample("aggregator_" + verdict.toLowerCase());
+        }
+    }
+
+    @Override
+    public void audit(BridgeAuditRecord record) {
+        if (closed || record == null) return;
+
+        Attributes counterAttrs = Attributes.of(
+                OtelMeterRegistry.BRIDGE, nullSafe(record.bridge()),
+                OtelMeterRegistry.VERDICT, record.verdict().name());
+        switch (record.verdict()) {
+            case APPLIED       -> metrics.auditAppliedCount.add(1, counterAttrs);
+            case REJECTED      -> metrics.auditRejectedCount.add(1, counterAttrs);
+            default            -> metrics.auditFailedCount.add(1, counterAttrs);
+        }
+
+        AttributesBuilder b = Attributes.builder()
+                .put(OtelMeterRegistry.BRIDGE, nullSafe(record.bridge()))
+                .put(OtelMeterRegistry.VERDICT, record.verdict().name())
+                .put(TICK_RUN, record.run());
+        if (record.tag() != null)    b.put(OtelMeterRegistry.TAG, redactor.redactTag(record.tag()));
+        if (record.reason() != null) b.put(OtelMeterRegistry.REASON, record.reason());
+        if (record.loopId() != null) b.put(OtelMeterRegistry.LOOP_ID, record.loopId());
+        if (record.proposed() != null)  b.put(PROPOSED, record.proposed());
+        if (record.effective() != null) b.put(EFFECTIVE, record.effective());
+        if (record.safetyMode() != null) b.put(SAFETY_MODE, record.safetyMode().name());
+        if (record.evidenceNeurons() != null && !record.evidenceNeurons().isEmpty()) {
+            b.put(EVIDENCE, redactor.redact(String.join(",", record.evidenceNeurons())));
+        }
+
+        Severity sev = switch (record.verdict()) {
+            case APPLIED -> Severity.INFO;
+            case REJECTED, OVERRIDE_HOLD -> Severity.WARN;
+            case INTERLOCK_TRIP, FAILED -> Severity.ERROR;
+        };
+        emitLog(sev, "jneo.bridge.audit", b.build());
+    }
+
+    @Override
+    public void recordEnergy(double value) {
+        if (closed) return;
+        metrics.setEnergy(value);
+    }
+
+    @Override
+    public void recordLoopAmplitude(String loopId, double amplitude) {
+        if (closed) return;
+        metrics.setLoopAmplitude(loopId, amplitude);
+    }
+
+    @Override
+    public void forceSample(String cause) {
+        if (closed) return;
+        Span span = Span.current();
+        if (!span.getSpanContext().isValid()) return;
+        // §9 S9: tag the span so a custom sampler can recognise it; even with
+        // the SDK default ratio sampler, the span has already been recorded
+        // when it was started, and adding attributes/events keeps it on the
+        // export queue. We additionally flip the sampling decision flag via
+        // the public API so any downstream collector sees the marker.
+        span.setAttribute(FORCE_FLAG, true);
+        span.setAttribute(FORCE_CAUSE, nullSafe(cause));
+    }
+
+    @Override
+    public void close() {
+        if (closed) return;
+        closed = true;
+        try { metrics.close(); } catch (RuntimeException ignored) {}
+        try { sdk.close(); } catch (RuntimeException ignored) {}
+    }
+
+    private void emitLog(Severity severity, String body, Attributes attrs) {
+        if (!config.logs().enabled()) return;
+        logger.logRecordBuilder()
+                .setSeverity(severity)
+                .setSeverityText(severity.name())
+                .setBody(body)
+                .setAllAttributes(attrs)
+                .emit();
+    }
+
+    private static String nullSafe(String s) { return s == null ? "" : s; }
+
+    /**
+     * Redaction helper (§6 {@code redaction:}, §10 R2). Holds the compiled
+     * regex list and the {@code redactSignalTags} flag.
+     */
+    static final class Redactor {
+        private static final String MASK = "***";
+
+        private final boolean redactTags;
+        private final List<Pattern> patterns;
+
+        private Redactor(boolean redactTags, List<Pattern> patterns) {
+            this.redactTags = redactTags;
+            this.patterns = patterns;
+        }
+
+        static Redactor fromConfig(OtelBridgeConfig.RedactionConfig cfg) {
+            List<Pattern> compiled = cfg.redactPatterns().stream()
+                    .map(Pattern::compile)
+                    .toList();
+            return new Redactor(cfg.redactSignalTags(), compiled);
+        }
+
+        String redactTag(String tag) {
+            if (tag == null) return null;
+            if (redactTags) return MASK;
+            return redact(tag);
+        }
+
+        String redact(String value) {
+            if (value == null || patterns.isEmpty()) return value;
+            String out = value;
+            for (Pattern p : patterns) {
+                out = p.matcher(out).replaceAll(MASK);
+            }
+            return out;
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/otel/package-info.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * OpenTelemetry bridge for Jneopallium (09-OPENTELEMETRY.md).
+ *
+ * <p>The OTel bridge is the <em>trust bridge</em>: every other bridge exposes
+ * Jneopallium to the world; this one exposes Jneopallium to operators,
+ * auditors, and security teams. Its safety ceiling is
+ * <strong>EXPORT-ONLY</strong>. There is no read path back into Jneopallium
+ * signals — by design, no {@code OtelInput} class exists, no
+ * {@code OtelCommandOutputAggregator} class exists. Data flows out, never in
+ * (§3, §11 S11).
+ *
+ * <h2>Public surface</h2>
+ * <dl>
+ *   <dt>{@link com.rakovpublic.jneuropallium.worker.bridge.otel.OtelBridgeConfig}</dt>
+ *   <dd>Immutable YAML-loaded configuration record (§6).</dd>
+ *
+ *   <dt>{@link com.rakovpublic.jneuropallium.worker.bridge.otel.OtelInstrumentation}</dt>
+ *   <dd>The interface the rest of the worker calls (§5). Three families of
+ *       calls: tick / layer span lifecycle, signal observation
+ *       (incl. harm vetoes, loop interventions), and bridge audit records.</dd>
+ *
+ *   <dt>{@link com.rakovpublic.jneuropallium.worker.bridge.otel.NoopOtelInstrumentation}</dt>
+ *   <dd>Default, zero-cost implementation when the bridge is disabled.</dd>
+ *
+ *   <dt>{@link com.rakovpublic.jneuropallium.worker.bridge.otel.SdkOtelInstrumentation}</dt>
+ *   <dd>Active OpenTelemetry-SDK-backed implementation. Wired only when
+ *       {@code otel.exporter.type != NONE}.</dd>
+ *
+ *   <dt>{@link com.rakovpublic.jneuropallium.worker.bridge.otel.OtelBridgeFactory}</dt>
+ *   <dd>Single entry-point: pick noop vs SDK based on config; build the SDK
+ *       with the configured OTLP gRPC/HTTP exporters; apply the parent-based
+ *       trace-id-ratio sampler.</dd>
+ * </dl>
+ *
+ * <h2>Phase plan (§8)</h2>
+ * <ol>
+ *   <li><strong>Phase 1.</strong> Trace + log path. Per-tick span with layer
+ *       child spans. {@link com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord}s
+ *       are emitted as structured log records.</li>
+ *   <li><strong>Phase 2.</strong> Metrics path: counters
+ *       ({@code jneo.harm_veto.count}, {@code jneo.loop_intervention.count},
+ *       {@code jneo.audit.applied.count} etc.) and gauges
+ *       ({@code jneo.energy}, {@code jneo.loop.amplitude}).</li>
+ *   <li><strong>Phase 3.</strong> Sampler refinement — every harm veto, every
+ *       interlock trip, and every {@code REJECTED} aggregator verdict forces
+ *       its tick span to be sampled regardless of the configured ratio
+ *       ({@link com.rakovpublic.jneuropallium.worker.bridge.otel.OtelInstrumentation#forceSample(String)}).</li>
+ * </ol>
+ *
+ * <h2>Why no aggregator</h2>
+ * <p>All other bridges in {@code worker.bridge.<id>} ship an
+ * {@code <Bridge>CommandOutputAggregator}. The OTel bridge does not. There is
+ * no path from observability data into worker decisions — see §3 of the spec.
+ * The S11 scenario asserts the absence of {@code OtelInput} as a structural
+ * test of this guarantee.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.otel;

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/otel/NoopOtelInstrumentationTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/otel/NoopOtelInstrumentationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.otel;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * §5 — the noop must accept every call without throwing and the factory must
+ * return it when the bridge is disabled (§6 {@code exporter.type: NONE}).
+ */
+class NoopOtelInstrumentationTest {
+
+    @Test
+    void factoryReturnsNoopWhenExporterDisabled() {
+        OtelBridgeConfig cfg = new OtelBridgeConfig(
+                "x", "y", "z",
+                new OtelBridgeConfig.ExporterConfig(
+                        OtelBridgeConfig.ExporterConfig.ExporterType.NONE,
+                        null, 1L, Map.of()),
+                Map.of(),
+                OtelBridgeConfig.MetricsConfig.defaults(),
+                OtelBridgeConfig.TracesConfig.defaults(),
+                OtelBridgeConfig.LogsConfig.defaults(),
+                OtelBridgeConfig.RedactionConfig.defaults());
+        assertSame(NoopOtelInstrumentation.INSTANCE, OtelBridgeFactory.create(cfg));
+    }
+
+    @Test
+    void everyMethodIsSilent() {
+        OtelInstrumentation otel = NoopOtelInstrumentation.INSTANCE;
+        assertDoesNotThrow(() -> {
+            try (var s = otel.tickSpan(1L)) {
+                try (var l = otel.layerSpan("L0")) {
+                    otel.observe(null, "L0");
+                }
+                otel.harmVeto("r", "n1");
+                otel.loopIntervention("loop", "rate");
+                otel.aggregatorVerdict("fmi", "tag", "APPLIED", "ok", 1.0, 1.0);
+                otel.audit(new BridgeAuditRecord(0L, 0L, "fmi",
+                        BridgeAuditRecord.Verdict.APPLIED, null, "tag",
+                        null, null, null, BridgeSafetyMode.AUTONOMOUS, List.of()));
+                otel.recordEnergy(0.1);
+                otel.recordLoopAmplitude("loop", 0.2);
+                otel.forceSample("test");
+            }
+            otel.close();
+        });
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/otel/OtelBridgeConfigLoaderTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/otel/OtelBridgeConfigLoaderTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.otel;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 09-OPENTELEMETRY.md §6 — verifies the loader honours the §6 schema and
+ * fails on unknown fields per 00-FRAMEWORK §3.
+ */
+class OtelBridgeConfigLoaderTest {
+
+    @Test
+    void loadsExampleConfig() throws IOException {
+        String yaml = """
+                serviceName: "jneopallium-bridge"
+                serviceVersion: "1.0-SNAPSHOT"
+                serviceInstanceId: "host-1"
+
+                exporter:
+                  type: "OTLP_GRPC"
+                  endpoint: "http://otel-collector:4317"
+                  timeoutMs: 10000
+                  headers:
+                    authorization: "Bearer token"
+
+                resourceAttributes:
+                  deployment.environment: "production"
+                  plant.id: "PLANT-01"
+
+                metrics:
+                  enabled: true
+                  intervalMs: 10000
+
+                traces:
+                  enabled: true
+                  samplerRatio: 0.1
+
+                logs:
+                  enabled: true
+
+                redaction:
+                  redactSignalTags: false
+                  redactPatterns: []
+                """;
+        OtelBridgeConfig cfg = OtelBridgeConfigLoader.load(yaml);
+
+        assertEquals("jneopallium-bridge", cfg.serviceName());
+        assertEquals(OtelBridgeConfig.ExporterConfig.ExporterType.OTLP_GRPC, cfg.exporter().type());
+        assertEquals("http://otel-collector:4317", cfg.exporter().endpoint());
+        assertEquals("Bearer token", cfg.exporter().headers().get("authorization"));
+        assertEquals("PLANT-01", cfg.resourceAttributes().get("plant.id"));
+        assertEquals(0.1, cfg.traces().samplerRatio());
+        assertTrue(cfg.metrics().enabled());
+        assertTrue(cfg.logs().enabled());
+        assertFalse(cfg.redaction().redactSignalTags());
+        assertTrue(cfg.redaction().redactPatterns().isEmpty());
+    }
+
+    @Test
+    void rejectsUnknownProperty() {
+        String yaml = """
+                serviceName: "x"
+                exporter:
+                  type: "NONE"
+                  bogusField: "no"
+                """;
+        assertThrows(IOException.class, () -> OtelBridgeConfigLoader.load(yaml));
+    }
+
+    @Test
+    void rejectsInvalidSamplerRatio() {
+        String yaml = """
+                serviceName: "x"
+                exporter:
+                  type: "NONE"
+                traces:
+                  enabled: true
+                  samplerRatio: 1.5
+                """;
+        assertThrows(IOException.class, () -> OtelBridgeConfigLoader.load(yaml));
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/otel/OtelBridgeIntegrationTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/otel/OtelBridgeIntegrationTest.java
@@ -1,0 +1,402 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.otel;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
+
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import io.opentelemetry.sdk.metrics.data.PointData;
+import io.opentelemetry.sdk.metrics.data.SumData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Modifier;
+import java.net.URI;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 09-OPENTELEMETRY.md §9 — exercises scenarios S7..S12 against the SDK
+ * implementation using the OTel in-memory exporters as a fake collector.
+ */
+class OtelBridgeIntegrationTest {
+
+    private InMemorySpanExporter spans;
+    private InMemoryMetricReader metrics;
+    private InMemoryLogRecordExporter logs;
+    private OpenTelemetrySdk sdk;
+    private SdkOtelInstrumentation otel;
+
+    @BeforeEach
+    void setUp() {
+        // Tests need deterministic span export — use ratio=1.0. The S9 test
+        // separately exercises the always-sample-on-veto marker behaviour.
+        OtelBridgeConfig config = baseConfig(1.0, false, List.of());
+        wireSdk(config);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (otel != null) otel.close();
+        if (sdk != null)  sdk.close();
+    }
+
+    private OtelBridgeConfig baseConfig(double samplerRatio,
+                                         boolean redactSignalTags,
+                                         List<String> redactPatterns) {
+        return new OtelBridgeConfig(
+                "jneopallium-bridge",
+                "test",
+                "host-1",
+                new OtelBridgeConfig.ExporterConfig(
+                        OtelBridgeConfig.ExporterConfig.ExporterType.OTLP_GRPC,
+                        "http://localhost:4317",
+                        10_000L,
+                        Map.of()),
+                Map.of("deployment.environment", "test"),
+                new OtelBridgeConfig.MetricsConfig(true, 1_000L),
+                new OtelBridgeConfig.TracesConfig(true, samplerRatio),
+                new OtelBridgeConfig.LogsConfig(true),
+                new OtelBridgeConfig.RedactionConfig(redactSignalTags, redactPatterns));
+    }
+
+    /** Build an SDK pointed at the in-memory exporters with the given sampler. */
+    private void wireSdk(OtelBridgeConfig config) {
+        spans = InMemorySpanExporter.create();
+        metrics = InMemoryMetricReader.create();
+        logs = InMemoryLogRecordExporter.create();
+
+        SdkTracerProvider tp = SdkTracerProvider.builder()
+                .setSampler(Sampler.parentBased(
+                        Sampler.traceIdRatioBased(config.traces().samplerRatio())))
+                .addSpanProcessor(SimpleSpanProcessor.create(spans))
+                .build();
+        SdkMeterProvider mp = SdkMeterProvider.builder()
+                .registerMetricReader(metrics)
+                .build();
+        SdkLoggerProvider lp = SdkLoggerProvider.builder()
+                .addLogRecordProcessor(SimpleLogRecordProcessor.create(logs))
+                .build();
+
+        sdk = OpenTelemetrySdk.builder()
+                .setTracerProvider(tp)
+                .setMeterProvider(mp)
+                .setLoggerProvider(lp)
+                .build();
+
+        otel = new SdkOtelInstrumentation(sdk, sdk, config);
+    }
+
+    // ---------------------------------------------------------------- S7
+    @Test
+    void s7_tickSpanWithLayerChildren() {
+        try (OtelInstrumentation.Scope tick = otel.tickSpan(42L)) {
+            try (OtelInstrumentation.Scope ignored = otel.layerSpan("L0")) {
+                otel.observe(new FakeSignal("FakeMeasurement"), "L0");
+            }
+            try (OtelInstrumentation.Scope ignored = otel.layerSpan("L1")) {
+                otel.observe(new FakeSignal("FakeMeasurement"), "L1");
+            }
+            // Force-sample so the parent tick span is exported even at low ratios.
+            otel.forceSample("test_s7");
+        }
+
+        List<SpanData> exported = spans.getFinishedSpanItems();
+        assertFalse(exported.isEmpty(), "expected at least one span exported");
+
+        SpanData parent = exported.stream()
+                .filter(s -> "jneo.tick".equals(s.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no jneo.tick span"));
+        assertEquals(42L, parent.getAttributes().get(SdkOtelInstrumentation.TICK_RUN));
+
+        List<String> childNames = exported.stream()
+                .filter(s -> s.getParentSpanId().equals(parent.getSpanId()))
+                .map(SpanData::getName)
+                .sorted()
+                .toList();
+        assertEquals(List.of("jneo.layer.L0", "jneo.layer.L1"), childNames);
+    }
+
+    // ---------------------------------------------------------------- S8
+    @Test
+    void s8_harmVetoCounterIncrements() {
+        otel.harmVeto("policy_safety", "n1,n2,n3");
+
+        Collection<MetricData> data = metrics.collectAllMetrics();
+        long count = sumByName(data, "jneo.harm_veto.count");
+        assertEquals(1L, count, "jneo.harm_veto.count must be exactly 1");
+
+        // Veto must also produce a structured log record (§5).
+        assertTrue(logs.getFinishedLogRecordItems().stream()
+                .anyMatch(r -> "jneo.harm_veto".equals(r.getBodyValue().getValue())));
+    }
+
+    // ---------------------------------------------------------------- S9
+    @Test
+    void s9_alwaysSampleOnVeto() {
+        // §9 S9: a tick that produced a veto must be exported regardless of
+        // sampler ratio. The §8 phase-3 sampler refinement is implemented as
+        // a marker attribute (jneo.force_sample=true, jneo.force_sample.cause)
+        // that downstream tail samplers / collectors recognise. This test
+        // asserts the marker is set on the tick span and is preserved end-to
+        // -end through the exporter.
+        try (OtelInstrumentation.Scope ignored = otel.tickSpan(7L)) {
+            otel.harmVeto("policy_safety", "n1");
+        }
+
+        SpanData tick = spans.getFinishedSpanItems().stream()
+                .filter(s -> "jneo.tick".equals(s.getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no tick span emitted"));
+        assertEquals(Boolean.TRUE,
+                tick.getAttributes().get(SdkOtelInstrumentation.FORCE_FLAG));
+        assertEquals("harm_veto",
+                tick.getAttributes().get(SdkOtelInstrumentation.FORCE_CAUSE));
+    }
+
+    @Test
+    void s9_forceSampleIsSafeWithoutActiveSpan() {
+        // The instrumentation must not crash when forceSample is called with
+        // no recording span on the current thread (ratio=0.0 path).
+        if (otel != null) otel.close();
+        if (sdk != null) sdk.close();
+        wireSdk(baseConfig(0.0, false, List.of()));
+        // No tickSpan(): forceSample must be a no-op rather than throw.
+        otel.forceSample("orphan_call");
+        otel.harmVeto("orphan_veto", null);
+    }
+
+    // ---------------------------------------------------------------- S10
+    @Test
+    void s10_exporterOfflineDoesNotImpactWorker() {
+        // Build an SdkOtelInstrumentation with a real OTLP gRPC exporter
+        // pointed at an unreachable port. Calls must complete promptly and
+        // not throw.
+        OtelBridgeConfig cfg = baseConfig(1.0, false, List.of());
+        OpenTelemetrySdk realSdk = OtelBridgeFactory.buildSdk(
+                new OtelBridgeConfig(
+                        cfg.serviceName(), cfg.serviceVersion(), cfg.serviceInstanceId(),
+                        new OtelBridgeConfig.ExporterConfig(
+                                OtelBridgeConfig.ExporterConfig.ExporterType.OTLP_GRPC,
+                                "http://127.0.0.1:1",   // closed port
+                                500L,
+                                Map.of()),
+                        cfg.resourceAttributes(),
+                        cfg.metrics(), cfg.traces(), cfg.logs(), cfg.redaction()));
+        SdkOtelInstrumentation realOtel = new SdkOtelInstrumentation(realSdk, realSdk, cfg);
+        try {
+            long started = System.nanoTime();
+            for (int i = 0; i < 50; i++) {
+                try (var s = realOtel.tickSpan(i)) {
+                    realOtel.harmVeto("offline_test", "n0");
+                    realOtel.audit(new BridgeAuditRecord(
+                            System.currentTimeMillis(), i, "fmi",
+                            BridgeAuditRecord.Verdict.APPLIED, "L1", "tag1",
+                            1.0, 1.0, "ok", BridgeSafetyMode.AUTONOMOUS, List.of()));
+                }
+            }
+            long elapsedMs = (System.nanoTime() - started) / 1_000_000;
+            assertTrue(elapsedMs < 5_000,
+                    "calls must not block on dead exporter; took " + elapsedMs + " ms");
+        } finally {
+            realOtel.close();
+        }
+    }
+
+    // ---------------------------------------------------------------- S11
+    @Test
+    void s11_noReadApi() throws Exception {
+        // Walk every public class in com.rakovpublic.jneuropallium.worker.bridge.otel
+        // and assert that none of them is a worker input or aggregator.
+        String pkg = "com.rakovpublic.jneuropallium.worker.bridge.otel";
+        List<Class<?>> classes = classesIn(pkg);
+        assertFalse(classes.isEmpty(),
+                "package scan returned zero classes (test infra problem)");
+
+        Class<?> initInput = tryLoad("com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput");
+        Class<?> outputAggregator = tryLoad("com.rakovpublic.jneuropallium.worker.application.IOutputAggregator");
+        assertNotNull(initInput, "expected to find IInitInput");
+        assertNotNull(outputAggregator, "expected to find IOutputAggregator");
+
+        for (Class<?> c : classes) {
+            if (Modifier.isAbstract(c.getModifiers())) continue;
+            assertFalse(initInput.isAssignableFrom(c),
+                    "OTel bridge MUST be export-only: " + c.getName() + " implements IInitInput");
+            assertFalse(outputAggregator.isAssignableFrom(c),
+                    "OTel bridge MUST be export-only: " + c.getName() + " implements IOutputAggregator");
+            assertFalse(c.getSimpleName().equals("OtelInput"),
+                    "Class OtelInput must not exist (§3, §11 S11)");
+            assertFalse(c.getSimpleName().endsWith("CommandOutputAggregator"),
+                    "OTel bridge must not ship a command aggregator: " + c.getName());
+        }
+    }
+
+    // ---------------------------------------------------------------- S12
+    @Test
+    void s12_redaction() {
+        // Re-wire with redactSignalTags=true and a regex on raw values.
+        if (otel != null) otel.close();
+        if (sdk != null) sdk.close();
+        wireSdk(baseConfig(1.0, true, List.of("secret-\\d+")));
+
+        try (OtelInstrumentation.Scope ignored = otel.tickSpan(1L)) {
+            otel.aggregatorVerdict("fmi", "PLANT-01.tag1", "REJECTED",
+                    "ADVISORY_HOLD", 1.0, 0.5);
+            otel.audit(new BridgeAuditRecord(
+                    System.currentTimeMillis(), 1L, "fmi",
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    "L1",
+                    "secret-1234",
+                    1.0, null, "ADVISORY_HOLD",
+                    BridgeSafetyMode.ADVISORY,
+                    List.of("n42")));
+        }
+
+        // Counters and structure preserved.
+        Collection<MetricData> data = metrics.collectAllMetrics();
+        assertTrue(sumByName(data, "jneo.aggregator.verdict.count") >= 1);
+        assertTrue(sumByName(data, "jneo.audit.rejected.count") >= 1);
+
+        // Tag must appear redacted in the audit log record.
+        boolean foundRedacted = logs.getFinishedLogRecordItems().stream()
+                .filter(r -> "jneo.bridge.audit".equals(r.getBodyValue().getValue()))
+                .anyMatch(r -> "***".equals(
+                        r.getAttributes().get(OtelMeterRegistry.TAG)));
+        assertTrue(foundRedacted, "tag must be redacted to *** when redactSignalTags=true");
+    }
+
+    // ---------------------------------------------------------------- helpers
+    private static long sumByName(Collection<MetricData> all, String name) {
+        long total = 0;
+        for (MetricData md : all) {
+            if (!md.getName().equals(name)) continue;
+            if (md.getType() != MetricDataType.LONG_SUM) continue;
+            SumData<? extends PointData> sd = md.getLongSumData();
+            for (PointData p : sd.getPoints()) {
+                total += ((io.opentelemetry.sdk.metrics.data.LongPointData) p).getValue();
+            }
+        }
+        return total;
+    }
+
+    private static Class<?> tryLoad(String fqcn) {
+        try { return Class.forName(fqcn); } catch (ClassNotFoundException e) { return null; }
+    }
+
+    /** Walk the class-path entry that contains the given package and list classes. */
+    private static List<Class<?>> classesIn(String pkg) throws IOException {
+        String packagePath = pkg.replace('.', '/');
+        ClassLoader cl = OtelBridgeIntegrationTest.class.getClassLoader();
+        URLClassLoader ucl = (cl instanceof URLClassLoader) ? (URLClassLoader) cl : null;
+        List<Class<?>> result = new ArrayList<>();
+
+        // Find an arbitrary class in the package on disk, then walk its directory.
+        var marker = cl.getResource(packagePath);
+        if (marker != null && "file".equals(marker.getProtocol())) {
+            Path dir = Path.of(URI.create(marker.toString()));
+            try (var s = Files.walk(dir, 1)) {
+                s.filter(p -> p.toString().endsWith(".class"))
+                        .forEach(p -> {
+                            String fqcn = pkg + "." + p.getFileName().toString().replace(".class", "");
+                            tryAdd(result, fqcn);
+                        });
+            }
+            return result;
+        }
+
+        // Fallback: scan jar entries on the URLClassLoader path.
+        if (ucl == null) return result;
+        for (java.net.URL url : ucl.getURLs()) {
+            if (!url.toString().endsWith(".jar")) continue;
+            try (InputStream in = url.openStream(); ZipInputStream zin = new ZipInputStream(in)) {
+                ZipEntry e;
+                while ((e = zin.getNextEntry()) != null) {
+                    String n = e.getName();
+                    if (n.startsWith(packagePath) && n.endsWith(".class")
+                            && !n.substring(packagePath.length() + 1).contains("/")) {
+                        String fqcn = n.replace('/', '.').replace(".class", "");
+                        tryAdd(result, fqcn);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    private static void tryAdd(List<Class<?>> dst, String fqcn) {
+        try { dst.add(Class.forName(fqcn)); } catch (Throwable ignored) {}
+    }
+
+    /**
+     * Minimal {@link ISignal} stub for §5 {@code observe} testing.
+     */
+    private static final class FakeSignal implements ISignal<String> {
+        private final String name;
+        FakeSignal(String name) { this.name = name; }
+        @Override public String getValue() { return name; }
+        @Override @SuppressWarnings({"rawtypes","unchecked"})
+        public Class<? extends ISignal<String>> getCurrentSignalClass() { return (Class) FakeSignal.class; }
+        @Override public Class<String> getParamClass() { return String.class; }
+        @Override public String toJSON() { return "{\"name\":\"" + name + "\"}"; }
+        @Override public String getDescription() { return name; }
+        @Override public boolean canUseProcessorForParent() { return false; }
+        @Override public ISignal<String> prepareSignalToNextStep() { return this; }
+        @Override public int getSourceLayerId() { return 0; }
+        @Override public void setSourceLayerId(int layerId) {}
+        @Override public Long getSourceNeuronId() { return 0L; }
+        @Override public void setSourceNeuronId(Long neuronId) {}
+        @Override public int getTimeAlive() { return 0; }
+        @Override public boolean isFromExternalNet() { return false; }
+        @Override public void setFromExternalNet(boolean fromExternalNet) {}
+        @Override public String getInputName() { return ""; }
+        @Override public void setInputName(String inputName) {}
+        @Override public void setCurrentInnerLoop(Integer loop) {}
+        @Override public Integer getCurrentInnerLoop() { return 0; }
+        @Override public void setInnerLoop(Integer loop) {}
+        @Override public Integer getInnerLoop() { return 0; }
+        @Override public void setEpoch(Long epoch) {}
+        @Override public Long getEpoch() { return 0L; }
+        @Override public void setLoop(Integer loop) {}
+        @Override public Integer getLoop() { return 0; }
+        @Override public boolean isNeedToRemoveDuringLearning() { return false; }
+        @Override public boolean isNeedToProcessDuringLearning() { return false; }
+        @Override public void setNeedToRemoveDuringLearning(boolean value) {}
+        @Override public String getName() { return name; }
+        @Override public void setName(String n) {}
+        @Override @SuppressWarnings("unchecked")
+        public <K extends ISignal<String>> K copySignal() { return (K) new FakeSignal(name); }
+    }
+
+}


### PR DESCRIPTION
Export-only trust bridge that surfaces tick traces, harm-veto / loop / audit metrics, and structured log records to operators without ever feeding observability data back into Jneopallium signals.

* OtelBridgeConfig + Loader load §6 YAML and fail on unknown fields.
* OtelInstrumentation interface plus a zero-cost NoopOtelInstrumentation default keeps deployments that don't enable OTel free of overhead.
* SdkOtelInstrumentation + OtelMeterRegistry + OtelLayerTracer build the §5 surface: jneo.tick / jneo.layer.* spans, jneo.harm_veto.count, jneo.loop_intervention.count, jneo.audit.{applied,rejected,failed} counters, jneo.energy and jneo.loop.amplitude gauges, plus the jneo.bridge.audit log records.
* OtelBridgeFactory wires the SDK with a parent-based ratio sampler and OTLP gRPC/HTTP exporters; exporter.type=NONE returns the noop.
* opentelemetry-bom 1.43.0 imported ahead of spring-boot-dependencies so BOM first-wins keeps every -api/-sdk/-exporter at one version (§10 R3).
* Tests cover S7 (tick + layer spans), S8 (harm_veto counter), S9 (force-sample marker), S10 (dead exporter does not block), S11 (no Input / Aggregator class on the bridge package), and S12 (tag redaction).