### PR TITLE
Implement Eclipse Ditto digital-twin bridge (10-DITTO.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ every loop.
 | 07 | DICOM | medical imaging | spec | READ-ONLY (context bridge) |
 | 08 | Apache Kafka | enterprise/cyber | spec | ADVISORY |
 | 09 | OpenTelemetry | observability | spec | EXPORT-ONLY (no writeback) |
-| 10 | Eclipse Ditto | digital twins | spec | ADVISORY |
+| 10 | Eclipse Ditto | digital twins | shipped | ADVISORY |
 | 11 | IEC 61850 | power grid | spec | READ-ONLY initially |
 | 12 | MAVLink | drones | spec | SIM-ONLY initially |
 | 13 | CANopen | embedded | spec | ADVISORY |
@@ -252,6 +252,18 @@ decisions to a configurable advisory namespace consumed by the operator HMI
 `AUTONOMOUS` per-tag promotion is rejected by the config validator. See
 [`docs/mqtt-bridge.md`](docs/mqtt-bridge.md) and
 [`02-MQTT-SPARKPLUG.md`](02-MQTT-SPARKPLUG.md).
+
+### Eclipse Ditto bridge
+
+For digital-twin / device-fleet use cases the Ditto bridge subscribes to
+twin events over WebSocket, emits typed `MeasurementSignal` /
+`AlarmSignal(TWIN_OFFLINE)` instances per configured feature property, and
+writes neuron-derived advisory setpoints back via Ditto's REST API to
+features whose name starts with `recommended_` or `advisory_` — never to
+the actual control feature. The advisory-prefix rule is enforced both at
+config load and at runtime; `AUTONOMOUS` per-tag promotion is rejected by
+the config validator. See [`docs/ditto-bridge.md`](docs/ditto-bridge.md)
+and [`10-DITTO.md`](10-DITTO.md).
 
 ## Applications
 

--- a/docs/ditto-bridge.md
+++ b/docs/ditto-bridge.md
@@ -1,0 +1,248 @@
+# Eclipse Ditto bridge
+
+> Companion to [`10-DITTO.md`](../10-DITTO.md) (the spec) and
+> [`00-FRAMEWORK.md`](../00-FRAMEWORK.md) (the universal contract). This file
+> documents the Ditto bridge's domain context, YAML schema, manual demo
+> procedure, and regulatory posture — i.e. the §10 Definition-of-Done items
+> that don't belong in the spec itself.
+
+## Domain context
+
+[Eclipse Ditto](https://www.eclipse.org/ditto/) is the open-source framework
+for managing **digital twins** of internet-connected devices. A *Thing* in
+Ditto carries features (state slots, e.g. `vibration`, `temperature`),
+attributes (static metadata), and a policy (access control). Devices push
+state in; consumers read it via REST or subscribe to twin events over a
+WebSocket; controllers write commands addressed to twin features.
+
+Ditto sits one layer above raw protocol bridges (MQTT, OPC UA, PLC4X). Where
+those bridges expose *measurement points*, Ditto exposes a *coherent device
+model*: "Pump-3 has a vibration feature that is currently 4.2 mm/s and was
+last calibrated on 2025-07-01." For Jneopallium that's useful when reasoning
+needs **device context** more than raw signal density — predictive
+maintenance, fleet-level anomaly detection, energy optimization across
+heterogeneous equipment.
+
+The bridge is positioned as **read + advisory write only**. It writes
+exclusively to feature names prefixed with `recommended_` or `advisory_` —
+never to the actual control feature. That rule is enforced *twice*: at config
+load (the loader rejects any write binding whose feature lacks the prefix)
+and at runtime in `DittoClientService.writeProperty` (defence-in-depth, per
+10-DITTO §4). `AUTONOMOUS` per-tag promotion is also rejected by the config
+validator: the structural ceiling is `ADVISORY`.
+
+## Components
+
+```
+worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/
+├── DittoBridgeConfig.java                ← YAML record (immutable, AUTONOMOUS rejected)
+├── DittoBridgeConfigLoader.java          ← Jackson YAML loader, FAIL_ON_UNKNOWN
+├── DittoFeatureBinding.java              ← thingId/feature/property binding (BridgeBinding)
+├── DittoSignalMapper.java                ← twin event JSON ↔ typed signal / command body
+├── DittoTransport.java                   ← test-seam interface (REST + WS)
+├── DefaultDittoTransport.java            ← java.net.http-backed production wiring
+├── DittoClientService.java               ← lifecycle, alive-thing cache, advisory queue
+├── DittoFeatureInput.java                ← IInitInput → MeasurementSignal
+├── DittoEventInput.java                  ← IInitInput → AlarmSignal (TWIN_OFFLINE / RECONNECTED)
+├── DittoAuditOutput.java                 ← local JSONL audit (00-FRAMEWORK §4)
+├── DittoAdvisoryOutputAggregator.java    ← IOutputAggregator (writes only to advisory features)
+└── package-info.java
+```
+
+The production transport uses the JDK's built-in `HttpClient` and `WebSocket`
+client to speak the [Ditto
+protocol](https://www.eclipse.org/ditto/protocol-overview.html) directly,
+which keeps the dependency surface minimal — no Akka classic transitive deps
+from `org.eclipse.ditto:ditto-client`. Tests inject an in-memory
+`DittoTransport` (`InMemoryDittoTransport` in the test tree), so acceptance
+scenarios run without a Ditto sandbox. Deployments that want richer
+protocol features (search, live channels) can swap in a transport implementing
+the same seam.
+
+## YAML schema reference
+
+```yaml
+connection:
+  baseUrl: "https://ditto.factory.local"
+  webSocketPath: "/ws/2"                  # default
+  httpPath: "/api/2"                      # default
+  requestTimeout: "PT10S"                 # default
+  advisoryQueueSize: 10000                # bound on outbound queue
+
+authentication:
+  type: "OAuth2BearerToken"               # None | BasicAuth | OAuth2BearerToken
+  tokenEndpoint: "https://idp.local/token"
+  clientId: "jneopallium-bridge"
+  clientSecretEnv: "DITTO_CLIENT_SECRET"  # env-var name; never embed the secret
+
+# Optional explicit list of subscribed things. The bridge automatically
+# subscribes to any thing referenced from a read or write binding too.
+things:
+  - "factory.line-a:pump-1"
+  - "factory.line-a:reactor-1"
+
+reads:
+  - bindingId: "PUMP1-VIB"
+    thingId:   "factory.line-a:pump-1"
+    feature:   "vibration"
+    property:  "rms_z"
+    signalTag: "PUMP01.VIB.Z"
+    signalKind: "MEASUREMENT"             # default; or ALARM for booleans
+
+  - bindingId: "REACTOR1-TEMP"
+    thingId:   "factory.line-a:reactor-1"
+    feature:   "temperature"
+    property:  "current"
+    signalTag: "REACTOR01.TEMP"
+
+writes:
+  - bindingId: "REACTOR1-ADVISED-SP"
+    thingId:   "factory.line-a:reactor-1"
+    feature:   "recommended_setpoint"     # MUST start with "recommended_" or "advisory_"
+    property:  "value"
+    signalTag: "REACTOR01.SP.ADV"
+    minClampValue:  0.0
+    maxClampValue: 100.0
+
+audit:
+  localAuditFile: "/var/log/jneopallium/ditto-audit.jsonl"
+
+severityMap:
+  high_temp: HIGH                         # boolean alarm feature → AlarmPriority
+
+perTagSafetyMode:
+  REACTOR1-ADVISED-SP: ADVISORY           # AUTONOMOUS rejected by the loader
+
+tickInterval: "PT0.25S"
+```
+
+`reads` produce a `MeasurementSignal` (numeric property) or an `AlarmSignal`
+(boolean property whose feature name appears in `severityMap`). Quality
+defaults to `GOOD`; when the bridge has flagged the thing as offline (after a
+`THING_DELETED` event) subsequent reads carry `Quality.UNCERTAIN` per
+00-FRAMEWORK §0.5.
+
+`writes` are restricted to features whose name starts with `recommended_` or
+`advisory_`. The compact constructor of `WriteBindingConfig` throws
+`IllegalArgumentException` on any other value — Jackson surfaces it as a
+load failure.
+
+## Manual demo procedure
+
+Pre-requisites: Java 17, Maven 3.9+, Docker, and a clone of
+[`eclipse-ditto/ditto-examples`](https://github.com/eclipse-ditto/ditto-examples).
+
+1. Start a local Ditto sandbox:
+
+   ```sh
+   git clone https://github.com/eclipse-ditto/ditto.git
+   cd ditto/deployment/docker
+   docker compose up -d
+   ```
+
+2. Register a thing (REST):
+
+   ```sh
+   curl -u ditto:ditto -X PUT \
+     "http://localhost:8080/api/2/things/factory.line-a:reactor-1" \
+     -H 'Content-Type: application/json' \
+     -d '{"features":{"temperature":{"properties":{"current":25.0}},
+                       "recommended_setpoint":{"properties":{"value":0.0}}}}'
+   ```
+
+3. Save a config to `/tmp/ditto-demo.yaml`:
+
+   ```yaml
+   connection:
+     baseUrl: "http://localhost:8080"
+   authentication:
+     type: "BasicAuth"
+     username: "ditto"
+     passwordEnv: "DITTO_DEMO_PWD"
+   reads:
+     - bindingId: "REACTOR1-TEMP"
+       thingId:   "factory.line-a:reactor-1"
+       feature:   "temperature"
+       property:  "current"
+       signalTag: "REACTOR01.TEMP"
+   writes:
+     - bindingId: "REACTOR1-ADVISED-SP"
+       thingId:   "factory.line-a:reactor-1"
+       feature:   "recommended_setpoint"
+       property:  "value"
+       signalTag: "REACTOR01.SP.ADV"
+       minClampValue:  0.0
+       maxClampValue: 100.0
+   audit:
+     localAuditFile: "/tmp/ditto-audit.jsonl"
+   perTagSafetyMode:
+     REACTOR1-ADVISED-SP: ADVISORY
+   ```
+
+   ```sh
+   export DITTO_DEMO_PWD=ditto
+   ```
+
+4. Construct the bridge and inject inputs/outputs:
+
+   ```java
+   DittoBridgeConfig cfg = DittoBridgeConfigLoader.load(Path.of("/tmp/ditto-demo.yaml"));
+   DittoAuditOutput  audit = new DittoAuditOutput(Path.of(cfg.audit().localAuditFile()));
+   DittoSignalMapper mapper = new DittoSignalMapper(cfg);
+   DittoTransport transport = new DefaultDittoTransport(cfg);
+   DittoClientService svc = new DittoClientService(cfg, transport, mapper, audit);
+   svc.start();
+
+   DittoFeatureInput               featureIn = new DittoFeatureInput("ditto-meas", svc, List.of("REACTOR1-TEMP"));
+   DittoEventInput                 eventIn   = new DittoEventInput("ditto-events", svc);
+   DittoAdvisoryOutputAggregator   agg       = new DittoAdvisoryOutputAggregator(svc, audit);
+   ```
+
+5. Update the source feature property via REST and observe one
+   `MeasurementSignal` per tick draining out of `featureIn`:
+
+   ```sh
+   curl -u ditto:ditto -X PUT \
+     "http://localhost:8080/api/2/things/factory.line-a:reactor-1/features/temperature/properties/current" \
+     -H 'Content-Type: application/json' -d '73.5'
+   ```
+
+6. Drive a `SetpointSignal(tag="REACTOR01.SP.ADV", setpoint=72.5)` into the
+   aggregator. The bridge issues a `PUT` to
+   `/api/2/things/factory.line-a:reactor-1/features/recommended_setpoint/properties/value`
+   with the clamped scalar payload, and writes an `APPLIED` audit line to
+   `/tmp/ditto-audit.jsonl`.
+
+7. Delete the thing (`curl -u ditto:ditto -X DELETE …`) and observe the
+   bridge emit `AlarmSignal(HIGH, TWIN_OFFLINE)` plus subsequent reads
+   carrying `Quality.UNCERTAIN`.
+
+## Regulatory posture
+
+The structural ceiling is **ADVISORY**, both in spec and in code:
+
+* The config loader rejects any per-tag `AUTONOMOUS` promotion.
+* The config loader rejects any write binding whose feature name does not
+  start with `recommended_` or `advisory_`. Re-checked at runtime in
+  `DittoClientService.writeProperty` for defence-in-depth — a programmatic
+  caller can't bypass it by hand-rolling a binding either.
+
+This is appropriate because:
+
+* Ditto is a context model, not a control plane. Closed-loop control through
+  a digital-twin API would route through Ditto's connectivity service to a
+  protocol bridge anyway — better to advise the operator HMI directly.
+* Policy-based access denial mid-run can occur silently from the bridge's
+  perspective; a write that a Ditto policy refuses produces an HTTP 403 and
+  is audited as `FAILED`. The bridge does not infer values from a 403; the
+  affected binding stays at the last known value with `Quality.UNCERTAIN`
+  on subsequent reads (per 10-DITTO §10 R3, 00-FRAMEWORK §0.5).
+* Per-binding feature path is validated at config load (10-DITTO §10 R1).
+
+For closed-loop control of field actuators, route through the OPC UA or
+PLC4X bridges, both of which are AUTONOMOUS-capable per-loop with the full
+clamp / rate-limit / interlock / override ladder enforced before any write.
+
+The local JSONL audit conforms to `00-FRAMEWORK §4`. There is no Ditto-side
+audit mirror channel by default — the source REST API is itself the audit
+trail of writes the bridge has issued.

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DefaultDittoTransport.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DefaultDittoTransport.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ditto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Production {@link DittoTransport} backed by the JDK's built-in
+ * {@link HttpClient} for REST and {@link WebSocket} for twin events
+ * (10-DITTO.md §3). The bridge is intentionally thin — the
+ * <a href="https://www.eclipse.org/ditto/protocol-overview.html">Ditto
+ * protocol</a> messages are JSON over WebSocket, so we hand-frame them
+ * rather than pulling in the full {@code org.eclipse.ditto:ditto-client}
+ * (and its Akka classic transitive deps).
+ *
+ * <p>Authentication: at present we support
+ * {@link DittoBridgeConfig.AuthType#None} and
+ * {@link DittoBridgeConfig.AuthType#BasicAuth}. OAuth2 token endpoints can
+ * be wired by an out-of-process refresher that updates the env var pointed
+ * to by {@code authentication.clientSecretEnv}; this transport will read
+ * the latest value on every request.
+ *
+ * <p>This implementation does not perform reconnect itself — the
+ * {@link DittoClientService} owns the reconnect policy
+ * (00-FRAMEWORK §2.3) and is the one that calls
+ * {@link DittoTransport#connect()} again after a disconnect.
+ */
+public final class DefaultDittoTransport implements DittoTransport {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultDittoTransport.class);
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private final DittoBridgeConfig config;
+    private final HttpClient http;
+    private final AtomicReference<WebSocket> ws = new AtomicReference<>();
+    private final AtomicReference<EventHandler> handler = new AtomicReference<>();
+    private final AtomicBoolean connected = new AtomicBoolean();
+
+    public DefaultDittoTransport(DittoBridgeConfig config) {
+        this.config = Objects.requireNonNull(config, "config");
+        this.http = HttpClient.newBuilder()
+                .connectTimeout(config.connection().requestTimeout())
+                .build();
+    }
+
+    @Override public synchronized void setHandler(EventHandler h) { handler.set(h); }
+    @Override public boolean isConnected() { return connected.get(); }
+
+    @Override
+    public synchronized void connect() {
+        if (connected.get()) return;
+        URI wsUri = URI.create(toWsScheme(config.connection().baseUrl())
+                + config.connection().webSocketPath());
+        try {
+            WebSocket socket = http.newWebSocketBuilder()
+                    .header("Authorization", buildAuthHeader())
+                    .connectTimeout(config.connection().requestTimeout())
+                    .buildAsync(wsUri, new Listener())
+                    .get();
+            ws.set(socket);
+            connected.set(true);
+            log.info("DittoTransport connected to {}", wsUri);
+        } catch (Exception ex) {
+            throw new DittoTransportException("Ditto WebSocket connect failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public void subscribe(String thingId) {
+        WebSocket socket = ws.get();
+        if (socket == null) throw new DittoTransportException("not connected");
+        // START-SEND-EVENTS scoped to the configured thing — Ditto's filter syntax.
+        String msg = "START-SEND-EVENTS?filter=eq(thingId,\"" + thingId + "\")";
+        socket.sendText(msg, true).join();
+    }
+
+    @Override
+    public boolean putFeatureProperty(String thingId, String feature, String property, byte[] body) {
+        URI uri = URI.create(config.connection().baseUrl()
+                + config.connection().httpPath()
+                + "/things/" + thingId + "/features/" + feature
+                + "/properties/" + property);
+        HttpRequest req = HttpRequest.newBuilder(uri)
+                .timeout(config.connection().requestTimeout())
+                .header("Authorization", buildAuthHeader())
+                .header("Content-Type", "application/json")
+                .PUT(HttpRequest.BodyPublishers.ofByteArray(body))
+                .build();
+        try {
+            HttpResponse<Void> resp = http.send(req, HttpResponse.BodyHandlers.discarding());
+            return resp.statusCode() / 100 == 2;
+        } catch (IOException | InterruptedException ex) {
+            if (ex instanceof InterruptedException) Thread.currentThread().interrupt();
+            throw new DittoTransportException("Ditto PUT failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public byte[] getFeatureProperty(String thingId, String feature, String property) {
+        URI uri = URI.create(config.connection().baseUrl()
+                + config.connection().httpPath()
+                + "/things/" + thingId + "/features/" + feature
+                + "/properties/" + property);
+        HttpRequest req = HttpRequest.newBuilder(uri)
+                .timeout(config.connection().requestTimeout())
+                .header("Authorization", buildAuthHeader())
+                .header("Accept", "application/json")
+                .GET()
+                .build();
+        try {
+            HttpResponse<byte[]> resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+            int sc = resp.statusCode();
+            if (sc == 404) return null;
+            if (sc / 100 != 2) {
+                throw new DittoTransportException("Ditto GET " + uri + " returned " + sc);
+            }
+            return resp.body();
+        } catch (IOException | InterruptedException ex) {
+            if (ex instanceof InterruptedException) Thread.currentThread().interrupt();
+            throw new DittoTransportException("Ditto GET failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        if (!connected.compareAndSet(true, false)) return;
+        WebSocket socket = ws.getAndSet(null);
+        if (socket == null) return;
+        try {
+            socket.sendClose(WebSocket.NORMAL_CLOSURE, "shutdown")
+                    .orTimeout(config.connection().requestTimeout().toMillis(),
+                            java.util.concurrent.TimeUnit.MILLISECONDS).join();
+        } catch (RuntimeException ex) {
+            log.warn("DittoTransport.close: WS close threw {}", ex.getMessage());
+        }
+    }
+
+    /* ===== auth + URL helpers ============================================= */
+
+    private String buildAuthHeader() {
+        DittoBridgeConfig.AuthConfig a = config.authentication();
+        if (a == null || a.type() == null || a.type() == DittoBridgeConfig.AuthType.None) {
+            return "";
+        }
+        if (a.type() == DittoBridgeConfig.AuthType.BasicAuth) {
+            String user = a.username() == null ? "" : a.username();
+            String pass = a.passwordEnv() == null ? "" : Optional.ofNullable(System.getenv(a.passwordEnv())).orElse("");
+            return "Basic " + Base64.getEncoder().encodeToString(
+                    (user + ":" + pass).getBytes(StandardCharsets.UTF_8));
+        }
+        if (a.type() == DittoBridgeConfig.AuthType.OAuth2BearerToken) {
+            String token = a.clientSecretEnv() == null ? "" : Optional.ofNullable(System.getenv(a.clientSecretEnv())).orElse("");
+            return "Bearer " + token;
+        }
+        return "";
+    }
+
+    static String toWsScheme(String baseUrl) {
+        if (baseUrl.startsWith("https://")) return "wss://" + baseUrl.substring("https://".length());
+        if (baseUrl.startsWith("http://")) return "ws://" + baseUrl.substring("http://".length());
+        return baseUrl;
+    }
+
+    /* ===== inbound WebSocket listener ===================================== */
+
+    private final class Listener implements WebSocket.Listener {
+        private final StringBuilder buf = new StringBuilder();
+
+        @Override public void onOpen(WebSocket webSocket) {
+            webSocket.request(1);
+        }
+
+        @Override
+        public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+            buf.append(data);
+            if (last) {
+                String msg = buf.toString();
+                buf.setLength(0);
+                dispatch(msg);
+            }
+            webSocket.request(1);
+            return null;
+        }
+
+        @Override
+        public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+            connected.set(false);
+            log.info("DittoTransport WS closed: status={} reason={}", statusCode, reason);
+            return null;
+        }
+
+        @Override
+        public void onError(WebSocket webSocket, Throwable error) {
+            connected.set(false);
+            log.warn("DittoTransport WS error: {}", error.toString());
+        }
+
+        @Override public CompletionStage<?> onPing(WebSocket webSocket, ByteBuffer message) {
+            webSocket.request(1);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private void dispatch(String message) {
+        EventHandler h = handler.get();
+        if (h == null) return;
+        try {
+            JsonNode root = JSON.readTree(message);
+            JsonNode topic = root.get("topic");
+            if (topic == null || !topic.isTextual()) return;
+            String topicText = topic.asText();
+            // topic format: <namespace>/<name>/things/twin/events/<action>
+            String[] parts = topicText.split("/");
+            if (parts.length < 6) return;
+            String thingId = parts[0] + ":" + parts[1];
+            String action = parts[5];
+            JsonNode pathNode = root.get("path");
+            String path = pathNode == null ? "/" : pathNode.asText();
+            EventType type;
+            String feature = null;
+            if ("deleted".equals(action) && "/".equals(path)) {
+                type = EventType.THING_DELETED;
+            } else if (path.startsWith("/features/")) {
+                String[] pp = path.split("/");
+                if (pp.length >= 3) feature = pp[2];
+                if (pp.length >= 5 && "properties".equals(pp[3])) {
+                    type = EventType.FEATURE_PROPERTY_MODIFIED;
+                } else {
+                    type = EventType.FEATURE_MODIFIED;
+                }
+            } else {
+                return;
+            }
+            h.onEvent(new TwinEvent(type, thingId, feature, message.getBytes(StandardCharsets.UTF_8)));
+        } catch (RuntimeException | IOException ex) {
+            log.warn("DittoTransport dispatch failed: {}", ex.getMessage());
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoAdvisoryOutputAggregator.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoAdvisoryOutputAggregator.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ditto;
+
+import com.rakovpublic.jneuropallium.worker.application.IOutputAggregator;
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import com.rakovpublic.jneuropallium.worker.net.layers.IResult;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+import com.rakovpublic.jneuropallium.worker.util.IContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IOutputAggregator} for the Ditto advisory egress
+ * (10-DITTO.md §4 egress table).
+ *
+ * <p>The bridge ceiling is structurally {@code ADVISORY} — the §0.1–§0.3
+ * autonomous-write algorithm doesn't apply here, but per-tag {@code SHADOW}
+ * still suppresses outbound traffic, the binding's
+ * {@code [minClampValue, maxClampValue]} is applied before write, and the
+ * {@code recommended_*} / {@code advisory_*} feature-name guard is
+ * re-enforced at runtime by {@link DittoClientService#writeProperty}.
+ *
+ * <p>Signal handling:
+ * <ul>
+ *   <li>{@link SetpointSignal} → modify the configured advisory feature
+ *       property on the same thing.</li>
+ *   <li>{@link ActuatorCommandSignal} (with {@code execute=true}) → same.</li>
+ * </ul>
+ *
+ * <p>{@code AUTONOMOUS} per-tag safety mode is rejected by
+ * {@link DittoBridgeConfig}'s constructor; this aggregator therefore only
+ * needs to differentiate {@code SHADOW} (drop) from {@code ADVISORY}
+ * (write).
+ */
+public final class DittoAdvisoryOutputAggregator implements IOutputAggregator {
+
+    private static final Logger log = LoggerFactory.getLogger(DittoAdvisoryOutputAggregator.class);
+
+    private final DittoClientService svc;
+    private final AbstractBridgeAuditOutput audit;
+    private final DittoBridgeConfig config;
+
+    public DittoAdvisoryOutputAggregator(DittoClientService svc,
+                                         AbstractBridgeAuditOutput audit) {
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.audit = Objects.requireNonNull(audit, "audit");
+        this.config = svc.config();
+    }
+
+    @Override
+    public void save(List<IResult> results, long timestamp, long run, IContext context) {
+        if (results == null || results.isEmpty()) return;
+        for (IResult r : results) {
+            if (r == null) continue;
+            IResultSignal<?> s = r.getResult();
+            if (s == null) continue;
+            Long neuronId = r.getNeuronId();
+            try {
+                if (s instanceof SetpointSignal sp) {
+                    handleNumeric(sp.getTag(), sp.getSetpoint(), timestamp, run, neuronId);
+                } else if (s instanceof ActuatorCommandSignal ac) {
+                    handleActuator(ac, timestamp, run, neuronId);
+                }
+            } catch (RuntimeException ex) {
+                audit.append(new BridgeAuditRecord(
+                        timestamp, run, DittoClientService.BRIDGE_NAME,
+                        BridgeAuditRecord.Verdict.FAILED,
+                        null, tagOf(s), null, null,
+                        BridgeAuditRecord.RejectReason.EXCEPTION + ":" + ex.getClass().getSimpleName(),
+                        null, evidence(neuronId)));
+            }
+        }
+    }
+
+    private void handleNumeric(String tag, double proposed, long ts, long run, Long neuronId) {
+        if (tag == null) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, DittoClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    null, null, proposed, null,
+                    BridgeAuditRecord.RejectReason.UNKNOWN_TAG, null, evidence(neuronId)));
+            return;
+        }
+        DittoFeatureBinding b = svc.writeBindingForTag(tag);
+        if (b == null) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, DittoClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    null, tag, proposed, null,
+                    BridgeAuditRecord.RejectReason.UNKNOWN_TAG, null, evidence(neuronId)));
+            return;
+        }
+
+        BridgeSafetyMode mode = config.perTagSafetyMode().getOrDefault(b.bindingId(), BridgeSafetyMode.ADVISORY);
+        if (mode == BridgeSafetyMode.SHADOW) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, DittoClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    b.loopId(), tag, proposed, null,
+                    BridgeAuditRecord.RejectReason.SHADOW_MODE, mode, evidence(neuronId)));
+            return;
+        }
+
+        // Clamp before writing (§4 — clamps still apply on advisory channel).
+        String modifyReason = null;
+        double effective = proposed;
+        if (b.maxClampValue() != null && effective > b.maxClampValue()) {
+            effective = b.maxClampValue();
+            modifyReason = BridgeAuditRecord.ModifyReason.CLAMPED_HIGH;
+        } else if (b.minClampValue() != null && effective < b.minClampValue()) {
+            effective = b.minClampValue();
+            modifyReason = BridgeAuditRecord.ModifyReason.CLAMPED_LOW;
+        }
+
+        boolean ok = svc.writeProperty(b.bindingId(), effective, ts, run, tag);
+        if (ok) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, DittoClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.APPLIED,
+                    b.loopId(), tag, proposed, effective,
+                    modifyReason, mode, evidence(neuronId)));
+        }
+        // Failure / non-advisory paths are audited inside DittoClientService.writeProperty.
+    }
+
+    private void handleActuator(ActuatorCommandSignal ac, long ts, long run, Long neuronId) {
+        String tag = ac.getTag();
+        if (!ac.isExecute()) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, DittoClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    null, tag, ac.getTargetValue(), null,
+                    BridgeAuditRecord.RejectReason.SHADOW_MODE, BridgeSafetyMode.SHADOW,
+                    evidence(neuronId)));
+            return;
+        }
+        handleNumeric(tag, ac.getTargetValue(), ts, run, neuronId);
+    }
+
+    private static String tagOf(IResultSignal<?> s) {
+        if (s instanceof SetpointSignal sp) return sp.getTag();
+        if (s instanceof ActuatorCommandSignal ac) return ac.getTag();
+        return null;
+    }
+
+    private static List<String> evidence(Long neuronId) {
+        return neuronId == null ? List.of() : List.of(String.valueOf(neuronId));
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoAuditOutput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoAuditOutput.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ditto;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+
+import java.nio.file.Path;
+
+/**
+ * JSONL audit sink for the Ditto bridge (00-FRAMEWORK §4, §6;
+ * 10-DITTO.md §5 {@code audit.localAuditFile}).
+ *
+ * <p>Ditto does not have a generic external audit channel comparable to
+ * Kafka or OpenTelemetry, so this sink only writes locally; the local
+ * JSONL conforms to 00-FRAMEWORK §4 and is consumed by the SOC/historian.
+ */
+public final class DittoAuditOutput extends AbstractBridgeAuditOutput {
+    public DittoAuditOutput(Path file) { super(file); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoBridgeConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoBridgeConfig.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ditto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Top-level configuration for the Eclipse Ditto digital-twin bridge
+ * (10-DITTO.md §5). Loaded from YAML via {@link DittoBridgeConfigLoader};
+ * immutable.
+ *
+ * <p>Per 00-FRAMEWORK §3 unknown YAML keys fail loading. Per 10-DITTO §1 the
+ * structural ceiling is {@code ADVISORY}; the compact constructor rejects
+ * per-tag {@code AUTONOMOUS} promotion. The egress feature-prefix rule
+ * ({@code recommended_*} / {@code advisory_*} only) is enforced both here
+ * (per binding) and in {@link DittoAdvisoryOutputAggregator} at runtime
+ * (defence-in-depth, §4).
+ */
+public record DittoBridgeConfig(
+        ConnectionConfig connection,
+        AuthConfig authentication,
+        List<String> things,
+        List<ReadBindingConfig> reads,
+        List<WriteBindingConfig> writes,
+        AuditConfig audit,
+        Map<String, BridgeSafetyMode> perTagSafetyMode,
+        Map<String, AlarmPriorityName> severityMap,
+        Duration tickInterval
+) {
+    /** Allowed prefixes for any write binding's {@code feature} (10-DITTO §4). */
+    public static final String ADVISORY_PREFIX = "advisory_";
+    public static final String RECOMMENDED_PREFIX = "recommended_";
+
+    public DittoBridgeConfig {
+        Objects.requireNonNull(connection, "connection");
+        things = things == null ? List.of() : List.copyOf(things);
+        reads = reads == null ? List.of() : List.copyOf(reads);
+        writes = writes == null ? List.of() : List.copyOf(writes);
+        if (perTagSafetyMode == null) {
+            perTagSafetyMode = Map.of();
+        } else {
+            Map<String, BridgeSafetyMode> linked = new LinkedHashMap<>(perTagSafetyMode);
+            for (Map.Entry<String, BridgeSafetyMode> e : linked.entrySet()) {
+                if (e.getValue() == BridgeSafetyMode.AUTONOMOUS) {
+                    throw new IllegalArgumentException(
+                            "Eclipse Ditto bridge ceiling is ADVISORY (10-DITTO.md §1): "
+                                    + "tag '" + e.getKey() + "' was promoted to AUTONOMOUS — refusing to load");
+                }
+            }
+            perTagSafetyMode = Map.copyOf(linked);
+        }
+        severityMap = severityMap == null ? Map.of() : Map.copyOf(severityMap);
+        for (WriteBindingConfig w : writes) {
+            requireAdvisoryPrefix(w.feature(), w.bindingId());
+        }
+    }
+
+    /** Throw when {@code feature} is not an advisory/recommended feature (10-DITTO §4). */
+    public static void requireAdvisoryPrefix(String feature, String bindingId) {
+        if (feature == null || !(feature.startsWith(ADVISORY_PREFIX)
+                || feature.startsWith(RECOMMENDED_PREFIX))) {
+            throw new IllegalArgumentException(
+                    "Ditto write binding '" + bindingId
+                            + "' targets feature '" + feature + "' which is not an advisory feature: "
+                            + "only feature names starting with '" + RECOMMENDED_PREFIX
+                            + "' or '" + ADVISORY_PREFIX + "' may receive advisory writes (10-DITTO §4)");
+        }
+    }
+
+    /** Connection-level settings. */
+    public record ConnectionConfig(
+            String baseUrl,
+            String webSocketPath,
+            String httpPath,
+            Duration requestTimeout,
+            int advisoryQueueSize
+    ) {
+        public ConnectionConfig {
+            Objects.requireNonNull(baseUrl, "baseUrl");
+            webSocketPath = webSocketPath == null || webSocketPath.isBlank()
+                    ? "/ws/2" : webSocketPath;
+            httpPath = httpPath == null || httpPath.isBlank()
+                    ? "/api/2" : httpPath;
+            requestTimeout = requestTimeout == null ? Duration.ofSeconds(10) : requestTimeout;
+            if (advisoryQueueSize <= 0) advisoryQueueSize = 10_000;
+        }
+
+        @JsonCreator
+        public static ConnectionConfig of(
+                @JsonProperty("baseUrl") String baseUrl,
+                @JsonProperty("webSocketPath") String webSocketPath,
+                @JsonProperty("httpPath") String httpPath,
+                @JsonProperty("requestTimeout") Duration requestTimeout,
+                @JsonProperty("advisoryQueueSize") Integer advisoryQueueSize) {
+            return new ConnectionConfig(baseUrl, webSocketPath, httpPath, requestTimeout,
+                    advisoryQueueSize == null ? 10_000 : advisoryQueueSize);
+        }
+    }
+
+    /**
+     * Authentication settings (10-DITTO §5). Secret material is never
+     * embedded — env-var names are stored, the connection layer reads them
+     * at start-up.
+     */
+    public record AuthConfig(
+            AuthType type,
+            String username,
+            String passwordEnv,
+            String tokenEndpoint,
+            String clientId,
+            String clientSecretEnv
+    ) {
+        @JsonCreator
+        public static AuthConfig of(
+                @JsonProperty("type") AuthType type,
+                @JsonProperty("username") String username,
+                @JsonProperty("passwordEnv") String passwordEnv,
+                @JsonProperty("tokenEndpoint") String tokenEndpoint,
+                @JsonProperty("clientId") String clientId,
+                @JsonProperty("clientSecretEnv") String clientSecretEnv) {
+            return new AuthConfig(type, username, passwordEnv,
+                    tokenEndpoint, clientId, clientSecretEnv);
+        }
+    }
+
+    public enum AuthType { None, BasicAuth, OAuth2BearerToken }
+
+    /**
+     * One ingress binding from a Ditto thing/feature/property to a
+     * Jneopallium signal (10-DITTO §4 ingress table).
+     */
+    public record ReadBindingConfig(
+            String bindingId,
+            String thingId,
+            String feature,
+            String property,
+            String signalTag,
+            ReadSignalKind signalKind
+    ) {
+        public ReadBindingConfig {
+            Objects.requireNonNull(bindingId, "bindingId");
+            Objects.requireNonNull(thingId, "thingId");
+            Objects.requireNonNull(feature, "feature");
+            Objects.requireNonNull(property, "property");
+            signalKind = signalKind == null ? ReadSignalKind.MEASUREMENT : signalKind;
+        }
+
+        @JsonCreator
+        public static ReadBindingConfig of(
+                @JsonProperty("bindingId") String bindingId,
+                @JsonProperty("thingId") String thingId,
+                @JsonProperty("feature") String feature,
+                @JsonProperty("property") String property,
+                @JsonProperty("signalTag") String signalTag,
+                @JsonProperty("signalKind") ReadSignalKind signalKind) {
+            return new ReadBindingConfig(bindingId, thingId, feature, property,
+                    signalTag, signalKind);
+        }
+    }
+
+    /** What signal class a {@link ReadBindingConfig} produces. */
+    public enum ReadSignalKind { MEASUREMENT, ALARM }
+
+    /**
+     * One advisory egress binding (10-DITTO §4 egress table). The
+     * compact constructor rejects any non-advisory {@code feature}.
+     */
+    public record WriteBindingConfig(
+            String bindingId,
+            String thingId,
+            String feature,
+            String property,
+            String signalTag,
+            Double minClampValue,
+            Double maxClampValue
+    ) {
+        public WriteBindingConfig {
+            Objects.requireNonNull(bindingId, "bindingId");
+            Objects.requireNonNull(thingId, "thingId");
+            Objects.requireNonNull(feature, "feature");
+            Objects.requireNonNull(property, "property");
+            requireAdvisoryPrefix(feature, bindingId);
+        }
+
+        @JsonCreator
+        public static WriteBindingConfig of(
+                @JsonProperty("bindingId") String bindingId,
+                @JsonProperty("thingId") String thingId,
+                @JsonProperty("feature") String feature,
+                @JsonProperty("property") String property,
+                @JsonProperty("signalTag") String signalTag,
+                @JsonProperty("minClampValue") Double minClampValue,
+                @JsonProperty("maxClampValue") Double maxClampValue) {
+            return new WriteBindingConfig(bindingId, thingId, feature, property,
+                    signalTag, minClampValue, maxClampValue);
+        }
+    }
+
+    /** Audit channel configuration (00-FRAMEWORK §3, §4). */
+    public record AuditConfig(
+            String localAuditFile
+    ) {
+        public AuditConfig {
+            Objects.requireNonNull(localAuditFile, "localAuditFile");
+        }
+
+        @JsonCreator
+        public static AuditConfig of(
+                @JsonProperty("localAuditFile") String localAuditFile) {
+            return new AuditConfig(localAuditFile);
+        }
+    }
+
+    /** Stable name for the AlarmPriority enum so it can appear in YAML config. */
+    public enum AlarmPriorityName { JOURNAL, LOW, HIGH, URGENT }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoBridgeConfigLoader.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoBridgeConfigLoader.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ditto;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+/**
+ * Loads {@link DittoBridgeConfig} from YAML (10-DITTO.md §5).
+ *
+ * <p>{@code FAIL_ON_UNKNOWN_PROPERTIES = true} per 00-FRAMEWORK §3 — a typo
+ * in a control-bridge config must be caught at load.
+ */
+public final class DittoBridgeConfigLoader {
+
+    private DittoBridgeConfigLoader() {}
+
+    public static DittoBridgeConfig load(Path yaml) throws IOException {
+        return mapper().readValue(yaml.toFile(), DittoBridgeConfig.class);
+    }
+
+    public static DittoBridgeConfig load(InputStream in) throws IOException {
+        return mapper().readValue(in, DittoBridgeConfig.class);
+    }
+
+    public static DittoBridgeConfig load(String yamlContent) throws IOException {
+        return mapper().readValue(yamlContent, DittoBridgeConfig.class);
+    }
+
+    private static ObjectMapper mapper() {
+        return new ObjectMapper(new YAMLFactory())
+                .registerModule(new JavaTimeModule())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoClientService.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoClientService.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ditto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmPriority;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.Quality;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Owns the Ditto WebSocket subscription, the per-thing online cache, and
+ * the advisory write queue (10-DITTO.md §3 &amp; §9).
+ *
+ * <p>Read flow: a {@link DittoTransport.TwinEvent} is decoded by
+ * {@link DittoSignalMapper} into a typed signal and queued per binding;
+ * {@link DittoFeatureInput} / {@link DittoEventInput} drain the queues per
+ * tick (00-FRAMEWORK §2.1). When a {@code THING_DELETED} event arrives, the
+ * thing is removed from the {@link #aliveThings} set; subsequent reads of
+ * any of its features carry {@link Quality#UNCERTAIN} (10-DITTO §4).
+ *
+ * <p>Write flow: {@link DittoAdvisoryOutputAggregator} computes the
+ * advisory payload, calls {@link #writeProperty}; this method enforces the
+ * bounded advisory queue (00-FRAMEWORK §6 R4 analogue), validates the
+ * advisory-prefix rule a second time, and audits the result.
+ */
+public final class DittoClientService implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(DittoClientService.class);
+
+    public static final String BRIDGE_NAME = "ditto";
+    public static final String TWIN_OFFLINE = "TWIN_OFFLINE";
+    public static final String BRIDGE_RECONNECTED = "BRIDGE_RECONNECTED";
+
+    /** Ditto-specific reasons (in addition to the 00-FRAMEWORK §4 vocabulary). */
+    public static final class Reason {
+        private Reason() {}
+        public static final String ADVISORY_QUEUE_FULL = "ADVISORY_QUEUE_FULL";
+        public static final String DECODER_ERROR       = "DECODER_ERROR";
+        public static final String WRITE_ERROR         = "WRITE_ERROR";
+        public static final String NON_ADVISORY_FEATURE = "NON_ADVISORY_FEATURE";
+    }
+
+    private final DittoBridgeConfig config;
+    private final DittoTransport transport;
+    private final DittoSignalMapper mapper;
+    private final AbstractBridgeAuditOutput audit;
+
+    /** Pending decoded measurement signals per read-bindingId. Drained per tick. */
+    private final Map<String, List<IInputSignal>> measurementsByBinding = new ConcurrentHashMap<>();
+    /** Pending alarm/event signals (single queue: alarms aren't tag-scoped). */
+    private final List<IInputSignal> events = new ArrayList<>();
+
+    private final Map<String, DittoFeatureBinding> readBindings = new HashMap<>();
+    private final Map<String, DittoFeatureBinding> writeBindings = new HashMap<>();
+    private final Map<String, DittoBridgeConfig.WriteBindingConfig> writeConfigs = new HashMap<>();
+
+    /** Per-binding lookup by feature path (thingId/feature/property). */
+    private final Map<String, DittoBridgeConfig.ReadBindingConfig> readByPath = new HashMap<>();
+    /** All read bindings grouped by (thingId, feature) for FEATURE_MODIFIED dispatch. */
+    private final Map<String, List<DittoBridgeConfig.ReadBindingConfig>> readByFeature = new HashMap<>();
+
+    /** Things currently considered alive. Empty set ⇒ all configured things default to alive. */
+    private final Set<String> aliveThings = ConcurrentHashMap.newKeySet();
+
+    private final AtomicLong advisoryQueueDepth = new AtomicLong();
+    private final AtomicBoolean started = new AtomicBoolean();
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    public DittoClientService(DittoBridgeConfig config,
+                              DittoTransport transport,
+                              DittoSignalMapper mapper,
+                              AbstractBridgeAuditOutput audit) {
+        this.config = Objects.requireNonNull(config, "config");
+        this.transport = Objects.requireNonNull(transport, "transport");
+        this.mapper = Objects.requireNonNull(mapper, "mapper");
+        this.audit = Objects.requireNonNull(audit, "audit");
+        for (DittoBridgeConfig.ReadBindingConfig r : config.reads()) {
+            readBindings.put(r.bindingId(), DittoFeatureBinding.fromRead(r));
+            measurementsByBinding.put(r.bindingId(), new ArrayList<>());
+            readByPath.put(DittoFeatureBinding.defaultTag(r.thingId(), r.feature(), r.property()), r);
+            readByFeature.computeIfAbsent(r.thingId() + "/" + r.feature(), k -> new ArrayList<>()).add(r);
+        }
+        for (DittoBridgeConfig.WriteBindingConfig w : config.writes()) {
+            writeBindings.put(w.bindingId(), DittoFeatureBinding.fromWrite(w));
+            writeConfigs.put(w.bindingId(), w);
+        }
+        // Configured things start as alive; THING_DELETED removes them.
+        aliveThings.addAll(distinctThings());
+    }
+
+    /** Open the WS connection, register the handler, subscribe to every configured thing. Idempotent. */
+    public synchronized void start() {
+        if (started.get()) return;
+        transport.setHandler(this::onEvent);
+        transport.connect();
+        for (String thingId : distinctThings()) {
+            transport.subscribe(thingId);
+        }
+        started.set(true);
+        log.info("DittoClientService started; {} read + {} write bindings, subscribed to {} thing(s)",
+                config.reads().size(), config.writes().size(), distinctThings().size());
+    }
+
+    /** Drop the alive-thing cache and emit a {@code BRIDGE_RECONNECTED} alarm (00-FRAMEWORK §2.3). */
+    public synchronized void onReconnected() {
+        aliveThings.clear();
+        aliveThings.addAll(distinctThings());
+        synchronized (events) {
+            events.add(new AlarmSignal(AlarmPriority.LOW, BRIDGE_NAME,
+                    BRIDGE_RECONNECTED, System.currentTimeMillis()));
+        }
+        log.info("DittoClientService: reconnect — cache cleared, advisory event emitted");
+    }
+
+    public List<IInputSignal> drainMeasurements(String bindingId) {
+        List<IInputSignal> q = measurementsByBinding.get(bindingId);
+        if (q == null || q.isEmpty()) return List.of();
+        synchronized (q) {
+            List<IInputSignal> snap = new ArrayList<>(q);
+            q.clear();
+            return snap;
+        }
+    }
+
+    public List<IInputSignal> drainEvents() {
+        synchronized (events) {
+            if (events.isEmpty()) return List.of();
+            List<IInputSignal> snap = new ArrayList<>(events);
+            events.clear();
+            return snap;
+        }
+    }
+
+    /**
+     * Issue a feature-property modify against the Ditto HTTP API. Returns
+     * {@code true} on a 2xx response. Refuses (and audits {@code REJECTED})
+     * any binding whose target feature is not advisory.
+     */
+    public boolean writeProperty(String bindingId, double value, long ts, long run, String signalTag) {
+        if (closed.get() || !started.get()) return false;
+        DittoBridgeConfig.WriteBindingConfig wc = writeConfigs.get(bindingId);
+        DittoFeatureBinding b = writeBindings.get(bindingId);
+        if (wc == null || b == null) {
+            audit.append(new BridgeAuditRecord(
+                    System.currentTimeMillis(), run, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    bindingId, signalTag, value, null,
+                    BridgeAuditRecord.RejectReason.UNKNOWN_TAG, null, List.of()));
+            return false;
+        }
+        // Defence-in-depth: even though the loader should have rejected this, refuse
+        // again at the runtime boundary (10-DITTO §4 — "Enforced at config-load and at runtime").
+        try {
+            DittoBridgeConfig.requireAdvisoryPrefix(wc.feature(), wc.bindingId());
+        } catch (IllegalArgumentException ex) {
+            audit.append(new BridgeAuditRecord(
+                    System.currentTimeMillis(), run, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    b.loopId(), signalTag, value, null,
+                    Reason.NON_ADVISORY_FEATURE, null, List.of()));
+            return false;
+        }
+
+        long current = advisoryQueueDepth.incrementAndGet();
+        if (current > config.connection().advisoryQueueSize()) {
+            advisoryQueueDepth.decrementAndGet();
+            audit.append(new BridgeAuditRecord(
+                    System.currentTimeMillis(), run, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.FAILED,
+                    bindingId, signalTag, value, null,
+                    Reason.ADVISORY_QUEUE_FULL, null, List.of()));
+            return false;
+        }
+        try {
+            byte[] body = mapper.encodeFeaturePropertyRestBody(value);
+            return transport.putFeatureProperty(wc.thingId(), wc.feature(), wc.property(), body);
+        } catch (RuntimeException ex) {
+            audit.append(new BridgeAuditRecord(
+                    System.currentTimeMillis(), run, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.FAILED,
+                    b.loopId(), signalTag, value, null,
+                    Reason.WRITE_ERROR + ":" + ex.getMessage(), null, List.of()));
+            return false;
+        } finally {
+            advisoryQueueDepth.decrementAndGet();
+        }
+    }
+
+    public DittoBridgeConfig config() { return config; }
+    public DittoFeatureBinding readBinding(String bindingId) { return readBindings.get(bindingId); }
+    public DittoFeatureBinding writeBinding(String bindingId) { return writeBindings.get(bindingId); }
+    public DittoBridgeConfig.WriteBindingConfig writeConfig(String bindingId) { return writeConfigs.get(bindingId); }
+    public DittoFeatureBinding writeBindingForTag(String tag) {
+        for (DittoFeatureBinding b : writeBindings.values()) {
+            if (Objects.equals(tag, b.signalTag())) return b;
+        }
+        return null;
+    }
+
+    /** Test helper — whether the bridge currently considers {@code thingId} alive. */
+    public boolean isThingAlive(String thingId) { return aliveThings.contains(thingId); }
+
+    @Override
+    public synchronized void close() {
+        if (!closed.compareAndSet(false, true)) return;
+        try { transport.close(); } catch (RuntimeException e) {
+            log.warn("DittoTransport.close() threw: {}", e.getMessage());
+        }
+    }
+
+    /* ===== inbound twin-event dispatch =================================== */
+
+    private void onEvent(DittoTransport.TwinEvent ev) {
+        try {
+            switch (ev.type()) {
+                case THING_DELETED -> handleThingDeleted(ev.thingId());
+                case FEATURE_PROPERTY_MODIFIED, FEATURE_MODIFIED -> handleFeatureChange(ev);
+            }
+        } catch (DittoSignalMapper.SignalMapperException ex) {
+            audit.append(new BridgeAuditRecord(
+                    System.currentTimeMillis(), 0, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.FAILED,
+                    null, ev.thingId(), null, null,
+                    Reason.DECODER_ERROR + ":" + ex.getMessage(), null, List.of()));
+        }
+    }
+
+    private void handleThingDeleted(String thingId) {
+        boolean wasAlive = aliveThings.remove(thingId);
+        if (!wasAlive) return;
+        long ts = System.currentTimeMillis();
+        synchronized (events) {
+            events.add(new AlarmSignal(AlarmPriority.HIGH, thingId, TWIN_OFFLINE, ts));
+        }
+    }
+
+    private void handleFeatureChange(DittoTransport.TwinEvent ev) {
+        JsonNode root = mapper.decode(ev.payload());
+        if (root == null) return;
+        long ts = mapper.pickTimestamp(root, System.currentTimeMillis());
+        boolean offline = !aliveThings.contains(ev.thingId());
+
+        Set<DittoBridgeConfig.ReadBindingConfig> matched = new HashSet<>();
+        if (ev.feature() != null) {
+            List<DittoBridgeConfig.ReadBindingConfig> byFeature =
+                    readByFeature.get(ev.thingId() + "/" + ev.feature());
+            if (byFeature != null) matched.addAll(byFeature);
+        }
+        // Property-specific event: also try the exact path lookup for correctness.
+        for (DittoBridgeConfig.ReadBindingConfig r : matched) {
+            JsonNode value = mapper.extractPropertyValue(root, r.feature(), r.property());
+            IInputSignal sig = mapper.toSignal(r, value, ts, offline);
+            if (sig == null) continue;
+            if (sig instanceof AlarmSignal) {
+                synchronized (events) { events.add(sig); }
+            } else {
+                List<IInputSignal> q = measurementsByBinding.get(r.bindingId());
+                if (q != null) synchronized (q) { q.add(sig); }
+            }
+        }
+    }
+
+    /** Build an alive-thing list from the explicit {@code things} block plus any binding's thingId. */
+    private Set<String> distinctThings() {
+        Set<String> all = new HashSet<>(config.things());
+        for (DittoBridgeConfig.ReadBindingConfig r : config.reads()) all.add(r.thingId());
+        for (DittoBridgeConfig.WriteBindingConfig w : config.writes()) all.add(w.thingId());
+        return all;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoEventInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoEventInput.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ditto;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IInitInput} that drains {@link AlarmSignal}s emitted by
+ * {@link DittoClientService} from {@code THING_DELETED} or
+ * {@code BRIDGE_RECONNECTED} conditions (10-DITTO.md §4).
+ */
+public final class DittoEventInput implements IInitInput {
+
+    private final String name;
+    private final DittoClientService svc;
+
+    public DittoEventInput(String name, DittoClientService svc) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.svc = Objects.requireNonNull(svc, "svc");
+    }
+
+    @Override public List<IInputSignal> readSignals() { return svc.drainEvents(); }
+    @Override public String getName() { return name; }
+    @Override public HashMap<String, List<IResultSignal>> getDesiredResults() { return new HashMap<>(); }
+    @Override public ProcessingFrequency getDefaultProcessingFrequency() {
+        return AlarmSignal.PROCESSING_FREQUENCY;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoFeatureBinding.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoFeatureBinding.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ditto;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeBinding;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeBindingDirection;
+
+/**
+ * One Ditto thing/feature/property ↔ signal-tag binding (10-DITTO.md §4).
+ *
+ * <p>The {@code featurePath} is the canonical address {@code thingId/feature/property}
+ * used as the default {@code signalTag} when one is not configured. Implements
+ * {@link BridgeBinding} so the universal audit record (00-FRAMEWORK §4)
+ * identifies the binding by tag and so write bindings can carry their
+ * clamp range.
+ */
+public record DittoFeatureBinding(
+        String bindingId,
+        String thingId,
+        String feature,
+        String property,
+        String signalTag,
+        BridgeBindingDirection direction,
+        Double minClampValue,
+        Double maxClampValue
+) implements BridgeBinding {
+
+    public static DittoFeatureBinding fromRead(DittoBridgeConfig.ReadBindingConfig r) {
+        String tag = (r.signalTag() == null || r.signalTag().isBlank())
+                ? defaultTag(r.thingId(), r.feature(), r.property())
+                : r.signalTag();
+        return new DittoFeatureBinding(r.bindingId(), r.thingId(), r.feature(), r.property(),
+                tag, BridgeBindingDirection.READ, null, null);
+    }
+
+    public static DittoFeatureBinding fromWrite(DittoBridgeConfig.WriteBindingConfig w) {
+        String tag = (w.signalTag() == null || w.signalTag().isBlank())
+                ? defaultTag(w.thingId(), w.feature(), w.property())
+                : w.signalTag();
+        return new DittoFeatureBinding(w.bindingId(), w.thingId(), w.feature(), w.property(),
+                tag, BridgeBindingDirection.WRITE,
+                w.minClampValue(), w.maxClampValue());
+    }
+
+    /** Canonical {@code thingId/feature/property} address. */
+    public static String defaultTag(String thingId, String feature, String property) {
+        return thingId + "/" + feature + "/" + property;
+    }
+
+    /** Canonical {@code thingId/feature/property} address for this binding. */
+    public String featurePath() { return defaultTag(thingId, feature, property); }
+
+    @Override public String loopId() { return bindingId; }
+    @Override public Double failSafeValue() { return null; }
+    @Override public Double rampRateMaxPerSec() { return null; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoFeatureInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoFeatureInput.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ditto;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IInitInput} that drains decoded {@link MeasurementSignal}s from
+ * {@link DittoClientService} (10-DITTO.md §4 ingress mapping).
+ *
+ * <p>One instance binds to one or more read bindings whose
+ * {@link DittoBridgeConfig.ReadSignalKind} is {@code MEASUREMENT}.
+ * {@code readSignals()} returns a snapshot — the connection service
+ * maintains the cache asynchronously; this method does not block on the
+ * network (00-FRAMEWORK §2.1).
+ */
+public final class DittoFeatureInput implements IInitInput {
+
+    private final String name;
+    private final DittoClientService svc;
+    private final List<String> bindingIds;
+
+    public DittoFeatureInput(String name, DittoClientService svc, List<String> bindingIds) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.bindingIds = List.copyOf(Objects.requireNonNull(bindingIds, "bindingIds"));
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        List<IInputSignal> out = new ArrayList<>();
+        for (String b : bindingIds) out.addAll(svc.drainMeasurements(b));
+        return out;
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() { return new HashMap<>(); }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() {
+        return MeasurementSignal.PROCESSING_FREQUENCY;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoSignalMapper.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoSignalMapper.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ditto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmPriority;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.Quality;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Pure (no-IO) functions translating Ditto twin payloads into Jneopallium
+ * signals (10-DITTO.md §4) and back into twin-command JSON.
+ *
+ * <p>Ingress: a feature property is a JSON value (number, boolean, object).
+ * Numeric properties become {@link MeasurementSignal}s with {@link Quality}
+ * derived from a {@code quality} sibling field if present (otherwise
+ * {@code GOOD}, or {@code UNCERTAIN} when the bridge has marked the thing as
+ * offline). Boolean properties whose feature name appears in the configured
+ * {@code severityMap} become {@link AlarmSignal}s.
+ *
+ * <p>Egress: an advisory write encodes a Ditto twin command in the
+ * <a href="https://www.eclipse.org/ditto/protocol-specification.html">Ditto
+ * protocol</a> shape — a {@code modify} command targeting
+ * {@code things/<thingId>/features/<feature>/properties/<property>} with a
+ * scalar value. The actual REST/WS path is composed by the transport.
+ */
+public final class DittoSignalMapper {
+
+    public static final ObjectMapper JSON = new ObjectMapper();
+
+    private final Map<String, DittoBridgeConfig.AlarmPriorityName> severityMap;
+
+    public DittoSignalMapper(DittoBridgeConfig cfg) {
+        this.severityMap = Objects.requireNonNull(cfg, "cfg").severityMap();
+    }
+
+    /**
+     * Build a typed signal from a property value already extracted from a
+     * Ditto twin event (or REST poll).
+     *
+     * @param binding read binding for which the value was observed
+     * @param value   raw JSON node for the property; {@code null} → no signal
+     * @param tsMs   wall-clock timestamp from the source (10-DITTO §0/00-FRAMEWORK §0.6)
+     * @param twinOffline whether the bridge has flagged the thing as offline; flips quality to {@code UNCERTAIN}
+     */
+    public IInputSignal toSignal(DittoBridgeConfig.ReadBindingConfig binding,
+                                 JsonNode value,
+                                 long tsMs,
+                                 boolean twinOffline) {
+        if (binding == null || value == null || value.isMissingNode() || value.isNull()) return null;
+        String tag = (binding.signalTag() == null || binding.signalTag().isBlank())
+                ? DittoFeatureBinding.defaultTag(binding.thingId(), binding.feature(), binding.property())
+                : binding.signalTag();
+
+        if (binding.signalKind() == DittoBridgeConfig.ReadSignalKind.ALARM) {
+            AlarmPriority p = AlarmPriority.JOURNAL;
+            DittoBridgeConfig.AlarmPriorityName mapped = severityMap.get(binding.feature());
+            if (mapped != null) p = AlarmPriority.valueOf(mapped.name());
+            boolean active = value.isBoolean() ? value.asBoolean()
+                    : value.isNumber() ? value.asDouble() != 0.0 : false;
+            return new AlarmSignal(p, tag, active ? "ALARM_ACTIVE" : "ALARM_NORMAL", tsMs);
+        }
+
+        if (!value.isNumber()) return null;
+        Quality q = twinOffline ? Quality.UNCERTAIN : Quality.GOOD;
+        return new MeasurementSignal(tag, value.asDouble(), q, tsMs);
+    }
+
+    /**
+     * Build a Ditto protocol envelope for a feature-property modify command.
+     * The transport layer dispatches this either via WebSocket or via REST
+     * {@code PUT /things/<thingId>/features/<feature>/properties/<property>};
+     * the JSON body is identical.
+     */
+    public byte[] encodeFeaturePropertyCommand(String thingId, String feature,
+                                               String property, double value, long ts) {
+        Map<String, Object> headers = new LinkedHashMap<>();
+        headers.put("response-required", false);
+        headers.put("content-type", "application/json");
+
+        Map<String, Object> envelope = new LinkedHashMap<>();
+        envelope.put("topic",
+                topicForModify(thingId, feature, property));
+        envelope.put("headers", headers);
+        envelope.put("path", "/features/" + feature + "/properties/" + property);
+        envelope.put("value", value);
+        envelope.put("timestamp", Instant.ofEpochMilli(ts).toString());
+        try {
+            return JSON.writeValueAsBytes(envelope);
+        } catch (Exception ex) {
+            throw new SignalMapperException("Ditto encode failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    /** REST-style PUT body for the property — a plain JSON scalar. */
+    public byte[] encodeFeaturePropertyRestBody(double value) {
+        try {
+            return JSON.writeValueAsBytes(value);
+        } catch (Exception ex) {
+            throw new SignalMapperException("Ditto encode failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    /** Decode a JSON payload (twin event, REST response). */
+    public JsonNode decode(byte[] payload) {
+        if (payload == null || payload.length == 0) return null;
+        try {
+            return JSON.readTree(payload);
+        } catch (IOException ex) {
+            throw new SignalMapperException("Ditto decode failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Pull a feature-property value out of a Ditto protocol envelope or a
+     * raw REST response. Honours both the {@code value} envelope shape
+     * (twin events) and a plain {@code {feature: {properties: {prop: x}}}}
+     * tree (REST snapshot).
+     */
+    public JsonNode extractPropertyValue(JsonNode root, String feature, String property) {
+        if (root == null) return null;
+        // twin event envelope: { value: <scalar> } when path is the property,
+        // or { value: {feature: {properties: {prop: x}}} } when path is /
+        JsonNode value = root.get("value");
+        if (value != null) {
+            if (value.isNumber() || value.isBoolean() || value.isTextual() || value.isNull()) {
+                return value;
+            }
+            JsonNode f = value.get(feature);
+            if (f != null) {
+                JsonNode props = f.get("properties");
+                if (props != null) return props.get(property);
+            }
+        }
+        // REST snapshot — the body itself is the property (PUT /properties/<p>) or
+        // the whole feature object (GET /features/<f>).
+        if (root.isNumber() || root.isBoolean()) return root;
+        JsonNode props = root.get("properties");
+        if (props != null) return props.get(property);
+        return null;
+    }
+
+    /**
+     * Pull the source-system timestamp out of a Ditto envelope. Falls back to
+     * the supplied wall-clock when the envelope carries none (00-FRAMEWORK §0.6).
+     */
+    public long pickTimestamp(JsonNode root, long fallbackMs) {
+        if (root == null) return fallbackMs;
+        JsonNode ts = root.get("timestamp");
+        if (ts == null) {
+            JsonNode headers = root.get("headers");
+            if (headers != null) ts = headers.get("timestamp");
+        }
+        if (ts == null || ts.isNull()) return fallbackMs;
+        if (ts.isNumber()) return ts.asLong();
+        if (ts.isTextual()) {
+            try {
+                return Instant.parse(ts.asText()).toEpochMilli();
+            } catch (DateTimeParseException ignored) {
+                return fallbackMs;
+            }
+        }
+        return fallbackMs;
+    }
+
+    /** Ditto protocol topic for a modify-feature-property command. */
+    public static String topicForModify(String thingId, String feature, String property) {
+        // thingId namespace:name → namespace/name in the topic per Ditto Protocol.
+        String[] parts = thingId.split(":", 2);
+        String namespace = parts.length == 2 ? parts[0] : "_";
+        String name = parts.length == 2 ? parts[1] : thingId;
+        return namespace + "/" + name + "/things/twin/commands/modify";
+    }
+
+    /** Wraps Jackson exceptions so the caller can audit uniformly. */
+    public static final class SignalMapperException extends RuntimeException {
+        public SignalMapperException(String msg, Throwable cause) { super(msg, cause); }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoTransport.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoTransport.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ditto;
+
+/**
+ * Test seam between {@link DittoClientService} and the actual Ditto wire
+ * (10-DITTO.md §3). Production wiring uses {@link DefaultDittoTransport}
+ * (java.net.http for REST and WebSocket); tests inject an in-memory
+ * implementation so the §8 scenarios run without a Ditto sandbox.
+ *
+ * <p>The transport is bytes-only; signal decoding lives in
+ * {@link DittoSignalMapper}.
+ */
+public interface DittoTransport extends AutoCloseable {
+
+    /** One twin event observed on the WebSocket. */
+    record TwinEvent(EventType type, String thingId, String feature, byte[] payload) {}
+
+    /** The relevant subset of Ditto twin event types the bridge reacts to. */
+    enum EventType {
+        /** A feature property changed. */
+        FEATURE_PROPERTY_MODIFIED,
+        /** A feature value was replaced as a whole. */
+        FEATURE_MODIFIED,
+        /** The thing was deleted (or all its features deleted). */
+        THING_DELETED
+    }
+
+    /** Callback invoked for every received twin event. */
+    @FunctionalInterface
+    interface EventHandler { void onEvent(TwinEvent event); }
+
+    /**
+     * Open the connection (HTTP for REST, WebSocket for events). Idempotent.
+     * Implementations doing real network work block until connected or fail
+     * with {@link DittoTransportException}.
+     */
+    void connect();
+
+    /**
+     * Subscribe to twin events for one thing. Implementations send the
+     * Ditto protocol {@code START-SEND-EVENTS} message bound to the thing.
+     */
+    void subscribe(String thingId);
+
+    /** Set (or replace) the event handler used by every subscription. */
+    void setHandler(EventHandler handler);
+
+    /**
+     * Issue a feature-property modify against the Ditto HTTP API:
+     * {@code PUT /api/2/things/<thingId>/features/<feature>/properties/<property>}
+     * with {@code body} as the JSON request entity. Returns {@code true} when
+     * the response status is 2xx.
+     */
+    boolean putFeatureProperty(String thingId, String feature, String property, byte[] body);
+
+    /**
+     * Read a feature-property snapshot:
+     * {@code GET /api/2/things/<thingId>/features/<feature>/properties/<property>}.
+     * Returns the raw response body, or {@code null} when the property does
+     * not exist (HTTP 404). Throws {@link DittoTransportException} on other
+     * non-2xx responses.
+     */
+    byte[] getFeatureProperty(String thingId, String feature, String property);
+
+    /** {@code true} once {@link #connect} succeeded and no disconnect has occurred since. */
+    boolean isConnected();
+
+    /** Shut down. Idempotent. */
+    @Override
+    void close();
+
+    /** Wraps any client throwable so the bridge can audit it uniformly. */
+    final class DittoTransportException extends RuntimeException {
+        public DittoTransportException(String message) { super(message); }
+        public DittoTransportException(String message, Throwable cause) { super(message, cause); }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * Eclipse Ditto digital-twin bridge (10-DITTO.md). A Ditto {@code Thing} is
+ * the upstream device-fleet model: features carry numeric / boolean state,
+ * a policy gates access. The bridge subscribes to twin events, emits typed
+ * {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal}
+ * /
+ * {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal}
+ * instances per the ingress mapping in 10-DITTO §4, and writes neuron-derived
+ * advisory setpoints back as twin commands targeting {@code recommended_*} /
+ * {@code advisory_*} features only — never the actual control feature.
+ *
+ * <p>The structural ceiling is {@code ADVISORY} (10-DITTO §1, README index).
+ * The {@link com.rakovpublic.jneuropallium.worker.bridge.ditto.DittoBridgeConfig}
+ * compact constructor rejects any per-tag {@code AUTONOMOUS} promotion, and
+ * the {@link com.rakovpublic.jneuropallium.worker.bridge.ditto.DittoBridgeConfigLoader}
+ * rejects any write binding whose feature name lacks the
+ * {@code recommended_} / {@code advisory_} prefix (§4 egress table).
+ *
+ * @see <a href="../../../../../../../../../../10-DITTO.md">10-DITTO.md</a>
+ * @see <a href="../../../../../../../../../../00-FRAMEWORK.md">00-FRAMEWORK.md</a>
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ditto;

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoBridgeConfigLoaderTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoBridgeConfigLoaderTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ditto;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Loader tests for {@link DittoBridgeConfigLoader} and validation rules in
+ * {@link DittoBridgeConfig} (10-DITTO.md §5, §8 S9).
+ */
+class DittoBridgeConfigLoaderTest {
+
+    @Test
+    void loadsCanonicalSpecYaml() throws Exception {
+        String yaml = """
+                connection:
+                  baseUrl: "https://ditto.factory.local"
+                authentication:
+                  type: "OAuth2BearerToken"
+                  tokenEndpoint: "https://idp.local/token"
+                  clientId: "jneopallium-bridge"
+                  clientSecretEnv: "DITTO_CLIENT_SECRET"
+                things:
+                  - "factory.line-a:pump-1"
+                  - "factory.line-a:reactor-1"
+                reads:
+                  - bindingId: "PUMP1-VIB"
+                    thingId: "factory.line-a:pump-1"
+                    feature: "vibration"
+                    property: "rms_z"
+                    signalTag: "PUMP01.VIB.Z"
+                  - bindingId: "REACTOR1-TEMP"
+                    thingId: "factory.line-a:reactor-1"
+                    feature: "temperature"
+                    property: "current"
+                    signalTag: "REACTOR01.TEMP"
+                writes:
+                  - bindingId: "REACTOR1-ADVISED-SP"
+                    thingId: "factory.line-a:reactor-1"
+                    feature: "recommended_setpoint"
+                    property: "value"
+                    signalTag: "REACTOR01.SP.ADV"
+                audit:
+                  localAuditFile: "/var/log/jneopallium/ditto-audit.jsonl"
+                perTagSafetyMode:
+                  REACTOR1-ADVISED-SP: ADVISORY
+                """;
+        DittoBridgeConfig cfg = DittoBridgeConfigLoader.load(yaml);
+        assertEquals("https://ditto.factory.local", cfg.connection().baseUrl());
+        assertEquals(2, cfg.things().size());
+        assertEquals(2, cfg.reads().size());
+        assertEquals("PUMP01.VIB.Z", cfg.reads().get(0).signalTag());
+        assertEquals(1, cfg.writes().size());
+        assertEquals("recommended_setpoint", cfg.writes().get(0).feature());
+        assertEquals(BridgeSafetyMode.ADVISORY,
+                cfg.perTagSafetyMode().get("REACTOR1-ADVISED-SP"));
+    }
+
+    /** S9: a write to a non-advisory feature is rejected at load. */
+    @Test
+    void rejectsNonAdvisoryFeaturePrefix() {
+        String yaml = """
+                connection:
+                  baseUrl: "https://ditto.factory.local"
+                writes:
+                  - bindingId: "BAD"
+                    thingId: "factory.line-a:reactor-1"
+                    feature: "setpoint"
+                    property: "value"
+                    signalTag: "X"
+                audit:
+                  localAuditFile: "/tmp/ditto-audit.jsonl"
+                """;
+        Exception e = assertThrows(Exception.class, () -> DittoBridgeConfigLoader.load(yaml));
+        Throwable t = e;
+        while (t != null && (t.getMessage() == null
+                || !t.getMessage().contains("advisory feature"))) {
+            t = t.getCause();
+        }
+        assertNotNull(t, "expected the failure to mention the advisory feature rule");
+    }
+
+    /** S9 (positive): {@code advisory_*} prefix is accepted. */
+    @Test
+    void acceptsAdvisoryPrefix() throws Exception {
+        String yaml = """
+                connection:
+                  baseUrl: "https://ditto.factory.local"
+                writes:
+                  - bindingId: "OK"
+                    thingId: "factory.line-a:reactor-1"
+                    feature: "advisory_maintenance"
+                    property: "window"
+                    signalTag: "MAINT"
+                audit:
+                  localAuditFile: "/tmp/ditto-audit.jsonl"
+                """;
+        DittoBridgeConfig cfg = DittoBridgeConfigLoader.load(yaml);
+        assertEquals("advisory_maintenance", cfg.writes().get(0).feature());
+    }
+
+    /** AUTONOMOUS rejected at config — the bridge ceiling is ADVISORY. */
+    @Test
+    void rejectsAutonomousMode() {
+        String yaml = """
+                connection:
+                  baseUrl: "https://ditto.factory.local"
+                audit:
+                  localAuditFile: "/tmp/ditto-audit.jsonl"
+                perTagSafetyMode:
+                  X: AUTONOMOUS
+                """;
+        Exception e = assertThrows(Exception.class, () -> DittoBridgeConfigLoader.load(yaml));
+        Throwable t = e;
+        while (t != null && (t.getMessage() == null || !t.getMessage().contains("ADVISORY"))) {
+            t = t.getCause();
+        }
+        assertNotNull(t, "expected the failure to mention the ADVISORY ceiling");
+    }
+
+    /** 00-FRAMEWORK §3: typos in config must fail loading. */
+    @Test
+    void rejectsUnknownProperty() {
+        String yaml = """
+                connection:
+                  baseUrl: "https://ditto.factory.local"
+                  thisFieldDoesNotExist: 42
+                audit:
+                  localAuditFile: "/tmp/ditto-audit.jsonl"
+                """;
+        assertThrows(Exception.class, () -> DittoBridgeConfigLoader.load(yaml));
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoBridgeIntegrationTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/DittoBridgeIntegrationTest.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ditto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import com.rakovpublic.jneuropallium.worker.net.layers.IResult;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.Quality;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the Eclipse Ditto bridge. Covers the universal
+ * 00-FRAMEWORK §5 scenarios that apply (S1, S3, S4, S5, S6) plus the
+ * bridge-specific scenarios S7–S11 from 10-DITTO.md §8. Runs against
+ * {@link InMemoryDittoTransport} — no Ditto sandbox required.
+ */
+class DittoBridgeIntegrationTest {
+
+    @TempDir Path tempDir;
+
+    private InMemoryDittoTransport transport;
+    private DittoAuditOutput audit;
+    private DittoClientService svc;
+    private DittoSignalMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        transport = new InMemoryDittoTransport();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (svc != null) svc.close();
+        if (audit != null) audit.close();
+    }
+
+    /* ===== framework universal scenarios ====================================== */
+
+    /** S1 / S7: a feature-property modify event delivers a typed {@link MeasurementSignal}. */
+    @Test
+    void s1_propertyModifiedEmitsMeasurementSignal() throws Exception {
+        DittoBridgeConfig cfg = baseConfig(
+                List.of(read("PUMP1-VIB", "factory.line-a:pump-1", "vibration", "rms_z",
+                        "PUMP01.VIB.Z")),
+                List.of());
+        bring(cfg);
+
+        deliverPropertyModified("factory.line-a:pump-1", "vibration", "rms_z", 4.2);
+
+        List<IInputSignal> signals = svc.drainMeasurements("PUMP1-VIB");
+        assertEquals(1, signals.size());
+        MeasurementSignal m = (MeasurementSignal) signals.get(0);
+        assertEquals("PUMP01.VIB.Z", m.getTag());
+        assertEquals(4.2, m.getMeasurement(), 0.0001);
+        assertEquals(Quality.GOOD, m.getQuality());
+    }
+
+    /** S3: SHADOW mode rejects writes with the SHADOW_MODE audit reason. */
+    @Test
+    void s3_shadowModeRejectsWrite() throws Exception {
+        DittoBridgeConfig cfg = baseConfig(
+                List.of(),
+                List.of(write("REACTOR1-ADVISED-SP", "factory.line-a:reactor-1",
+                        "recommended_setpoint", "value", "REACTOR01.SP.ADV", null, null)),
+                Map.of("REACTOR1-ADVISED-SP", BridgeSafetyMode.SHADOW));
+        bring(cfg);
+
+        DittoAdvisoryOutputAggregator agg = new DittoAdvisoryOutputAggregator(svc, audit);
+        agg.save(List.of(result(setpoint("REACTOR01.SP.ADV", 50.0))),
+                System.currentTimeMillis(), 1L, null);
+
+        assertTrue(transport.puts().isEmpty(), "SHADOW mode must not write to Ditto");
+        String log = Files.readString(tempDir.resolve("ditto-audit.jsonl"));
+        assertTrue(log.contains("SHADOW_MODE"), "expected a SHADOW_MODE audit, got: " + log);
+    }
+
+    /** S4 / S11: reconnect drops the alive cache and emits a {@code BRIDGE_RECONNECTED} event. */
+    @Test
+    void s4_reconnectClearsCacheAndEmitsAdvisoryEvent() throws Exception {
+        DittoBridgeConfig cfg = baseConfig(
+                List.of(read("PUMP1-VIB", "factory.line-a:pump-1", "vibration", "rms_z",
+                        "PUMP01.VIB.Z")),
+                List.of());
+        bring(cfg);
+
+        assertTrue(svc.isThingAlive("factory.line-a:pump-1"));
+        // Mark thing offline first to give the reconnect something to clear-and-restore.
+        deliverThingDeleted("factory.line-a:pump-1");
+        assertFalse(svc.isThingAlive("factory.line-a:pump-1"));
+
+        svc.onReconnected();
+        // After reconnect, the alive set is restored from configured things.
+        assertTrue(svc.isThingAlive("factory.line-a:pump-1"));
+
+        List<IInputSignal> events = svc.drainEvents();
+        assertTrue(events.stream().anyMatch(e ->
+                e instanceof AlarmSignal a
+                        && DittoClientService.BRIDGE_RECONNECTED.equals(a.getConditionCode())));
+    }
+
+    /** S5: an unwritable audit file does not crash the bridge — degraded mode persists. */
+    @Test
+    void s5_auditFailureDoesNotKillBridge() throws Exception {
+        Path file = tempDir.resolve("ditto-audit.jsonl");
+        Files.writeString(file, "");
+        DittoAuditOutput output = new DittoAuditOutput(file);
+        output.close();
+        // append() on a closed sink falls back to degraded; no exception expected.
+        assertDoesNotThrow(() -> output.append(new com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord(
+                System.currentTimeMillis(), 1, "ditto",
+                com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord.Verdict.APPLIED,
+                "X", "X.tag", null, null, null, null, List.of())));
+    }
+
+    /** S6: an aggregator that receives a command for an unknown tag audits {@code UNKNOWN_TAG}. */
+    @Test
+    void s6_unknownTagRejected() throws Exception {
+        DittoBridgeConfig cfg = baseConfig(
+                List.of(),
+                List.of(write("OK", "factory.line-a:reactor-1",
+                        "recommended_setpoint", "value", "KNOWN.TAG", null, null)));
+        bring(cfg);
+
+        DittoAdvisoryOutputAggregator agg = new DittoAdvisoryOutputAggregator(svc, audit);
+        agg.save(List.of(result(setpoint("UNKNOWN.TAG", 1.0))),
+                System.currentTimeMillis(), 1L, null);
+
+        assertTrue(transport.puts().isEmpty());
+        String log = Files.readString(tempDir.resolve("ditto-audit.jsonl"));
+        assertTrue(log.contains("UNKNOWN_TAG"), "audit should mention UNKNOWN_TAG: " + log);
+    }
+
+    /* ===== bridge-specific scenarios ========================================== */
+
+    /** S7: bridge connects and emits a MeasurementSignal per configured feature. */
+    @Test
+    void s7_connectAndEmitSignal() throws Exception {
+        DittoBridgeConfig cfg = baseConfig(
+                List.of(read("REACTOR1-TEMP", "factory.line-a:reactor-1", "temperature",
+                        "current", "REACTOR01.TEMP")),
+                List.of());
+        bring(cfg);
+
+        deliverPropertyModified("factory.line-a:reactor-1", "temperature", "current", 73.5);
+        List<IInputSignal> sigs = svc.drainMeasurements("REACTOR1-TEMP");
+        assertEquals(1, sigs.size());
+        assertEquals(73.5, ((MeasurementSignal) sigs.get(0)).getMeasurement(), 0.0001);
+    }
+
+    /** S8: a twin update via the REST API surfaces as a property-modified event in the same shape. */
+    @Test
+    void s8_twinUpdateReflectsInCache() throws Exception {
+        DittoBridgeConfig cfg = baseConfig(
+                List.of(read("R", "factory.line-a:reactor-1", "temperature", "current", "R.TAG")),
+                List.of());
+        bring(cfg);
+
+        deliverPropertyModified("factory.line-a:reactor-1", "temperature", "current", 50.0);
+        deliverPropertyModified("factory.line-a:reactor-1", "temperature", "current", 60.0);
+        List<IInputSignal> sigs = svc.drainMeasurements("R");
+        assertEquals(2, sigs.size());
+        assertEquals(60.0, ((MeasurementSignal) sigs.get(1)).getMeasurement(), 0.0001);
+    }
+
+    /** S9: a non-advisory write binding is rejected at config-load. */
+    @Test
+    void s9_configLoadRejectsNonAdvisoryWrite() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> baseConfig(
+                        List.of(),
+                        List.of(write("BAD", "factory.line-a:reactor-1",
+                                "setpoint", "value", "BAD.TAG", null, null))));
+        assertTrue(ex.getMessage().contains("advisory feature"),
+                "Expected the loader/config to mention the advisory rule, got: " + ex.getMessage());
+    }
+
+    /**
+     * S10: when a configured thing is deleted upstream, the bridge emits
+     * {@code AlarmSignal(TWIN_OFFLINE)} and subsequent reads of any of its
+     * features carry {@link Quality#UNCERTAIN}.
+     */
+    @Test
+    void s10_thingDeletedAlarmAndUncertainQuality() throws Exception {
+        DittoBridgeConfig cfg = baseConfig(
+                List.of(read("PUMP1-VIB", "factory.line-a:pump-1", "vibration", "rms_z",
+                        "PUMP01.VIB.Z")),
+                List.of());
+        bring(cfg);
+
+        deliverThingDeleted("factory.line-a:pump-1");
+        List<IInputSignal> events = svc.drainEvents();
+        assertTrue(events.stream().anyMatch(s ->
+                s instanceof AlarmSignal a
+                        && DittoClientService.TWIN_OFFLINE.equals(a.getConditionCode())));
+        assertFalse(svc.isThingAlive("factory.line-a:pump-1"));
+
+        // A subsequent property modify is ingested with UNCERTAIN quality.
+        deliverPropertyModified("factory.line-a:pump-1", "vibration", "rms_z", 4.2);
+        List<IInputSignal> sigs = svc.drainMeasurements("PUMP1-VIB");
+        assertEquals(1, sigs.size());
+        assertEquals(Quality.UNCERTAIN, ((MeasurementSignal) sigs.get(0)).getQuality());
+    }
+
+    /** S11: reconnect re-arms subscriptions and emits an advisory event. */
+    @Test
+    void s11_reconnectEmitsAdvisoryEvent() throws Exception {
+        DittoBridgeConfig cfg = baseConfig(
+                List.of(read("PUMP1-VIB", "factory.line-a:pump-1", "vibration", "rms_z",
+                        "PUMP01.VIB.Z")),
+                List.of());
+        bring(cfg);
+
+        svc.onReconnected();
+        List<IInputSignal> events = svc.drainEvents();
+        assertTrue(events.stream().anyMatch(s ->
+                s instanceof AlarmSignal a
+                        && DittoClientService.BRIDGE_RECONNECTED.equals(a.getConditionCode())));
+    }
+
+    /** ADVISORY mode writes the recommended-feature property and audits APPLIED with clamping. */
+    @Test
+    void advisoryWriteAppliesAndClamps() throws Exception {
+        DittoBridgeConfig cfg = baseConfig(
+                List.of(),
+                List.of(write("REACTOR1-ADVISED-SP", "factory.line-a:reactor-1",
+                        "recommended_setpoint", "value", "REACTOR01.SP.ADV", 0.0, 100.0)));
+        bring(cfg);
+
+        DittoAdvisoryOutputAggregator agg = new DittoAdvisoryOutputAggregator(svc, audit);
+        // 250.0 must be clamped to 100.0.
+        agg.save(List.of(result(setpoint("REACTOR01.SP.ADV", 250.0))),
+                System.currentTimeMillis(), 1L, null);
+
+        List<InMemoryDittoTransport.Put> puts = transport.puts();
+        assertEquals(1, puts.size());
+        InMemoryDittoTransport.Put put = puts.get(0);
+        assertEquals("recommended_setpoint", put.feature());
+        assertEquals("value", put.property());
+        // Body is a JSON scalar — extract and check.
+        JsonNode body = new ObjectMapper().readTree(put.body());
+        assertEquals(100.0, body.asDouble(), 0.0001);
+
+        String log = Files.readString(tempDir.resolve("ditto-audit.jsonl"));
+        assertTrue(log.contains("APPLIED"), "expected APPLIED audit; got: " + log);
+        assertTrue(log.contains("CLAMPED_HIGH"), "expected CLAMPED_HIGH reason; got: " + log);
+    }
+
+    /** A representative APPLIED audit line conforms to the universal §4 schema. */
+    @Test
+    void auditLineConformsToFrameworkSchema() throws Exception {
+        DittoBridgeConfig cfg = baseConfig(
+                List.of(),
+                List.of(write("S", "factory.line-a:reactor-1",
+                        "advisory_value", "x", "S.tag", null, null)));
+        bring(cfg);
+
+        DittoAdvisoryOutputAggregator agg = new DittoAdvisoryOutputAggregator(svc, audit);
+        agg.save(List.of(result(setpoint("S.tag", 1.0))), 100L, 7L, null);
+
+        String log = Files.readString(tempDir.resolve("ditto-audit.jsonl")).trim();
+        String[] lines = log.split("\n");
+        JsonNode line = new ObjectMapper().readTree(lines[lines.length - 1]);
+        assertEquals(7, line.get("run").asLong());
+        assertEquals("ditto", line.get("bridge").asText());
+        assertEquals("APPLIED", line.get("verdict").asText());
+        assertEquals("S.tag", line.get("tag").asText());
+    }
+
+    /* ===== helpers ============================================================ */
+
+    private DittoBridgeConfig baseConfig(
+            List<DittoBridgeConfig.ReadBindingConfig> reads,
+            List<DittoBridgeConfig.WriteBindingConfig> writes) {
+        return baseConfig(reads, writes, Map.of());
+    }
+
+    private DittoBridgeConfig baseConfig(
+            List<DittoBridgeConfig.ReadBindingConfig> reads,
+            List<DittoBridgeConfig.WriteBindingConfig> writes,
+            Map<String, BridgeSafetyMode> perTag) {
+        DittoBridgeConfig.ConnectionConfig conn = new DittoBridgeConfig.ConnectionConfig(
+                "https://ditto.local", "/ws/2", "/api/2",
+                Duration.ofSeconds(5), 10_000);
+        return new DittoBridgeConfig(
+                conn,
+                null,
+                List.of(),
+                reads, writes,
+                new DittoBridgeConfig.AuditConfig(tempDir.resolve("ditto-audit.jsonl").toString()),
+                perTag,
+                Map.of(),
+                Duration.ofMillis(250));
+    }
+
+    private DittoBridgeConfig.ReadBindingConfig read(String id, String thingId,
+                                                     String feature, String property,
+                                                     String tag) {
+        return new DittoBridgeConfig.ReadBindingConfig(
+                id, thingId, feature, property, tag,
+                DittoBridgeConfig.ReadSignalKind.MEASUREMENT);
+    }
+
+    private DittoBridgeConfig.WriteBindingConfig write(String id, String thingId,
+                                                       String feature, String property,
+                                                       String tag,
+                                                       Double min, Double max) {
+        return new DittoBridgeConfig.WriteBindingConfig(
+                id, thingId, feature, property, tag, min, max);
+    }
+
+    private SetpointSignal setpoint(String tag, double value) {
+        SetpointSignal s = new SetpointSignal();
+        s.setTag(tag);
+        s.setSetpoint(value);
+        return s;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private IResult result(IResultSignal sig) {
+        return new IResult<IResultSignal>() {
+            @Override public IResultSignal getResult() { return sig; }
+            @Override public Long getNeuronId() { return 42L; }
+        };
+    }
+
+    private void bring(DittoBridgeConfig cfg) {
+        audit = new DittoAuditOutput(tempDir.resolve("ditto-audit.jsonl"));
+        mapper = new DittoSignalMapper(cfg);
+        svc = new DittoClientService(cfg, transport, mapper, audit);
+        svc.start();
+    }
+
+    private void deliverPropertyModified(String thingId, String feature, String property, double value) {
+        // Build a minimal Ditto-protocol envelope: { topic, path, value, timestamp }.
+        String[] parts = thingId.split(":", 2);
+        String topic = parts[0] + "/" + parts[1] + "/things/twin/events/modified";
+        String json = "{"
+                + "\"topic\":\"" + topic + "\","
+                + "\"path\":\"/features/" + feature + "/properties/" + property + "\","
+                + "\"value\":" + value
+                + "}";
+        transport.deliver(new DittoTransport.TwinEvent(
+                DittoTransport.EventType.FEATURE_PROPERTY_MODIFIED, thingId, feature,
+                json.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private void deliverThingDeleted(String thingId) {
+        String[] parts = thingId.split(":", 2);
+        String topic = parts[0] + "/" + parts[1] + "/things/twin/events/deleted";
+        String json = "{"
+                + "\"topic\":\"" + topic + "\","
+                + "\"path\":\"/\""
+                + "}";
+        transport.deliver(new DittoTransport.TwinEvent(
+                DittoTransport.EventType.THING_DELETED, thingId, null,
+                json.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/InMemoryDittoTransport.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/ditto/InMemoryDittoTransport.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ditto;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Pure-Java in-memory {@link DittoTransport} for the Ditto-bridge integration
+ * tests. Runs without a Ditto sandbox; mirrors enough of Ditto's protocol
+ * semantics to validate the §8 scenarios in 10-DITTO.md.
+ *
+ * <ul>
+ *   <li>{@link #deliver(DittoTransport.TwinEvent)} pushes a twin event into the
+ *       configured handler.</li>
+ *   <li>{@link #failNextPut(int)} flips the PUT path to throw N times — used
+ *       to test {@code WRITE_ERROR} audit paths.</li>
+ *   <li>{@link #puts()} returns every PUT issued via
+ *       {@link #putFeatureProperty(String, String, String, byte[])}, so tests
+ *       assert on the advisory traffic.</li>
+ * </ul>
+ */
+public final class InMemoryDittoTransport implements DittoTransport {
+
+    public record Put(String thingId, String feature, String property, byte[] body) {}
+
+    private EventHandler handler;
+    private boolean connected;
+    private final List<String> subscriptions = new ArrayList<>();
+    private final List<Put> puts = new ArrayList<>();
+    private final Map<String, byte[]> snapshots = new LinkedHashMap<>();
+    private final AtomicLong putFailsRemaining = new AtomicLong();
+
+    @Override public synchronized void connect() { connected = true; }
+    @Override public synchronized void setHandler(EventHandler h) { this.handler = h; }
+    @Override public synchronized boolean isConnected() { return connected; }
+    @Override public synchronized void subscribe(String thingId) { subscriptions.add(thingId); }
+
+    @Override
+    public synchronized boolean putFeatureProperty(String thingId, String feature, String property, byte[] body) {
+        if (putFailsRemaining.get() > 0) {
+            putFailsRemaining.decrementAndGet();
+            throw new DittoTransportException("simulated PUT failure on " + thingId + "/" + feature + "/" + property);
+        }
+        puts.add(new Put(thingId, feature, property, Arrays.copyOf(body, body.length)));
+        snapshots.put(thingId + "/" + feature + "/" + property, Arrays.copyOf(body, body.length));
+        return true;
+    }
+
+    @Override
+    public synchronized byte[] getFeatureProperty(String thingId, String feature, String property) {
+        byte[] v = snapshots.get(thingId + "/" + feature + "/" + property);
+        return v == null ? null : Arrays.copyOf(v, v.length);
+    }
+
+    @Override
+    public synchronized void close() { connected = false; }
+
+    /* ===== test helpers ====================================================== */
+
+    public synchronized void deliver(TwinEvent event) {
+        EventHandler h = this.handler;
+        if (h == null) return;
+        // Only deliver to subscribed things — mirrors START-SEND-EVENTS behaviour.
+        if (!subscriptions.contains(event.thingId())) return;
+        h.onEvent(event);
+    }
+
+    public void failNextPut(int n) { putFailsRemaining.set(n); }
+
+    public synchronized List<Put> puts() { return new ArrayList<>(puts); }
+
+    public synchronized int subscriptionCount() { return subscriptions.size(); }
+
+    public synchronized void disconnect() { connected = false; }
+}


### PR DESCRIPTION
Read flow: WebSocket twin events → MeasurementSignal / AlarmSignal per configured thingId/feature/property binding. Things flagged offline (after THING_DELETED) yield Quality.UNCERTAIN on subsequent reads.

Write flow: SetpointSignal → REST PUT against the twin's recommended_*/ advisory_* feature property only. The advisory-prefix rule is enforced at config load (compact constructor) and re-checked at runtime in DittoClientService.writeProperty for defence-in-depth. AUTONOMOUS per-tag promotion is rejected by the loader; the structural ceiling is ADVISORY.

Production transport uses the JDK's built-in HttpClient + WebSocket so the bridge does not need to pull org.eclipse.ditto:ditto-client (and its Akka classic transitive deps); tests inject InMemoryDittoTransport.

https://claude.ai/code/session_01NigNBeZtuP4hTMeA15qTHD