### PR TITLE
Implement ROS 2 / DDS bridge (04-ROS2-DDS.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ every loop.
 | 01 | Apache PLC4X | legacy PLC | shipped | AUTONOMOUS (per-loop) |
 | 02 | MQTT + Sparkplug | IIoT | shipped | ADVISORY |
 | 03 | FMI / FMU | simulation | shipped | AUTONOMOUS (sim only) |
-| 04 | ROS 2 / DDS | robotics | spec | ADVISORY initially |
+| 04 | ROS 2 / DDS | robotics | shipped | ADVISORY initially |
 | 05 | Lab Streaming Layer | BCI | spec | ADVISORY (read-mostly) |
 | 06 | HL7 FHIR | clinical | spec | ADVISORY (regulatory ceiling) |
 | 07 | DICOM | medical imaging | spec | READ-ONLY (context bridge) |
@@ -252,6 +252,23 @@ decisions to a configurable advisory namespace consumed by the operator HMI
 `AUTONOMOUS` per-tag promotion is rejected by the config validator. See
 [`docs/mqtt-bridge.md`](docs/mqtt-bridge.md) and
 [`02-MQTT-SPARKPLUG.md`](02-MQTT-SPARKPLUG.md).
+
+### ROS 2 / DDS bridge
+
+For robotics and swarm deployments the ROS 2 bridge subscribes to
+`rosbridge_suite` over WebSocket and emits typed
+`SensorySignal` / `ProprioceptiveSignal` / `EfficiencySignal` /
+`PeerObservationSignal` instances per configured topic binding. The
+egress side publishes neuron-derived
+`MotorCommandSignal` / `FormationSignal` / `HarmVetoSignal` decisions to
+a configurable advisory namespace that an external autonomy supervisor
+consumes — never directly to `/cmd_vel`, `/joint_trajectory`, or
+`/joint_command` in production. The forbidden-topic rule is enforced
+both at config load and at runtime; per-tag `AUTONOMOUS` promotion is
+rejected unless `simulatorOnly: true` is set, which models the
+simulator-with-watchdog escape from the spec's §3. See
+[`docs/ros2-bridge.md`](docs/ros2-bridge.md) and
+[`04-ROS2-DDS.md`](04-ROS2-DDS.md).
 
 ### Eclipse Ditto bridge
 

--- a/docs/ros2-bridge.md
+++ b/docs/ros2-bridge.md
@@ -1,0 +1,136 @@
+# ROS 2 / DDS bridge
+
+> Companion to [`04-ROS2-DDS.md`](../04-ROS2-DDS.md) (the spec) and
+> [`00-FRAMEWORK.md`](../00-FRAMEWORK.md) (the universal contract). This file
+> documents the ROS 2 bridge's domain context, YAML schema, manual demo
+> procedure, and regulatory posture — i.e. the §10 Definition-of-Done items
+> that don't belong in the spec itself.
+
+## Domain context
+
+[ROS 2](https://docs.ros.org/) is the dominant middleware for modern
+robotics; its standard transport is
+[DDS](https://www.dds-foundation.org/) (Data Distribution Service). The
+bridge implements **Strategy B** from the spec: a thin
+JSON-over-WebSocket adapter on top of
+[`rosbridge_suite`](https://github.com/RobotWebTools/rosbridge_suite),
+backed by the JDK's built-in `java.net.http.WebSocket`. **Strategy A**
+(an embedded `rcljava` client) is left as a feature flag in
+`RcljavaClientService` and is not built into the v1 worker jar.
+
+The bridge is **advisory-only** by construction (04-ROS2-DDS.md §3): it
+subscribes to perception, proprioception and battery topics, emits typed
+`SensorySignal` / `ProprioceptiveSignal` / `EfficiencySignal` /
+`PeerObservationSignal` instances, and publishes neuron-derived
+`MotorCommandSignal` / `FormationSignal` / `HarmVetoSignal` decisions
+to a configurable advisory namespace consumed by an external autonomy
+supervisor — never directly to `/cmd_vel`, `/joint_trajectory`, or
+`/joint_command` in production. The forbidden-topic rule is enforced
+both at config load (in `Ros2BridgeConfig`) and at runtime (in
+`Ros2ClientService.publish`); per-tag `AUTONOMOUS` promotion is rejected
+unless `simulatorOnly: true` is set, which models the
+simulator-with-watchdog escape from §3.
+
+## Components
+
+```
+worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/
+├── Ros2BridgeConfig.java               ← YAML record (immutable, /cmd_vel rejected)
+├── Ros2BridgeConfigLoader.java         ← Jackson YAML loader, FAIL_ON_UNKNOWN
+├── Ros2TopicBinding.java               ← read/write binding (BridgeBinding)
+├── Ros2MessageMapper.java              ← ROS 2 JSON ↔ typed signal (pure)
+├── Ros2Transport.java                  ← test-seam interface
+├── RosbridgeTransport.java             ← Strategy B (rosbridge over JDK WebSocket)
+├── RcljavaClientService.java           ← Strategy A placeholder (feature flag)
+├── Ros2ClientService.java              ← lifecycle, latest cache, decimation, payload caps
+├── Ros2SensoryInput.java               ← IInitInput → SensorySignal/PeerObservationSignal/AlarmSignal
+├── Ros2StateInput.java                 ← IInitInput → ProprioceptiveSignal/EfficiencySignal
+├── Ros2AuditOutput.java                ← local JSONL audit + optional ROS 2 mirror topic
+├── Ros2AdvisoryOutputAggregator.java   ← IOutputAggregator (advisory publish only, with clamps)
+└── package-info.java
+```
+
+## YAML schema
+
+Refer to 04-ROS2-DDS.md §7 for the canonical example. Key points:
+
+* `mode: ROSBRIDGE` (default) selects Strategy B; `RCLJAVA` selects
+  Strategy A and currently fails fast since the dependency is not built
+  in.
+* `rosbridgeUrl` is the rosbridge_websocket URL (e.g.
+  `ws://localhost:9090`). Required for `ROSBRIDGE` mode.
+* `simulatorOnly: false` forbids `writes` whose `topic` is `/cmd_vel`,
+  `/joint_trajectory`, or `/joint_command`. Setting it to `true`
+  unlocks them — only do that when (a) the topics are namespaced under a
+  simulator (Gazebo, Ignition, Webots), and (b) an external watchdog
+  node will kill the bridge if heartbeats stop.
+* Each `read` binding maps one ROS 2 topic to one signal class. The
+  signal class is inferred from `msgType` if `signalKind` is not set:
+  - `nav_msgs/msg/Odometry` → `ProprioceptiveSignal` (or
+    `PeerObservationSignal` when `asPeerObservation: true`)
+  - `sensor_msgs/msg/JointState` → `ProprioceptiveSignal`
+  - `sensor_msgs/msg/LaserScan` → `SensorySignal` (`maxRangeBins`
+    downsamples)
+  - `sensor_msgs/msg/Image` / `CompressedImage` → `SensorySignal`
+    (the bus carries a hash, never bytes — §5)
+  - `sensor_msgs/msg/BatteryState` → `EfficiencySignal`
+* `decimateBy` drops all but every Nth message at the binding (S10).
+* `maxPayloadBytes` drops oversized messages with one audit entry per
+  minute per binding (§10 R3).
+* Each `write` binding clamps to `[minClampValue, maxClampValue]` and
+  rate-limits to `rampRateMaxPerSec`. The aggregator currently clamps
+  the dominant linear-x axis on a `Twist`; for other shapes it clamps
+  the L2 magnitude.
+
+## Manual demo (turtlesim)
+
+Phase 1 acceptance test for the bridge follows §10 S7. Outside of
+unit/integration tests, the manual demo is:
+
+```bash
+# 1. Bring up rosbridge_server and turtlesim in a ROS 2 (humble/iron/jazzy)
+#    environment.
+ros2 run rosbridge_server rosbridge_websocket
+ros2 run turtlesim turtlesim_node
+
+# 2. Point the bridge at the WS endpoint and bind /turtle1/pose.
+cat <<EOF > /tmp/ros2-bridge.yaml
+mode: ROSBRIDGE
+rosbridgeUrl: "ws://localhost:9090"
+simulatorOnly: true
+reads:
+  - bindingId: TURTLE-POSE
+    topic: /turtle1/pose
+    msgType: turtlesim/msg/Pose
+    signalTag: TURTLE.T1.POSE
+audit:
+  localAuditFile: /tmp/jneopallium/ros2-audit.jsonl
+EOF
+
+# 3. Run a small Java program that loads the config, builds
+#    Ros2ClientService + Ros2SensoryInput/Ros2StateInput, and prints the
+#    signals it drains each tick. After ~2s the cache should contain
+#    ProprioceptiveSignal instances reflecting turtle1's pose.
+```
+
+## Regulatory posture
+
+The bridge ceiling is `ADVISORY` (04-ROS2-DDS.md §3). A robot can hurt
+people: the bridge does **not** publish to a `cmd_vel`, `joint_trajectory`,
+or `joint_command` topic in any production environment. The intended
+steady state is:
+
+* Bridge subscribes to perception / proprioception / battery topics →
+  produces typed signals.
+* Jneopallium swarm/planning module reasons over them.
+* Bridge publishes to `mission_advice` / `formation_advisory` /
+  `safety_veto` topics that an external **autonomy supervisor**
+  consumes. The supervisor decides whether to hand the advice to
+  actuators.
+
+Direct `cmd_vel` publication is supported only against
+`simulatorOnly: true`, in which case the operator runbook MUST
+document the watchdog node that kills the bridge on a heartbeat
+failure. Document `ROS_DOMAIN_ID` and `ROS_LOCALHOST_ONLY=1` in the
+operator runbook to prevent DDS multicast leaking topics across
+machines (§11 R2).

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/ai/signals/BaseSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/ai/signals/BaseSignal.java
@@ -1,9 +1,10 @@
 package com.rakovpublic.jneuropallium.ai.signals;
 
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
-public abstract class BaseSignal extends AbstractSignal<Void> {
+public abstract class BaseSignal extends AbstractSignal<Void> implements IResultSignal<Void> {
 
     public BaseSignal() {
         super();
@@ -17,6 +18,12 @@ public abstract class BaseSignal extends AbstractSignal<Void> {
 
     @Override
     public Class<Void> getParamClass() { return Void.class; }
+
+    @Override
+    public Void getResultObject() { return null; }
+
+    @Override
+    public Class<Void> getResultObjectClass() { return Void.class; }
 
     @Override
     public String toJSON() { return "{}"; }

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/ai/signals/fast/SensorySignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/ai/signals/fast/SensorySignal.java
@@ -1,9 +1,10 @@
 package com.rakovpublic.jneuropallium.ai.signals.fast;
 
 import com.rakovpublic.jneuropallium.ai.signals.BaseSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
-public class SensorySignal extends BaseSignal {
+public class SensorySignal extends BaseSignal implements IInputSignal<Void> {
     private double[] rawValues;
     private String sensorId;
     private long timestamp;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/RcljavaClientService.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/RcljavaClientService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ros2;
+
+/**
+ * Strategy A — embedded {@code rcljava} client (04-ROS2-DDS.md §1, §2).
+ *
+ * <p>Strategy A is opt-in (§9 Phase 3) and lives behind a feature flag.
+ * The community-maintained {@code rcljava} dependency is not pulled into
+ * the worker module at v1; this class is a placeholder so the package
+ * layout in §8 is complete and so {@link Ros2BridgeConfig.TransportMode#RCLJAVA}
+ * can compile-link to a sentinel rather than break loading.
+ *
+ * <p>To finish Strategy A: add the {@code org.ros2:rcljava} dependency,
+ * implement {@link Ros2Transport} on top of {@code rcljava} {@code Node} and
+ * {@code Subscription} primitives, and bridge the {@code domainId} +
+ * {@code qosProfile} fields onto the {@code QoSProfile} struct.
+ *
+ * <p>Until then, instantiating this class throws
+ * {@link UnsupportedOperationException} so the bridge fails fast at start
+ * rather than silently fall back to no-op.
+ */
+public final class RcljavaClientService {
+
+    /** Sentinel: feature is not built into the v1 worker jar. */
+    public RcljavaClientService(Ros2BridgeConfig config) {
+        if (config != null && config.mode() == Ros2BridgeConfig.TransportMode.RCLJAVA) {
+            throw new UnsupportedOperationException(
+                    "Strategy A (rcljava) not yet built into the worker jar; see 04-ROS2-DDS.md §9 Phase 3");
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2AdvisoryOutputAggregator.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2AdvisoryOutputAggregator.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ros2;
+
+import com.rakovpublic.jneuropallium.ai.signals.fast.HarmVetoSignal;
+import com.rakovpublic.jneuropallium.ai.signals.fast.MotorCommandSignal;
+import com.rakovpublic.jneuropallium.ai.signals.fast.TransparencyLogSignal;
+import com.rakovpublic.jneuropallium.worker.application.IOutputAggregator;
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import com.rakovpublic.jneuropallium.worker.net.layers.IResult;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.FormationSignal;
+import com.rakovpublic.jneuropallium.worker.util.IContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IOutputAggregator} for the ROS 2 advisory egress (04-ROS2-DDS.md §3,
+ * §5 egress table).
+ *
+ * <p>Per §3 the bridge's structural ceiling is {@code ADVISORY}: outbound
+ * traffic goes only to a configurable advisory namespace consumed by the
+ * external autonomy supervisor. The §0.1–§0.3 chain still runs at the
+ * tag-level: {@code SHADOW} suppresses publication, and only an
+ * {@link MotorCommandSignal} carrying {@code execute=true} is forwarded.
+ *
+ * <p>Signal handling:
+ * <ul>
+ *   <li>{@link MotorCommandSignal} → encoded as the binding's {@code msgType}
+ *       (typically {@code geometry_msgs/msg/Twist}), clamped on the linear/x
+ *       axis when configured.</li>
+ *   <li>{@link FormationSignal} → publish slot index as a tiny JSON.</li>
+ *   <li>{@link HarmVetoSignal} → publish veto reason on a {@code std_msgs/msg/String}.</li>
+ *   <li>{@link TransparencyLogSignal} → publish to {@code audit.advisoryAuditTopic}
+ *       when configured (the bridge's audit-mirror channel).</li>
+ * </ul>
+ *
+ * <p>{@code AUTONOMOUS} per-tag promotion is rejected by
+ * {@link Ros2BridgeConfig}'s constructor unless {@code simulatorOnly} is
+ * set; this aggregator only differentiates {@code SHADOW} (drop) from
+ * {@code ADVISORY} / {@code AUTONOMOUS} (publish) at runtime.
+ */
+public final class Ros2AdvisoryOutputAggregator implements IOutputAggregator {
+
+    private static final Logger log = LoggerFactory.getLogger(Ros2AdvisoryOutputAggregator.class);
+
+    private final Ros2ClientService svc;
+    private final AbstractBridgeAuditOutput audit;
+    private final Ros2BridgeConfig config;
+    private final Ros2MessageMapper mapper;
+
+    public Ros2AdvisoryOutputAggregator(Ros2ClientService svc,
+                                        AbstractBridgeAuditOutput audit) {
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.audit = Objects.requireNonNull(audit, "audit");
+        this.config = svc.config();
+        this.mapper = new Ros2MessageMapper();
+    }
+
+    @Override
+    public void save(List<IResult> results, long timestamp, long run, IContext context) {
+        if (results == null || results.isEmpty()) return;
+        for (IResult r : results) {
+            if (r == null) continue;
+            IResultSignal<?> s = r.getResult();
+            if (s == null) continue;
+            Long neuronId = r.getNeuronId();
+            try {
+                if (s instanceof MotorCommandSignal mc) {
+                    handleMotor(mc, timestamp, run, neuronId);
+                } else if (s instanceof FormationSignal fs) {
+                    handleFormation(fs, timestamp, run, neuronId);
+                } else if (s instanceof HarmVetoSignal hv) {
+                    handleVeto(hv, timestamp, run, neuronId);
+                } else if (s instanceof TransparencyLogSignal tl) {
+                    handleTransparency(tl, timestamp, run, neuronId);
+                }
+            } catch (RuntimeException ex) {
+                audit.append(new BridgeAuditRecord(
+                        timestamp, run, Ros2ClientService.BRIDGE_NAME,
+                        BridgeAuditRecord.Verdict.FAILED,
+                        null, null, null, null,
+                        BridgeAuditRecord.RejectReason.EXCEPTION + ":" + ex.getClass().getSimpleName(),
+                        null, evidence(neuronId)));
+            }
+        }
+    }
+
+    /* ===== command paths ====================================================== */
+
+    private void handleMotor(MotorCommandSignal mc, long ts, long run, Long neuronId) {
+        // §0.1: only forward when planning chain has set execute=true.
+        if (!mc.isExecute()) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, Ros2ClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    null, mc.getName(), magnitude(mc), null,
+                    BridgeAuditRecord.RejectReason.SHADOW_MODE,
+                    BridgeSafetyMode.SHADOW, evidence(neuronId)));
+            return;
+        }
+        String tag = mc.getName();
+        Ros2TopicBinding b = tag == null ? null : svc.writeBindingForTag(tag);
+        if (b == null) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, Ros2ClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    null, tag, magnitude(mc), null,
+                    BridgeAuditRecord.RejectReason.UNKNOWN_TAG, null, evidence(neuronId)));
+            return;
+        }
+
+        BridgeSafetyMode mode = config.perTagSafetyMode()
+                .getOrDefault(b.bindingId(), BridgeSafetyMode.ADVISORY);
+        if (mode == BridgeSafetyMode.SHADOW) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, Ros2ClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    b.loopId(), tag, magnitude(mc), null,
+                    BridgeAuditRecord.RejectReason.SHADOW_MODE, mode, evidence(neuronId)));
+            return;
+        }
+
+        // Clamp the dominant linear axis on a Twist; for other shapes, clamp the L2 magnitude.
+        double[] params = mc.getParams();
+        String modifyReason = null;
+        if (params != null && params.length > 0) {
+            double primary = params[0];
+            if (b.maxClampValue() != null && primary > b.maxClampValue()) {
+                params[0] = b.maxClampValue();
+                modifyReason = BridgeAuditRecord.ModifyReason.CLAMPED_HIGH;
+            } else if (b.minClampValue() != null && primary < b.minClampValue()) {
+                params[0] = b.minClampValue();
+                modifyReason = BridgeAuditRecord.ModifyReason.CLAMPED_LOW;
+            }
+            mc.setParams(params);
+        }
+
+        String json = encode(b, mc);
+        boolean ok = svc.publish(b.bindingId(), json, ts, run, tag);
+        if (ok) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, Ros2ClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.APPLIED,
+                    b.loopId(), tag, magnitude(mc), magnitude(mc),
+                    modifyReason, mode, evidence(neuronId)));
+        }
+    }
+
+    private String encode(Ros2TopicBinding b, MotorCommandSignal mc) {
+        return switch (b.msgType()) {
+            case "geometry_msgs/msg/Twist" -> mapper.encodeTwist(mc);
+            case "std_msgs/msg/Float64" -> mapper.encodeStdFloat64(magnitude(mc));
+            default -> mapper.encodeStdString("MotorCommand:" + b.signalTag());
+        };
+    }
+
+    private void handleFormation(FormationSignal fs, long ts, long run, Long neuronId) {
+        String tag = fs.getName();
+        Ros2TopicBinding b = tag == null ? null : svc.writeBindingForTag(tag);
+        if (b == null) return;
+        BridgeSafetyMode mode = config.perTagSafetyMode()
+                .getOrDefault(b.bindingId(), BridgeSafetyMode.ADVISORY);
+        if (mode == BridgeSafetyMode.SHADOW) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, Ros2ClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    b.loopId(), tag, (double) fs.getSlotIndex(), null,
+                    BridgeAuditRecord.RejectReason.SHADOW_MODE, mode, evidence(neuronId)));
+            return;
+        }
+        String body = "formation=" + fs.getTemplate() + " slot=" + fs.getSlotIndex();
+        boolean ok = svc.publish(b.bindingId(), mapper.encodeStdString(body), ts, run, tag);
+        if (ok) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, Ros2ClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.APPLIED,
+                    b.loopId(), tag, (double) fs.getSlotIndex(), (double) fs.getSlotIndex(),
+                    null, mode, evidence(neuronId)));
+        }
+    }
+
+    private void handleVeto(HarmVetoSignal hv, long ts, long run, Long neuronId) {
+        // The veto channel is highest-priority; bind by the signal's name (per §5).
+        String tag = hv.getName();
+        Ros2TopicBinding b = tag == null ? null : svc.writeBindingForTag(tag);
+        if (b == null) return;
+        BridgeSafetyMode mode = config.perTagSafetyMode()
+                .getOrDefault(b.bindingId(), BridgeSafetyMode.ADVISORY);
+        if (mode == BridgeSafetyMode.SHADOW) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, Ros2ClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    b.loopId(), tag, null, null,
+                    BridgeAuditRecord.RejectReason.SHADOW_MODE, mode, evidence(neuronId)));
+            return;
+        }
+        String reason = hv.getVetoReason() == null ? "VETO" : hv.getVetoReason();
+        boolean ok = svc.publish(b.bindingId(), mapper.encodeStdString(reason), ts, run, tag);
+        if (ok) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, Ros2ClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.APPLIED,
+                    b.loopId(), tag, null, null, null, mode, evidence(neuronId)));
+        }
+    }
+
+    private void handleTransparency(TransparencyLogSignal tl, long ts, long run, Long neuronId) {
+        if (config.audit() == null
+                || config.audit().advisoryAuditTopic() == null
+                || config.audit().advisoryAuditTopic().isBlank()) {
+            return;
+        }
+        String body = "actionPlan=" + tl.getActionPlanId() + " verdict=" + tl.getVerdict();
+        svc.publishRaw(config.audit().advisoryAuditTopic(), mapper.encodeStdString(body));
+        audit.append(new BridgeAuditRecord(
+                ts, run, Ros2ClientService.BRIDGE_NAME,
+                BridgeAuditRecord.Verdict.APPLIED,
+                null, "AUDIT", null, null, null, null, evidence(neuronId)));
+    }
+
+    /* ===== helpers ============================================================ */
+
+    private static Double magnitude(MotorCommandSignal mc) {
+        return mc == null ? null : mc.getMagnitudeEstimate();
+    }
+
+    private static List<String> evidence(Long neuronId) {
+        return neuronId == null ? List.of() : List.of(String.valueOf(neuronId));
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2AuditOutput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2AuditOutput.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ros2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+
+/**
+ * JSONL audit sink for the ROS 2 bridge (00-FRAMEWORK §4, §6;
+ * 04-ROS2-DDS.md §7 {@code audit.localAuditFile}).
+ *
+ * <p>If {@code audit.advisoryAuditTopic} is configured, each audit record is
+ * also published to that ROS 2 advisory topic (a {@code std_msgs/msg/String})
+ * via a {@link Ros2ClientService} supplied through
+ * {@link #attach(Ros2ClientService, String)}. The mirror is best-effort and
+ * never blocks the local file write.
+ */
+public final class Ros2AuditOutput extends AbstractBridgeAuditOutput {
+
+    private static final Logger log = LoggerFactory.getLogger(Ros2AuditOutput.class);
+    private static final ObjectMapper JSON =
+            new ObjectMapper().disable(SerializationFeature.INDENT_OUTPUT);
+
+    private Ros2ClientService svc;
+    private String topic;
+    private final Ros2MessageMapper mapper = new Ros2MessageMapper();
+
+    public Ros2AuditOutput(Path file) { super(file); }
+
+    /** Wire up the optional ROS 2 mirror channel. {@code topic == null} disables it. */
+    public synchronized void attach(Ros2ClientService svc, String topic) {
+        this.svc = svc;
+        this.topic = topic;
+    }
+
+    @Override
+    protected void mirror(BridgeAuditRecord record) {
+        Ros2ClientService s = this.svc;
+        String t = this.topic;
+        if (s == null || t == null || t.isBlank()) return;
+        try {
+            String body = JSON.writeValueAsString(record);
+            s.publishRaw(t, mapper.encodeStdString(body));
+        } catch (Exception e) {
+            log.debug("Audit ROS 2 mirror skipped: {}", e.getMessage());
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2BridgeConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2BridgeConfig.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ros2;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Top-level configuration for the ROS 2 / DDS bridge (04-ROS2-DDS.md §7).
+ * Loaded from YAML via {@link Ros2BridgeConfigLoader}. Immutable.
+ *
+ * <p>Per 04-ROS2-DDS.md §3 the structural ceiling is {@code ADVISORY}. The
+ * compact constructor enforces it: any per-tag promotion to
+ * {@code AUTONOMOUS} fails the load <i>unless</i> {@link #simulatorOnly()} is
+ * {@code true}, which models the simulator-with-watchdog escape.
+ *
+ * <p>The validator forbids any write binding whose topic matches one of the
+ * actuating topics in {@link #FORBIDDEN_WRITE_TOPICS} unless
+ * {@code simulatorOnly} is set; see §3 and §7.
+ */
+public record Ros2BridgeConfig(
+        TransportMode mode,
+        String rosbridgeUrl,
+        Integer domainId,
+        QosProfile qosProfile,
+        boolean simulatorOnly,
+        List<ReadBindingConfig> reads,
+        List<WriteBindingConfig> writes,
+        AuditConfig audit,
+        Map<String, BridgeSafetyMode> perTagSafetyMode,
+        Duration tickInterval
+) {
+
+    /**
+     * Topics whose write bindings are rejected unless {@link #simulatorOnly()}
+     * is {@code true}. These name actuators that the bridge MUST NOT drive
+     * directly in production (04-ROS2-DDS.md §3, §7).
+     */
+    public static final Set<String> FORBIDDEN_WRITE_TOPICS =
+            Set.of("/cmd_vel", "/joint_trajectory", "/joint_command");
+
+    public Ros2BridgeConfig {
+        Objects.requireNonNull(mode, "mode");
+        if (mode == TransportMode.ROSBRIDGE) {
+            Objects.requireNonNull(rosbridgeUrl, "rosbridgeUrl");
+        }
+        qosProfile = qosProfile == null ? QosProfile.SENSOR_DATA : qosProfile;
+        reads = reads == null ? List.of() : List.copyOf(reads);
+        writes = writes == null ? List.of() : List.copyOf(writes);
+        tickInterval = tickInterval == null ? Duration.ofMillis(250) : tickInterval;
+
+        // Forbidden-topic rule (§3, §7): /cmd_vel etc. require simulatorOnly.
+        if (!simulatorOnly) {
+            for (WriteBindingConfig w : writes) {
+                if (w.topic() != null && FORBIDDEN_WRITE_TOPICS.contains(w.topic())) {
+                    throw new IllegalArgumentException(
+                            "ROS 2 bridge: write binding '" + w.bindingId()
+                                    + "' targets actuating topic '" + w.topic()
+                                    + "' but simulatorOnly=false (04-ROS2-DDS.md §3, §7)");
+                }
+            }
+        }
+
+        // Detect duplicate bindingIds early — the runtime maps key on it.
+        Set<String> seen = new LinkedHashSet<>();
+        for (ReadBindingConfig r : reads) {
+            if (!seen.add(r.bindingId())) {
+                throw new IllegalArgumentException("Duplicate bindingId: " + r.bindingId());
+            }
+        }
+        for (WriteBindingConfig w : writes) {
+            if (!seen.add(w.bindingId())) {
+                throw new IllegalArgumentException("Duplicate bindingId: " + w.bindingId());
+            }
+        }
+
+        // Per-tag AUTONOMOUS only allowed in simulatorOnly mode (04-ROS2-DDS §3).
+        if (perTagSafetyMode == null) {
+            perTagSafetyMode = Map.of();
+        } else {
+            Map<String, BridgeSafetyMode> linked = new LinkedHashMap<>(perTagSafetyMode);
+            if (!simulatorOnly) {
+                for (Map.Entry<String, BridgeSafetyMode> e : linked.entrySet()) {
+                    if (e.getValue() == BridgeSafetyMode.AUTONOMOUS) {
+                        throw new IllegalArgumentException(
+                                "ROS 2 bridge ceiling is ADVISORY (04-ROS2-DDS.md §3): "
+                                        + "binding '" + e.getKey() + "' was promoted to AUTONOMOUS "
+                                        + "but simulatorOnly=false");
+                    }
+                }
+            }
+            perTagSafetyMode = Map.copyOf(linked);
+        }
+    }
+
+    @JsonCreator
+    public static Ros2BridgeConfig create(
+            @JsonProperty("mode") TransportMode mode,
+            @JsonProperty("rosbridgeUrl") String rosbridgeUrl,
+            @JsonProperty("domainId") Integer domainId,
+            @JsonProperty("qosProfile") QosProfile qosProfile,
+            @JsonProperty("simulatorOnly") Boolean simulatorOnly,
+            @JsonProperty("reads") List<ReadBindingConfig> reads,
+            @JsonProperty("writes") List<WriteBindingConfig> writes,
+            @JsonProperty("audit") AuditConfig audit,
+            @JsonProperty("perTagSafetyMode") Map<String, BridgeSafetyMode> perTagSafetyMode,
+            @JsonProperty("tickInterval") Duration tickInterval) {
+        return new Ros2BridgeConfig(
+                mode == null ? TransportMode.ROSBRIDGE : mode,
+                rosbridgeUrl, domainId, qosProfile,
+                simulatorOnly != null && simulatorOnly,
+                reads, writes, audit, perTagSafetyMode, tickInterval);
+    }
+
+    /** Strategy A or Strategy B (04-ROS2-DDS.md §1). */
+    public enum TransportMode {
+        /** Strategy B — rosbridge_suite WebSocket JSON. Default. */
+        ROSBRIDGE,
+        /** Strategy A — embedded rcljava client. Behind a feature flag. */
+        RCLJAVA
+    }
+
+    /** ROS 2 QoS preset names (04-ROS2-DDS.md §7). */
+    public enum QosProfile { SENSOR_DATA, RELIABLE, PARAMETERS }
+
+    /**
+     * One subscribe-side binding. The bridge produces the signal class
+     * indicated by {@link ReadSignalKind} (or, for swarm peers, by
+     * {@code asPeerObservation: true}).
+     */
+    public record ReadBindingConfig(
+            String bindingId,
+            String topic,
+            String msgType,
+            String signalTag,
+            ReadSignalKind signalKind,
+            boolean asPeerObservation,
+            String peerId,
+            int decimateBy,
+            int maxRangeBins,
+            int maxPayloadBytes
+    ) {
+        public ReadBindingConfig {
+            Objects.requireNonNull(bindingId, "bindingId");
+            Objects.requireNonNull(topic, "topic");
+            Objects.requireNonNull(msgType, "msgType");
+            if (decimateBy <= 0) decimateBy = 1;
+            if (maxRangeBins <= 0) maxRangeBins = 720;
+            if (maxPayloadBytes <= 0) maxPayloadBytes = 1_048_576;
+            if (signalKind == null) {
+                signalKind = inferKind(msgType);
+            }
+            if (asPeerObservation && !"nav_msgs/msg/Odometry".equals(msgType)) {
+                throw new IllegalArgumentException(
+                        "ReadBinding '" + bindingId
+                                + "' asPeerObservation=true requires msgType=nav_msgs/msg/Odometry");
+            }
+        }
+
+        @JsonCreator
+        public static ReadBindingConfig of(
+                @JsonProperty("bindingId") String bindingId,
+                @JsonProperty("topic") String topic,
+                @JsonProperty("msgType") String msgType,
+                @JsonProperty("signalTag") String signalTag,
+                @JsonProperty("signalKind") ReadSignalKind signalKind,
+                @JsonProperty("asPeerObservation") Boolean asPeerObservation,
+                @JsonProperty("peerId") String peerId,
+                @JsonProperty("decimateBy") Integer decimateBy,
+                @JsonProperty("maxRangeBins") Integer maxRangeBins,
+                @JsonProperty("maxPayloadBytes") Integer maxPayloadBytes) {
+            return new ReadBindingConfig(
+                    bindingId, topic, msgType, signalTag, signalKind,
+                    asPeerObservation != null && asPeerObservation,
+                    peerId,
+                    decimateBy == null ? 1 : decimateBy,
+                    maxRangeBins == null ? 720 : maxRangeBins,
+                    maxPayloadBytes == null ? 1_048_576 : maxPayloadBytes);
+        }
+
+        private static ReadSignalKind inferKind(String msgType) {
+            return switch (msgType) {
+                case "sensor_msgs/msg/Image",
+                     "sensor_msgs/msg/CompressedImage",
+                     "sensor_msgs/msg/LaserScan",
+                     "sensor_msgs/msg/PointCloud2" -> ReadSignalKind.SENSORY;
+                case "sensor_msgs/msg/JointState",
+                     "nav_msgs/msg/Odometry" -> ReadSignalKind.PROPRIOCEPTIVE;
+                case "sensor_msgs/msg/BatteryState" -> ReadSignalKind.ENERGY;
+                default -> ReadSignalKind.SENSORY;
+            };
+        }
+    }
+
+    /** What signal class a {@link ReadBindingConfig} produces. */
+    public enum ReadSignalKind { SENSORY, PROPRIOCEPTIVE, ENERGY }
+
+    /**
+     * One advisory egress binding. The bridge publishes the encoded payload
+     * onto the configured topic. Egress to the topics in
+     * {@link Ros2BridgeConfig#FORBIDDEN_WRITE_TOPICS} is rejected at config
+     * load unless {@code simulatorOnly == true}.
+     */
+    public record WriteBindingConfig(
+            String bindingId,
+            String topic,
+            String msgType,
+            String signalTag,
+            Double minClampValue,
+            Double maxClampValue,
+            Double rampRateMaxPerSec,
+            Double failSafeValue
+    ) {
+        public WriteBindingConfig {
+            Objects.requireNonNull(bindingId, "bindingId");
+            Objects.requireNonNull(topic, "topic");
+            Objects.requireNonNull(msgType, "msgType");
+            Objects.requireNonNull(signalTag, "signalTag");
+        }
+
+        @JsonCreator
+        public static WriteBindingConfig of(
+                @JsonProperty("bindingId") String bindingId,
+                @JsonProperty("topic") String topic,
+                @JsonProperty("msgType") String msgType,
+                @JsonProperty("signalTag") String signalTag,
+                @JsonProperty("minClampValue") Double minClampValue,
+                @JsonProperty("maxClampValue") Double maxClampValue,
+                @JsonProperty("rampRateMaxPerSec") Double rampRateMaxPerSec,
+                @JsonProperty("failSafeValue") Double failSafeValue) {
+            return new WriteBindingConfig(bindingId, topic, msgType, signalTag,
+                    minClampValue, maxClampValue, rampRateMaxPerSec, failSafeValue);
+        }
+    }
+
+    /** Audit channel configuration (00-FRAMEWORK §3, §4). */
+    public record AuditConfig(
+            String localAuditFile,
+            String advisoryAuditTopic
+    ) {
+        public AuditConfig {
+            Objects.requireNonNull(localAuditFile, "localAuditFile");
+        }
+
+        @JsonCreator
+        public static AuditConfig of(
+                @JsonProperty("localAuditFile") String localAuditFile,
+                @JsonProperty("advisoryAuditTopic") String advisoryAuditTopic) {
+            return new AuditConfig(localAuditFile, advisoryAuditTopic);
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2BridgeConfigLoader.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2BridgeConfigLoader.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ros2;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+/**
+ * Loads {@link Ros2BridgeConfig} from YAML (04-ROS2-DDS.md §7).
+ *
+ * <p>{@code FAIL_ON_UNKNOWN_PROPERTIES = true} per 00-FRAMEWORK §3 — typos in
+ * a robot-bridge config must be caught at load.
+ */
+public final class Ros2BridgeConfigLoader {
+
+    private Ros2BridgeConfigLoader() {}
+
+    public static Ros2BridgeConfig load(Path yaml) throws IOException {
+        return mapper().readValue(yaml.toFile(), Ros2BridgeConfig.class);
+    }
+
+    public static Ros2BridgeConfig load(InputStream in) throws IOException {
+        return mapper().readValue(in, Ros2BridgeConfig.class);
+    }
+
+    public static Ros2BridgeConfig load(String yamlContent) throws IOException {
+        return mapper().readValue(yamlContent, Ros2BridgeConfig.class);
+    }
+
+    private static ObjectMapper mapper() {
+        return new ObjectMapper(new YAMLFactory())
+                .registerModule(new JavaTimeModule())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2ClientService.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2ClientService.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ros2;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmPriority;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Owns the ROS 2 connection (rosbridge or rcljava) and the latest-value
+ * cache (04-ROS2-DDS.md §4). Read flow: ROS 2 message → mapper → per-binding
+ * queue drained by {@link Ros2SensoryInput} / {@link Ros2StateInput} on each
+ * tick (00-FRAMEWORK §2.1). Write flow: {@link Ros2AdvisoryOutputAggregator}
+ * computes the advisory payload and calls {@link #publish}.
+ *
+ * <p>Decimation, payload-size capping (§7, §10 R3), and the safety-critical
+ * runtime check that no write hits a forbidden actuating topic outside
+ * {@code simulatorOnly} mode (§3) all live here.
+ *
+ * <p>Reconnect (00-FRAMEWORK §2.3) is handled by the host loop calling
+ * {@link #onReconnected()} after the transport reports a fresh connect.
+ */
+public final class Ros2ClientService implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(Ros2ClientService.class);
+
+    public static final String BRIDGE_NAME = "ros2";
+    public static final String BRIDGE_RECONNECTED = "BRIDGE_RECONNECTED";
+
+    /** ROS 2 specific reasons in addition to 00-FRAMEWORK §4 vocabulary. */
+    public static final class Reason {
+        private Reason() {}
+        public static final String FORBIDDEN_TOPIC   = "FORBIDDEN_TOPIC";
+        public static final String DECODER_ERROR     = "DECODER_ERROR";
+        public static final String PUBLISH_ERROR     = "PUBLISH_ERROR";
+        public static final String OVERSIZED_PAYLOAD = "OVERSIZED_PAYLOAD";
+    }
+
+    private final Ros2BridgeConfig config;
+    private final Ros2Transport transport;
+    private final Ros2MessageMapper mapper;
+    private final AbstractBridgeAuditOutput audit;
+
+    /** Pending decoded signals per read binding. Drained per tick. */
+    private final Map<String, List<IInputSignal>> queueByBinding = new ConcurrentHashMap<>();
+
+    /** Pending alarm/event signals (advisory channel). */
+    private final List<IInputSignal> events = new ArrayList<>();
+
+    /** Resolved bindings keyed by bindingId. */
+    private final Map<String, Ros2TopicBinding> readBindings = new HashMap<>();
+    private final Map<String, Ros2TopicBinding> writeBindings = new HashMap<>();
+
+    /** Topic → read binding lookup (rosbridge subscribes are topic-keyed). */
+    private final Map<String, Ros2TopicBinding> readByTopic = new HashMap<>();
+
+    /** Per-binding decimation counter. */
+    private final Map<String, AtomicLong> decimationCounters = new ConcurrentHashMap<>();
+
+    /** Per-binding minute-windowed warning suppressor for oversized payloads (§10 R3). */
+    private final Map<String, AtomicLong> oversizeWindowMs = new ConcurrentHashMap<>();
+
+    private final AtomicBoolean started = new AtomicBoolean();
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    public Ros2ClientService(Ros2BridgeConfig config,
+                             Ros2Transport transport,
+                             Ros2MessageMapper mapper,
+                             AbstractBridgeAuditOutput audit) {
+        this.config = Objects.requireNonNull(config, "config");
+        this.transport = Objects.requireNonNull(transport, "transport");
+        this.mapper = Objects.requireNonNull(mapper, "mapper");
+        this.audit = Objects.requireNonNull(audit, "audit");
+        for (Ros2BridgeConfig.ReadBindingConfig r : config.reads()) {
+            Ros2TopicBinding b = Ros2TopicBinding.fromRead(r);
+            readBindings.put(r.bindingId(), b);
+            readByTopic.put(r.topic(), b);
+            queueByBinding.put(r.bindingId(), new ArrayList<>());
+            decimationCounters.put(r.bindingId(), new AtomicLong());
+        }
+        for (Ros2BridgeConfig.WriteBindingConfig w : config.writes()) {
+            writeBindings.put(w.bindingId(), Ros2TopicBinding.fromWrite(w));
+        }
+    }
+
+    /** Open the ROS 2 connection, register the message handler, subscribe + advertise. Idempotent. */
+    public synchronized void start() {
+        if (started.get()) return;
+        transport.setHandler(this::onMessage);
+        transport.connect();
+        for (Ros2TopicBinding r : readBindings.values()) {
+            transport.subscribe(r.topic(), r.msgType());
+        }
+        for (Ros2TopicBinding w : writeBindings.values()) {
+            transport.advertise(w.topic(), w.msgType());
+        }
+        started.set(true);
+        log.info("Ros2ClientService started; {} read + {} write bindings",
+                readBindings.size(), writeBindings.size());
+    }
+
+    /**
+     * Drop in-flight latest-value cache and emit a {@code BRIDGE_RECONNECTED}
+     * alarm. Called by the host after the transport reports a reconnect
+     * (00-FRAMEWORK §2.3).
+     */
+    public synchronized void onReconnected() {
+        for (List<IInputSignal> q : queueByBinding.values()) {
+            synchronized (q) { q.clear(); }
+        }
+        synchronized (events) {
+            events.add(new AlarmSignal(AlarmPriority.LOW, BRIDGE_NAME,
+                    BRIDGE_RECONNECTED, System.currentTimeMillis()));
+        }
+        log.info("Ros2ClientService: reconnect — cache cleared, advisory event emitted");
+    }
+
+    /** Drain (and clear) all decoded signals for one read binding. */
+    public List<IInputSignal> drain(String bindingId) {
+        List<IInputSignal> out = queueByBinding.get(bindingId);
+        if (out == null || out.isEmpty()) return List.of();
+        synchronized (out) {
+            List<IInputSignal> snap = new ArrayList<>(out);
+            out.clear();
+            return snap;
+        }
+    }
+
+    /** Drain (and clear) all decoded alarm/event signals. */
+    public List<IInputSignal> drainEvents() {
+        synchronized (events) {
+            if (events.isEmpty()) return List.of();
+            List<IInputSignal> snap = new ArrayList<>(events);
+            events.clear();
+            return snap;
+        }
+    }
+
+    /**
+     * Publish a JSON-encoded ROS 2 message to the configured topic. The
+     * caller (the aggregator) has already clamped, rate-limited, and
+     * audited the proposed value. Returns {@code true} on a successful
+     * transport-level publish; on failure an audit record is appended and
+     * {@code false} is returned. Per §3 and §7, a write to a forbidden
+     * topic is rejected here as the runtime backstop.
+     */
+    public boolean publish(String bindingId, String json, long ts, long run, String signalTag) {
+        if (closed.get() || !started.get()) return false;
+        Ros2TopicBinding b = writeBindings.get(bindingId);
+        if (b == null) {
+            audit.append(new BridgeAuditRecord(
+                    System.currentTimeMillis(), run, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    bindingId, signalTag, null, null,
+                    BridgeAuditRecord.RejectReason.UNKNOWN_TAG, null, List.of()));
+            return false;
+        }
+        // Hard runtime backstop for the §3 forbidden-topic rule.
+        if (!config.simulatorOnly()
+                && Ros2BridgeConfig.FORBIDDEN_WRITE_TOPICS.contains(b.topic())) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    b.loopId(), signalTag, null, null,
+                    Reason.FORBIDDEN_TOPIC, null, List.of()));
+            return false;
+        }
+        try {
+            transport.publish(b.topic(), json);
+            return true;
+        } catch (RuntimeException ex) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.FAILED,
+                    b.loopId(), signalTag, null, null,
+                    Reason.PUBLISH_ERROR + ":" + ex.getMessage(),
+                    null, List.of()));
+            return false;
+        }
+    }
+
+    /** Publish a raw JSON string — used by the audit-mirror channel. */
+    public boolean publishRaw(String topic, String json) {
+        if (closed.get() || !started.get()) return false;
+        try {
+            transport.publish(topic, json);
+            return true;
+        } catch (RuntimeException ex) {
+            log.warn("publishRaw to {} failed: {}", topic, ex.getMessage());
+            return false;
+        }
+    }
+
+    public Ros2BridgeConfig config() { return config; }
+    public Ros2TopicBinding readBinding(String bindingId) { return readBindings.get(bindingId); }
+    public Ros2TopicBinding writeBinding(String bindingId) { return writeBindings.get(bindingId); }
+    public Ros2TopicBinding writeBindingForTag(String tag) {
+        for (Ros2TopicBinding b : writeBindings.values()) {
+            if (Objects.equals(tag, b.signalTag())) return b;
+        }
+        return null;
+    }
+
+    @Override
+    public synchronized void close() {
+        if (!closed.compareAndSet(false, true)) return;
+        try { transport.close(); } catch (RuntimeException e) {
+            log.warn("Ros2Transport.close() threw: {}", e.getMessage());
+        }
+    }
+
+    /* ===== inbound message dispatch ============================================ */
+
+    private void onMessage(Ros2Transport.InboundMessage msg) {
+        Ros2TopicBinding b = readByTopic.get(msg.topic());
+        if (b == null) return;
+        try {
+            // §10 R3: drop oversized payloads with a single audit per minute per binding.
+            int len = msg.json() == null ? 0 : msg.json().length();
+            if (b.maxPayloadBytes() > 0 && len > b.maxPayloadBytes()) {
+                long now = System.currentTimeMillis();
+                AtomicLong window = oversizeWindowMs.computeIfAbsent(
+                        b.bindingId(), k -> new AtomicLong());
+                long last = window.get();
+                if (now - last > 60_000L) {
+                    window.set(now);
+                    audit.append(new BridgeAuditRecord(
+                            now, 0, BRIDGE_NAME,
+                            BridgeAuditRecord.Verdict.REJECTED,
+                            b.loopId(), b.signalTag(), null, null,
+                            Reason.OVERSIZED_PAYLOAD + ":" + len, null, List.of()));
+                }
+                return;
+            }
+
+            // §7 / §10 S10: decimate.
+            if (b.decimateBy() > 1) {
+                AtomicLong c = decimationCounters.get(b.bindingId());
+                long n = c == null ? 0 : c.incrementAndGet();
+                if (n % b.decimateBy() != 0) return;
+            }
+
+            IInputSignal signal = mapper.fromRosbridgeEnvelope(b, msg.json());
+            if (signal == null) return;
+            if (signal instanceof AlarmSignal) {
+                synchronized (events) { events.add(signal); }
+            } else {
+                List<IInputSignal> q = queueByBinding.get(b.bindingId());
+                if (q != null) synchronized (q) { q.add(signal); }
+            }
+        } catch (Ros2MessageMapper.SignalMapperException ex) {
+            audit.append(new BridgeAuditRecord(
+                    System.currentTimeMillis(), 0, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.FAILED,
+                    b.loopId(), b.signalTag(), null, null,
+                    Reason.DECODER_ERROR + ":" + ex.getMessage(),
+                    null, List.of()));
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2MessageMapper.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2MessageMapper.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ros2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.rakovpublic.jneuropallium.ai.signals.fast.MotorCommandSignal;
+import com.rakovpublic.jneuropallium.ai.signals.fast.SensorySignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.ProprioceptiveSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.EfficiencySignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerObservationSignal;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Pure functions: ROS 2 JSON message ↔ Jneopallium typed signal
+ * (04-ROS2-DDS.md §5).
+ *
+ * <p>Mapping is deliberately minimal. Per §5 a large payload (image,
+ * point-cloud) is carried as a reference (URI / sha) rather than bytes; only
+ * the {@link SensorySignal} {@code rawValues} is populated for compact
+ * messages such as {@code LaserScan}. {@link Ros2ClientService} applies
+ * the per-binding decimation and payload caps ({@code decimateBy},
+ * {@code maxPayloadBytes}, §7 / §10 R3) before calling this mapper.
+ */
+public final class Ros2MessageMapper {
+
+    private static final ObjectMapper JSON =
+            new ObjectMapper().disable(SerializationFeature.INDENT_OUTPUT);
+
+    /** Returned to {@link #toSignal} on a malformed payload. The bridge audits. */
+    public static final class SignalMapperException extends RuntimeException {
+        public SignalMapperException(String message) { super(message); }
+        public SignalMapperException(String message, Throwable cause) { super(message, cause); }
+    }
+
+    public ObjectMapper jsonMapper() { return JSON; }
+
+    /**
+     * Decode a rosbridge {@code "publish"} envelope and route the inner
+     * {@code msg} field through {@link #toSignal(Ros2TopicBinding, JsonNode)}.
+     * The envelope shape is
+     * {@code { "op":"publish", "topic":"…", "msg":{ … } }}.
+     */
+    public IInputSignal fromRosbridgeEnvelope(Ros2TopicBinding b, String envelopeJson) {
+        try {
+            JsonNode root = JSON.readTree(envelopeJson);
+            JsonNode msg = root.get("msg");
+            if (msg == null || msg.isNull()) return null;
+            return toSignal(b, msg);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new SignalMapperException("malformed JSON: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Map a decoded ROS 2 message body to the Jneopallium signal class
+     * implied by the binding. {@code null} when the message carries no
+     * actionable value (e.g. a header-only ping).
+     */
+    public IInputSignal toSignal(Ros2TopicBinding b, JsonNode msg) {
+        if (msg == null) return null;
+        long ts = headerTimestampMs(msg);
+        if (b.asPeerObservation() && "nav_msgs/msg/Odometry".equals(b.msgType())) {
+            return toPeerObservation(b, msg);
+        }
+        return switch (b.msgType()) {
+            case "nav_msgs/msg/Odometry" -> toOdomProprioceptive(b, msg, ts);
+            case "sensor_msgs/msg/JointState" -> toJointStateProprioceptive(b, msg, ts);
+            case "sensor_msgs/msg/LaserScan" -> toLaserScanSensory(b, msg, ts);
+            case "sensor_msgs/msg/Image",
+                 "sensor_msgs/msg/CompressedImage" -> toImageReferenceSensory(b, msg, ts);
+            case "sensor_msgs/msg/BatteryState" -> toBatteryEfficiency(b, msg);
+            case "turtlesim/msg/Pose" -> toTurtlePoseProprioceptive(b, msg, ts);
+            default -> toGenericSensory(b, msg, ts);
+        };
+    }
+
+    /* ===== egress encoders ============================================== */
+
+    /** Encode a {@code geometry_msgs/msg/Twist} from a {@link MotorCommandSignal}. */
+    public String encodeTwist(MotorCommandSignal cmd) {
+        double[] p = cmd == null ? null : cmd.getParams();
+        double linX = (p != null && p.length > 0) ? p[0] : 0.0;
+        double linY = (p != null && p.length > 1) ? p[1] : 0.0;
+        double linZ = (p != null && p.length > 2) ? p[2] : 0.0;
+        double angX = (p != null && p.length > 3) ? p[3] : 0.0;
+        double angY = (p != null && p.length > 4) ? p[4] : 0.0;
+        double angZ = (p != null && p.length > 5) ? p[5] : 0.0;
+        ObjectNode root = JSON.createObjectNode();
+        ObjectNode lin = root.putObject("linear");
+        lin.put("x", linX); lin.put("y", linY); lin.put("z", linZ);
+        ObjectNode ang = root.putObject("angular");
+        ang.put("x", angX); ang.put("y", angY); ang.put("z", angZ);
+        return root.toString();
+    }
+
+    /** Encode a {@code std_msgs/msg/String}. */
+    public String encodeStdString(String text) {
+        ObjectNode root = JSON.createObjectNode();
+        root.put("data", text == null ? "" : text);
+        return root.toString();
+    }
+
+    /** Encode a {@code std_msgs/msg/Float64}. */
+    public String encodeStdFloat64(double value) {
+        ObjectNode root = JSON.createObjectNode();
+        root.put("data", value);
+        return root.toString();
+    }
+
+    /* ===== ingress decoders ============================================ */
+
+    private IInputSignal toOdomProprioceptive(Ros2TopicBinding b, JsonNode msg, long ts) {
+        // /<topic>/odom: pose.pose.position.{x,y,z} + twist.twist.linear.{x,y,z}
+        double px = readDouble(msg, "pose", "pose", "position", "x");
+        double py = readDouble(msg, "pose", "pose", "position", "y");
+        double pz = readDouble(msg, "pose", "pose", "position", "z");
+        double vx = readDouble(msg, "twist", "twist", "linear", "x");
+        double vy = readDouble(msg, "twist", "twist", "linear", "y");
+        double vz = readDouble(msg, "twist", "twist", "linear", "z");
+        ProprioceptiveSignal sig = new ProprioceptiveSignal(
+                b.bindingId().hashCode(), new double[]{px, py, pz, vx, vy, vz}, ts);
+        sig.setName(b.signalTag());
+        return sig;
+    }
+
+    private IInputSignal toJointStateProprioceptive(Ros2TopicBinding b, JsonNode msg, long ts) {
+        // {name: [...], position: [...], velocity: [...], effort: [...]}
+        double[] positions = readDoubleArray(msg, "position");
+        ProprioceptiveSignal sig = new ProprioceptiveSignal(
+                b.bindingId().hashCode(), positions, ts);
+        sig.setName(b.signalTag());
+        return sig;
+    }
+
+    private IInputSignal toLaserScanSensory(Ros2TopicBinding b, JsonNode msg, long ts) {
+        // {ranges: [...]} — already capped upstream by maxRangeBins
+        double[] ranges = readDoubleArray(msg, "ranges");
+        if (b.maxRangeBins() > 0 && ranges.length > b.maxRangeBins()) {
+            double[] capped = new double[b.maxRangeBins()];
+            int step = ranges.length / b.maxRangeBins();
+            for (int i = 0; i < b.maxRangeBins(); i++) capped[i] = ranges[i * step];
+            ranges = capped;
+        }
+        SensorySignal sig = new SensorySignal(ranges, b.signalTag(), ts);
+        return sig;
+    }
+
+    private IInputSignal toImageReferenceSensory(Ros2TopicBinding b, JsonNode msg, long ts) {
+        // §5: do NOT carry image bytes through the bus. Hash the data field for a stable reference.
+        JsonNode dataNode = msg.get("data");
+        long contentRef = dataNode == null ? 0L : (long) dataNode.toString().hashCode();
+        SensorySignal sig = new SensorySignal(new double[]{(double) contentRef}, b.signalTag(), ts);
+        return sig;
+    }
+
+    private IInputSignal toBatteryEfficiency(Ros2TopicBinding b, JsonNode msg) {
+        // sensor_msgs/msg/BatteryState: percentage in [0,1]; voltage etc. ignored at v1
+        double pct = readDouble(msg, "percentage");
+        // Map 0..1 percentage to efficiency in [0,1] vs baseline 1.0.
+        EfficiencySignal sig = new EfficiencySignal(b.signalTag(), pct, 1.0);
+        return sig;
+    }
+
+    private IInputSignal toPeerObservation(Ros2TopicBinding b, JsonNode msg) {
+        double px = readDouble(msg, "pose", "pose", "position", "x");
+        double py = readDouble(msg, "pose", "pose", "position", "y");
+        double pz = readDouble(msg, "pose", "pose", "position", "z");
+        double vx = readDouble(msg, "twist", "twist", "linear", "x");
+        double vy = readDouble(msg, "twist", "twist", "linear", "y");
+        double vz = readDouble(msg, "twist", "twist", "linear", "z");
+        String peerId = b.peerId() == null ? b.bindingId() : b.peerId();
+        PeerObservationSignal sig = new PeerObservationSignal(
+                peerId, new double[]{px, py, pz}, new double[]{vx, vy, vz}, 1.0);
+        sig.setName(b.signalTag());
+        return sig;
+    }
+
+    private IInputSignal toTurtlePoseProprioceptive(Ros2TopicBinding b, JsonNode msg, long ts) {
+        // turtlesim/msg/Pose: x,y,theta,linear_velocity,angular_velocity
+        double x = readDouble(msg, "x");
+        double y = readDouble(msg, "y");
+        double theta = readDouble(msg, "theta");
+        double lv = readDouble(msg, "linear_velocity");
+        double av = readDouble(msg, "angular_velocity");
+        ProprioceptiveSignal sig = new ProprioceptiveSignal(
+                b.bindingId().hashCode(), new double[]{x, y, theta, lv, av}, ts);
+        sig.setName(b.signalTag());
+        return sig;
+    }
+
+    private IInputSignal toGenericSensory(Ros2TopicBinding b, JsonNode msg, long ts) {
+        // Best-effort: pick a "data" scalar if present, else hash the payload.
+        JsonNode data = msg.get("data");
+        double v;
+        if (data != null && data.isNumber()) {
+            v = data.doubleValue();
+        } else if (data != null && data.isBoolean()) {
+            v = data.booleanValue() ? 1.0 : 0.0;
+        } else {
+            v = (double) msg.toString().hashCode();
+        }
+        return new SensorySignal(new double[]{v}, b.signalTag(), ts);
+    }
+
+    /* ===== helpers ===================================================== */
+
+    private static double readDouble(JsonNode root, String... path) {
+        JsonNode node = root;
+        for (String p : path) {
+            if (node == null) return 0.0;
+            node = node.get(p);
+        }
+        return node == null || node.isNull() || !node.isNumber() ? 0.0 : node.doubleValue();
+    }
+
+    private static double[] readDoubleArray(JsonNode root, String key) {
+        JsonNode arr = root == null ? null : root.get(key);
+        if (arr == null || !arr.isArray()) return new double[0];
+        List<Double> out = new ArrayList<>(arr.size());
+        for (JsonNode n : arr) {
+            if (n.isNumber()) out.add(n.doubleValue());
+            else if (n.isNull()) out.add(0.0);
+        }
+        double[] result = new double[out.size()];
+        for (int i = 0; i < out.size(); i++) result[i] = out.get(i);
+        return result;
+    }
+
+    /**
+     * §0.6: prefer the message's {@code header.stamp} (sec, nanosec) over
+     * the JVM clock. Falls back to {@link System#currentTimeMillis()}.
+     */
+    private static long headerTimestampMs(JsonNode msg) {
+        JsonNode header = msg.get("header");
+        if (header == null) return System.currentTimeMillis();
+        JsonNode stamp = header.get("stamp");
+        if (stamp == null) return System.currentTimeMillis();
+        long sec = stamp.has("sec") && stamp.get("sec").isNumber() ? stamp.get("sec").longValue() : 0L;
+        long nsec = stamp.has("nanosec") && stamp.get("nanosec").isNumber()
+                ? stamp.get("nanosec").longValue() : 0L;
+        if (sec == 0 && nsec == 0) return System.currentTimeMillis();
+        return sec * 1000L + nsec / 1_000_000L;
+    }
+
+    /** Build a rosbridge {@code subscribe} command envelope. */
+    public String rosbridgeSubscribe(String topic, String msgType) {
+        Map<String, Object> cmd = new LinkedHashMap<>();
+        cmd.put("op", "subscribe");
+        cmd.put("topic", topic);
+        cmd.put("type", msgType);
+        return writeJson(cmd);
+    }
+
+    /** Build a rosbridge {@code advertise} command envelope. */
+    public String rosbridgeAdvertise(String topic, String msgType) {
+        Map<String, Object> cmd = new LinkedHashMap<>();
+        cmd.put("op", "advertise");
+        cmd.put("topic", topic);
+        cmd.put("type", msgType);
+        return writeJson(cmd);
+    }
+
+    /** Build a rosbridge {@code publish} envelope. {@code msgJson} is the inner ROS message JSON. */
+    public String rosbridgePublishEnvelope(String topic, String msgJson) {
+        try {
+            ObjectNode root = JSON.createObjectNode();
+            root.put("op", "publish");
+            root.put("topic", topic);
+            root.set("msg", JSON.readTree(msgJson));
+            return root.toString();
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new SignalMapperException("publish envelope encode failed: " + e.getMessage(), e);
+        }
+    }
+
+    private String writeJson(Object value) {
+        try {
+            return JSON.writeValueAsString(value);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new SignalMapperException("json encode failed: " + e.getMessage(), e);
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2SensoryInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2SensoryInput.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ros2;
+
+import com.rakovpublic.jneuropallium.ai.signals.fast.SensorySignal;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IInitInput} that drains decoded {@link SensorySignal} (and
+ * {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerObservationSignal})
+ * instances from {@link Ros2ClientService} (04-ROS2-DDS.md §5).
+ *
+ * <p>One instance binds to one or more SENSORY-class read bindings.
+ * {@code readSignals()} returns a snapshot — the connection service
+ * maintains the cache asynchronously; this method does not block on the
+ * network.
+ */
+public final class Ros2SensoryInput implements IInitInput {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private final String name;
+    private final Ros2ClientService svc;
+    private final List<String> bindingIds;
+
+    public Ros2SensoryInput(String name, Ros2ClientService svc, List<String> bindingIds) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.bindingIds = List.copyOf(Objects.requireNonNull(bindingIds, "bindingIds"));
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        List<IInputSignal> out = new ArrayList<>();
+        for (String b : bindingIds) out.addAll(svc.drain(b));
+        out.addAll(svc.drainEvents());
+        return out;
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() { return new HashMap<>(); }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() { return PROCESSING_FREQUENCY; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2StateInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2StateInput.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ros2;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.ProprioceptiveSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IInitInput} that drains decoded
+ * {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.ProprioceptiveSignal}
+ * and
+ * {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.EfficiencySignal}
+ * instances from {@link Ros2ClientService} (04-ROS2-DDS.md §5).
+ *
+ * <p>One instance binds to one or more PROPRIOCEPTIVE/ENERGY-class read
+ * bindings. {@code readSignals()} returns a snapshot.
+ */
+public final class Ros2StateInput implements IInitInput {
+
+    private final String name;
+    private final Ros2ClientService svc;
+    private final List<String> bindingIds;
+
+    public Ros2StateInput(String name, Ros2ClientService svc, List<String> bindingIds) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.bindingIds = List.copyOf(Objects.requireNonNull(bindingIds, "bindingIds"));
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        List<IInputSignal> out = new ArrayList<>();
+        for (String b : bindingIds) out.addAll(svc.drain(b));
+        return out;
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() { return new HashMap<>(); }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() {
+        return ProprioceptiveSignal.PROCESSING_FREQUENCY;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2TopicBinding.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2TopicBinding.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ros2;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeBinding;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeBindingDirection;
+
+/**
+ * One ROS 2 topic ↔ signal-tag binding (04-ROS2-DDS.md §5, §7).
+ *
+ * <p>For READ bindings {@code topic} is the subscribed ROS 2 topic; the
+ * binding additionally carries the message type and a per-binding decimation
+ * factor. For WRITE bindings {@code topic} is the advisory namespace topic
+ * that the operator's autonomy supervisor consumes.
+ *
+ * <p>Implements {@link BridgeBinding} so the universal audit record
+ * (00-FRAMEWORK §4) can identify the binding by tag and loop, and so write
+ * bindings can carry their clamp / rate / fail-safe metadata.
+ */
+public record Ros2TopicBinding(
+        String bindingId,
+        String topic,
+        String msgType,
+        String signalTag,
+        BridgeBindingDirection direction,
+        Ros2BridgeConfig.ReadSignalKind readKind,
+        boolean asPeerObservation,
+        String peerId,
+        int decimateBy,
+        int maxRangeBins,
+        int maxPayloadBytes,
+        Double minClampValue,
+        Double maxClampValue,
+        Double rampRateMaxPerSec,
+        Double failSafeValue
+) implements BridgeBinding {
+
+    public static Ros2TopicBinding fromRead(Ros2BridgeConfig.ReadBindingConfig r) {
+        return new Ros2TopicBinding(
+                r.bindingId(), r.topic(), r.msgType(), r.signalTag(),
+                BridgeBindingDirection.READ,
+                r.signalKind(), r.asPeerObservation(), r.peerId(),
+                r.decimateBy(), r.maxRangeBins(), r.maxPayloadBytes(),
+                null, null, null, null);
+    }
+
+    public static Ros2TopicBinding fromWrite(Ros2BridgeConfig.WriteBindingConfig w) {
+        return new Ros2TopicBinding(
+                w.bindingId(), w.topic(), w.msgType(), w.signalTag(),
+                BridgeBindingDirection.WRITE,
+                null, false, null, 1, 0, 0,
+                w.minClampValue(), w.maxClampValue(),
+                w.rampRateMaxPerSec(), w.failSafeValue());
+    }
+
+    @Override public String loopId() { return bindingId; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2Transport.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2Transport.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ros2;
+
+/**
+ * Test seam between {@link Ros2ClientService} and the actual ROS 2 wire
+ * (04-ROS2-DDS.md §1, §2).
+ *
+ * <p>Strategy B (the MVP) plugs in {@link RosbridgeTransport}, a thin
+ * WebSocket adapter on top of {@code rosbridge_suite}. Strategy A
+ * (rcljava, §2 advanced) would plug a different implementation behind the
+ * same interface. Tests inject an in-memory implementation so the §10
+ * scenarios run without rosbridge.
+ *
+ * <p>The transport is JSON-bytes-only on egress and JSON-text on ingress;
+ * payload decoding lives in {@link Ros2MessageMapper}.
+ */
+public interface Ros2Transport extends AutoCloseable {
+
+    /** One ROS 2 message observed on a subscribed topic. */
+    record InboundMessage(String topic, String json) {}
+
+    /** Callback invoked for every received message. */
+    @FunctionalInterface
+    interface MessageHandler { void onMessage(InboundMessage msg); }
+
+    /**
+     * Open the connection. Idempotent. Implementations doing real network
+     * work block until connected or fail with {@link Ros2TransportException}.
+     */
+    void connect();
+
+    /** Subscribe to one ROS 2 topic of the given message type. */
+    void subscribe(String topic, String msgType);
+
+    /** Advertise a ROS 2 topic for publishing. */
+    void advertise(String topic, String msgType);
+
+    /** Set (or replace) the inbound message handler. */
+    void setHandler(MessageHandler handler);
+
+    /** Publish a JSON-serialised ROS 2 message to {@code topic}. */
+    void publish(String topic, String json);
+
+    /** {@code true} once {@link #connect} succeeded and no disconnect has occurred since. */
+    boolean isConnected();
+
+    /** Shut down. Idempotent. */
+    @Override
+    void close();
+
+    /** Wraps any client throwable so the bridge can audit it uniformly. */
+    final class Ros2TransportException extends RuntimeException {
+        public Ros2TransportException(String message) { super(message); }
+        public Ros2TransportException(String message, Throwable cause) { super(message, cause); }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/RosbridgeTransport.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/RosbridgeTransport.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ros2;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Production {@link Ros2Transport} backed by the JDK's built-in
+ * {@link HttpClient} {@link WebSocket} talking the JSON-over-WebSocket
+ * protocol exposed by
+ * <a href="https://github.com/RobotWebTools/rosbridge_suite">rosbridge_suite</a>
+ * (04-ROS2-DDS.md §1 Strategy B, §2). The bridge is intentionally thin — no
+ * extra Java-WebSocket dependency is needed because the JDK ships one since
+ * Java 11.
+ *
+ * <p>This implementation does not perform reconnect itself — the
+ * {@link Ros2ClientService} owns the reconnect policy (00-FRAMEWORK §2.3)
+ * and is the one that calls {@link Ros2Transport#connect()} again after a
+ * disconnect.
+ */
+public final class RosbridgeTransport implements Ros2Transport {
+
+    private static final Logger log = LoggerFactory.getLogger(RosbridgeTransport.class);
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(10);
+
+    private final Ros2BridgeConfig config;
+    private final Ros2MessageMapper mapper;
+    private final HttpClient http;
+    private final AtomicReference<WebSocket> ws = new AtomicReference<>();
+    private final AtomicReference<MessageHandler> handler = new AtomicReference<>();
+    private final AtomicBoolean connected = new AtomicBoolean();
+
+    public RosbridgeTransport(Ros2BridgeConfig config, Ros2MessageMapper mapper) {
+        this.config = Objects.requireNonNull(config, "config");
+        this.mapper = Objects.requireNonNull(mapper, "mapper");
+        this.http = HttpClient.newBuilder().connectTimeout(CONNECT_TIMEOUT).build();
+    }
+
+    @Override public synchronized void setHandler(MessageHandler h) { handler.set(h); }
+    @Override public boolean isConnected() { return connected.get(); }
+
+    @Override
+    public synchronized void connect() {
+        if (connected.get()) return;
+        URI uri = URI.create(config.rosbridgeUrl());
+        try {
+            WebSocket socket = http.newWebSocketBuilder()
+                    .connectTimeout(CONNECT_TIMEOUT)
+                    .buildAsync(uri, new Listener())
+                    .get();
+            ws.set(socket);
+            connected.set(true);
+            log.info("RosbridgeTransport connected to {}", uri);
+        } catch (Exception ex) {
+            throw new Ros2TransportException("rosbridge connect failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public void subscribe(String topic, String msgType) {
+        WebSocket socket = ws.get();
+        if (socket == null) throw new Ros2TransportException("not connected");
+        socket.sendText(mapper.rosbridgeSubscribe(topic, msgType), true).join();
+    }
+
+    @Override
+    public void advertise(String topic, String msgType) {
+        WebSocket socket = ws.get();
+        if (socket == null) throw new Ros2TransportException("not connected");
+        socket.sendText(mapper.rosbridgeAdvertise(topic, msgType), true).join();
+    }
+
+    @Override
+    public void publish(String topic, String json) {
+        WebSocket socket = ws.get();
+        if (socket == null) throw new Ros2TransportException("not connected");
+        try {
+            socket.sendText(mapper.rosbridgePublishEnvelope(topic, json), true).join();
+        } catch (RuntimeException ex) {
+            throw new Ros2TransportException("rosbridge publish failed: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        if (!connected.compareAndSet(true, false)) return;
+        WebSocket socket = ws.getAndSet(null);
+        if (socket == null) return;
+        try {
+            socket.sendClose(WebSocket.NORMAL_CLOSURE, "shutdown")
+                    .orTimeout(CONNECT_TIMEOUT.toMillis(),
+                            java.util.concurrent.TimeUnit.MILLISECONDS).join();
+        } catch (RuntimeException ex) {
+            log.warn("RosbridgeTransport.close: WS close threw {}", ex.getMessage());
+        }
+    }
+
+    /* ===== inbound WebSocket listener ===================================== */
+
+    private final class Listener implements WebSocket.Listener {
+        private final StringBuilder buf = new StringBuilder();
+
+        @Override public void onOpen(WebSocket webSocket) {
+            webSocket.request(1);
+        }
+
+        @Override
+        public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+            buf.append(data);
+            if (last) {
+                String text = buf.toString();
+                buf.setLength(0);
+                dispatch(text);
+            }
+            webSocket.request(1);
+            return null;
+        }
+
+        @Override
+        public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+            connected.set(false);
+            log.info("RosbridgeTransport WS closed: status={} reason={}", statusCode, reason);
+            return null;
+        }
+
+        @Override
+        public void onError(WebSocket webSocket, Throwable error) {
+            connected.set(false);
+            log.warn("RosbridgeTransport WS error: {}", error.toString());
+        }
+
+        @Override public CompletionStage<?> onPing(WebSocket webSocket, ByteBuffer message) {
+            webSocket.request(1);
+            return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    private void dispatch(String message) {
+        MessageHandler h = handler.get();
+        if (h == null) return;
+        try {
+            // Parse just enough to find the topic — full payload decoding
+            // happens inside the mapper.
+            com.fasterxml.jackson.databind.JsonNode root = mapper.jsonMapper().readTree(message);
+            com.fasterxml.jackson.databind.JsonNode op = root.get("op");
+            if (op == null || !"publish".equals(op.asText())) return;
+            com.fasterxml.jackson.databind.JsonNode topic = root.get("topic");
+            if (topic == null || !topic.isTextual()) return;
+            h.onMessage(new InboundMessage(topic.asText(), message));
+        } catch (Exception ex) {
+            log.warn("RosbridgeTransport dispatch failed: {}", ex.getMessage());
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/package-info.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * ROS 2 / DDS bridge (04-ROS2-DDS.md).
+ *
+ * <p><b>Safety ceiling:</b> {@code ADVISORY}. The bridge never publishes to
+ * a field-actuating topic ({@code /cmd_vel}, {@code /joint_trajectory},
+ * {@code /joint_command}) in production: outbound traffic goes only to a
+ * configurable advisory namespace consumed by the external autonomy
+ * supervisor. The forbidden-topic rule is enforced both at config load
+ * (in {@link com.rakovpublic.jneuropallium.worker.bridge.ros2.Ros2BridgeConfig})
+ * and at runtime
+ * (in {@link com.rakovpublic.jneuropallium.worker.bridge.ros2.Ros2ClientService#publish}).
+ * {@code AUTONOMOUS} per-tag promotion is rejected unless
+ * {@code simulatorOnly: true} is set (the simulator-with-watchdog escape
+ * from §3).
+ *
+ * <p><b>Layout (§8):</b>
+ * <ul>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.bridge.ros2.Ros2BridgeConfig}
+ *       / {@link com.rakovpublic.jneuropallium.worker.bridge.ros2.Ros2BridgeConfigLoader}
+ *       — YAML config (00-FRAMEWORK §3, FAIL_ON_UNKNOWN_PROPERTIES).</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.bridge.ros2.Ros2TopicBinding}
+ *       — read/write binding (BridgeBinding).</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.bridge.ros2.Ros2MessageMapper}
+ *       — pure functions: ROS 2 JSON ↔ typed Jneopallium signals.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.bridge.ros2.Ros2ClientService}
+ *       — connection lifecycle, latest-value cache, decimation,
+ *       payload caps, advisory queue (AutoCloseable).</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.bridge.ros2.Ros2Transport}
+ *       — test seam between the service and the wire.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.bridge.ros2.RosbridgeTransport}
+ *       — Strategy B production transport (rosbridge_suite over JDK
+ *       {@link java.net.http.WebSocket}).</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.bridge.ros2.RcljavaClientService}
+ *       — Strategy A placeholder (rcljava, behind a feature flag).</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.bridge.ros2.Ros2SensoryInput}
+ *       / {@link com.rakovpublic.jneuropallium.worker.bridge.ros2.Ros2StateInput}
+ *       — IInitInputs draining the per-binding signal queues.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.bridge.ros2.Ros2AdvisoryOutputAggregator}
+ *       — IOutputAggregator publishing only to advisory topics.</li>
+ *   <li>{@link com.rakovpublic.jneuropallium.worker.bridge.ros2.Ros2AuditOutput}
+ *       — JSONL audit, optionally mirrored to a ROS 2 audit topic.</li>
+ * </ul>
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ros2;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/embodiment/ProprioceptiveSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/embodiment/ProprioceptiveSignal.java
@@ -5,6 +5,7 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment;
 
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
@@ -13,7 +14,7 @@ import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
  * afferents ascending via the dorsal columns.
  * <p>ProcessingFrequency: loop=1, epoch=1.
  */
-public class ProprioceptiveSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class ProprioceptiveSignal extends AbstractSignal<Void> implements ISignal<Void>, IInputSignal<Void> {
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
 

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/EfficiencySignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/industrial/EfficiencySignal.java
@@ -5,13 +5,14 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial;
 
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
  * Per-unit efficiency measurement with its baseline.
  * ProcessingFrequency: loop=2, epoch=1.
  */
-public class EfficiencySignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class EfficiencySignal extends AbstractSignal<Void> implements ISignal<Void>, IInputSignal<Void> {
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 2);
 

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/PeerObservationSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/swarm/PeerObservationSignal.java
@@ -5,6 +5,7 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm;
 
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
@@ -12,7 +13,7 @@ import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
  * link-quality indicator. Per spec §3: no perfect-comms assumption.
  * ProcessingFrequency: loop=1, epoch=2.
  */
-public class PeerObservationSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class PeerObservationSignal extends AbstractSignal<Void> implements ISignal<Void>, IInputSignal<Void> {
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
 

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/InMemoryRos2Transport.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/InMemoryRos2Transport.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ros2;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * In-memory {@link Ros2Transport} for the ROS 2 bridge integration tests.
+ * Runs without rosbridge; mirrors enough of the wire to validate the §10
+ * scenarios in 04-ROS2-DDS.md.
+ */
+public final class InMemoryRos2Transport implements Ros2Transport {
+
+    private MessageHandler handler;
+    private boolean connected;
+    private final List<String> subscriptions = new ArrayList<>();
+    private final Map<String, String> advertised = new HashMap<>();
+    private final Map<String, List<String>> publishedByTopic = new LinkedHashMap<>();
+    private final List<Published> publishedAll = new ArrayList<>();
+    private final AtomicLong failsRemaining = new AtomicLong();
+
+    public record Published(String topic, String json) {}
+
+    @Override public synchronized void connect() { connected = true; }
+    @Override public synchronized void setHandler(MessageHandler h) { this.handler = h; }
+    @Override public synchronized boolean isConnected() { return connected; }
+
+    @Override
+    public synchronized void subscribe(String topic, String msgType) {
+        subscriptions.add(topic);
+    }
+
+    @Override
+    public synchronized void advertise(String topic, String msgType) {
+        advertised.put(topic, msgType);
+    }
+
+    @Override
+    public synchronized void publish(String topic, String json) {
+        if (failsRemaining.get() > 0) {
+            failsRemaining.decrementAndGet();
+            throw new Ros2TransportException("simulated publish failure on " + topic);
+        }
+        publishedByTopic.computeIfAbsent(topic, k -> new ArrayList<>()).add(json);
+        publishedAll.add(new Published(topic, json));
+    }
+
+    @Override
+    public synchronized void close() { connected = false; }
+
+    /* ===== test helpers ====================================================== */
+
+    /** Deliver a rosbridge-shape "publish" envelope to every matching subscription. */
+    public synchronized void deliverEnvelope(String topic, String envelopeJson) {
+        if (handler == null) return;
+        if (subscriptions.contains(topic)) {
+            handler.onMessage(new InboundMessage(topic, envelopeJson));
+        }
+    }
+
+    /** Build a rosbridge envelope and deliver it. */
+    public synchronized void deliver(String topic, String msgJson) {
+        deliverEnvelope(topic,
+                "{\"op\":\"publish\",\"topic\":\"" + topic + "\",\"msg\":" + msgJson + "}");
+    }
+
+    /** Number of registered subscriptions. */
+    public synchronized int subscriptionCount() { return subscriptions.size(); }
+
+    public synchronized boolean isAdvertised(String topic) { return advertised.containsKey(topic); }
+
+    /** Make the next {@code n} publishes throw — used for PUBLISH_ERROR tests. */
+    public void failNextPublish(int n) { failsRemaining.set(n); }
+
+    public synchronized List<String> published(String topic) {
+        return new ArrayList<>(publishedByTopic.getOrDefault(topic, List.of()));
+    }
+
+    public synchronized List<Published> publishes() { return new ArrayList<>(publishedAll); }
+
+    public synchronized void disconnect() { connected = false; }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2BridgeConfigLoaderTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2BridgeConfigLoaderTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ros2;
+
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests for {@link Ros2BridgeConfigLoader} (04-ROS2-DDS.md §7, §10 S8). */
+final class Ros2BridgeConfigLoaderTest {
+
+    private static Throwable rootCause(Throwable t) {
+        Throwable cur = t;
+        while (cur.getCause() != null && cur.getCause() != cur) cur = cur.getCause();
+        return cur;
+    }
+
+    private static final String HAPPY = """
+            mode: ROSBRIDGE
+            rosbridgeUrl: "ws://localhost:9090"
+            qosProfile: SENSOR_DATA
+            simulatorOnly: false
+            reads:
+              - bindingId: ROBOT-ODOM
+                topic: /robot1/odom
+                msgType: nav_msgs/msg/Odometry
+                signalTag: ROBOT.R1.ODOM
+              - bindingId: PEER-ODOM-2
+                topic: /robot2/odom
+                msgType: nav_msgs/msg/Odometry
+                signalTag: ROBOT.R2.PEER_ODOM
+                asPeerObservation: true
+                peerId: r2
+            writes:
+              - bindingId: MISSION-ADVICE
+                topic: /jneopallium/advisory/mission_advice
+                msgType: std_msgs/msg/String
+                signalTag: ROBOT.R1.MISSION_ADV
+            audit:
+              localAuditFile: /tmp/jneopallium/ros2-audit.jsonl
+            perTagSafetyMode:
+              MISSION-ADVICE: ADVISORY
+            """;
+
+    @Test
+    void loadsHappyPath() throws IOException {
+        Ros2BridgeConfig cfg = Ros2BridgeConfigLoader.load(HAPPY);
+        assertEquals(Ros2BridgeConfig.TransportMode.ROSBRIDGE, cfg.mode());
+        assertEquals(2, cfg.reads().size());
+        assertEquals(1, cfg.writes().size());
+        assertFalse(cfg.simulatorOnly());
+        assertEquals(BridgeSafetyMode.ADVISORY, cfg.perTagSafetyMode().get("MISSION-ADVICE"));
+        assertNotNull(cfg.audit());
+    }
+
+    /** §10 S8: a write binding for /cmd_vel without simulatorOnly must fail loading. */
+    @Test
+    void rejectsCmdVelWithoutSimulatorOnly() {
+        String yaml = """
+                mode: ROSBRIDGE
+                rosbridgeUrl: "ws://localhost:9090"
+                simulatorOnly: false
+                writes:
+                  - bindingId: BAD-CMDVEL
+                    topic: /cmd_vel
+                    msgType: geometry_msgs/msg/Twist
+                    signalTag: ROBOT.R1.CMDVEL
+                audit:
+                  localAuditFile: /tmp/jneopallium/ros2-audit.jsonl
+                """;
+        Exception ex = assertThrows(Exception.class, () -> Ros2BridgeConfigLoader.load(yaml));
+        assertTrue(rootCause(ex).getMessage().contains("/cmd_vel"));
+    }
+
+    @Test
+    void rejectsJointTrajectoryWithoutSimulatorOnly() {
+        String yaml = """
+                mode: ROSBRIDGE
+                rosbridgeUrl: "ws://localhost:9090"
+                writes:
+                  - bindingId: JT
+                    topic: /joint_trajectory
+                    msgType: trajectory_msgs/msg/JointTrajectory
+                    signalTag: T1
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        assertThrows(Exception.class, () -> Ros2BridgeConfigLoader.load(yaml));
+    }
+
+    @Test
+    void allowsCmdVelInSimulatorOnlyMode() throws IOException {
+        String yaml = """
+                mode: ROSBRIDGE
+                rosbridgeUrl: "ws://localhost:9090"
+                simulatorOnly: true
+                writes:
+                  - bindingId: SIM-CMDVEL
+                    topic: /cmd_vel
+                    msgType: geometry_msgs/msg/Twist
+                    signalTag: SIM.CMDVEL
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        Ros2BridgeConfig cfg = Ros2BridgeConfigLoader.load(yaml);
+        assertTrue(cfg.simulatorOnly());
+        assertEquals(1, cfg.writes().size());
+    }
+
+    @Test
+    void rejectsAutonomousPromotionOutsideSimulatorOnly() {
+        String yaml = """
+                mode: ROSBRIDGE
+                rosbridgeUrl: "ws://localhost:9090"
+                simulatorOnly: false
+                writes:
+                  - bindingId: ADVICE
+                    topic: /advisory/mission
+                    msgType: std_msgs/msg/String
+                    signalTag: ROBOT.R1.ADV
+                audit:
+                  localAuditFile: /tmp/x
+                perTagSafetyMode:
+                  ADVICE: AUTONOMOUS
+                """;
+        assertThrows(Exception.class, () -> Ros2BridgeConfigLoader.load(yaml));
+    }
+
+    @Test
+    void unknownPropertyFailsLoading() {
+        String yaml = """
+                mode: ROSBRIDGE
+                rosbridgeUrl: "ws://localhost:9090"
+                bogusKey: 42
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        assertThrows(UnrecognizedPropertyException.class, () -> Ros2BridgeConfigLoader.load(yaml));
+    }
+
+    @Test
+    void rejectsDuplicateBindingIds() {
+        String yaml = """
+                mode: ROSBRIDGE
+                rosbridgeUrl: "ws://localhost:9090"
+                reads:
+                  - bindingId: SAME
+                    topic: /a
+                    msgType: nav_msgs/msg/Odometry
+                    signalTag: T.A
+                writes:
+                  - bindingId: SAME
+                    topic: /advisory/b
+                    msgType: std_msgs/msg/String
+                    signalTag: T.B
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        assertThrows(Exception.class, () -> Ros2BridgeConfigLoader.load(yaml));
+    }
+
+    @Test
+    void rejectsPeerObservationOnNonOdometryMsgType() {
+        String yaml = """
+                mode: ROSBRIDGE
+                rosbridgeUrl: "ws://localhost:9090"
+                reads:
+                  - bindingId: PEER
+                    topic: /peer/x
+                    msgType: sensor_msgs/msg/JointState
+                    signalTag: T.X
+                    asPeerObservation: true
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        assertThrows(Exception.class, () -> Ros2BridgeConfigLoader.load(yaml));
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2BridgeIntegrationTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/ros2/Ros2BridgeIntegrationTest.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.ros2;
+
+import com.rakovpublic.jneuropallium.ai.signals.fast.HarmVetoSignal;
+import com.rakovpublic.jneuropallium.ai.signals.fast.MotorCommandSignal;
+import com.rakovpublic.jneuropallium.ai.signals.fast.SensorySignal;
+import com.rakovpublic.jneuropallium.ai.signals.fast.TransparencyLogSignal;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import com.rakovpublic.jneuropallium.worker.net.layers.IResult;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.ProprioceptiveSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerObservationSignal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for the ROS 2 / DDS bridge. Covers the universal
+ * 00-FRAMEWORK §5 scenarios that apply (S1, S3, S4, S5) plus the
+ * bridge-specific scenarios S7–S11 from 04-ROS2-DDS.md §10. Runs against
+ * {@link InMemoryRos2Transport} — no rosbridge required.
+ */
+class Ros2BridgeIntegrationTest {
+
+    @TempDir Path tempDir;
+
+    private InMemoryRos2Transport transport;
+    private Ros2AuditOutput audit;
+    private Ros2ClientService svc;
+    private Ros2MessageMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        transport = new InMemoryRos2Transport();
+        mapper = new Ros2MessageMapper();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (svc != null) svc.close();
+        if (audit != null) audit.close();
+    }
+
+    /* ===== framework universal scenarios ====================================== */
+
+    /** S1: a /turtle1/pose delivers a typed signal within one drain. */
+    @Test
+    void s1_pureReadEmitsTypedSignal() throws Exception {
+        Ros2BridgeConfig cfg = baseConfig(
+                List.of(readBinding("ROBOT-ODOM", "/robot1/odom",
+                        "nav_msgs/msg/Odometry", "ROBOT.R1.ODOM")),
+                List.of(),
+                Map.of(),
+                false);
+        bring(cfg);
+
+        transport.deliver("/robot1/odom", odomJson(1.0, 2.0, 3.0, 0.1, 0.2, 0.3));
+
+        List<IInputSignal> signals = svc.drain("ROBOT-ODOM");
+        assertEquals(1, signals.size());
+        ProprioceptiveSignal sig = (ProprioceptiveSignal) signals.get(0);
+        assertArrayEquals(new double[]{1.0, 2.0, 3.0, 0.1, 0.2, 0.3},
+                sig.getJointStates(), 1e-9);
+    }
+
+    /** S3: SHADOW mode rejects writes; nothing reaches the wire. */
+    @Test
+    void s3_shadowModeRejectsWrite() throws Exception {
+        Ros2BridgeConfig cfg = baseConfig(
+                List.of(),
+                List.of(writeBinding("MISSION-ADVICE",
+                        "/jneopallium/advisory/mission_advice",
+                        "std_msgs/msg/String", "ROBOT.R1.MISSION_ADV")),
+                Map.of("MISSION-ADVICE", BridgeSafetyMode.SHADOW),
+                false);
+        bring(cfg);
+
+        Ros2AdvisoryOutputAggregator agg = new Ros2AdvisoryOutputAggregator(svc, audit);
+        MotorCommandSignal mc = new MotorCommandSignal(0, new double[]{1.0});
+        mc.setName("ROBOT.R1.MISSION_ADV");
+        mc.setExecute(true);
+        agg.save(List.of(result(mc)), System.currentTimeMillis(), 1L, null);
+
+        assertTrue(transport.published("/jneopallium/advisory/mission_advice").isEmpty(),
+                "SHADOW mode must not publish");
+        String log = Files.readString(tempDir.resolve("ros2-audit.jsonl"));
+        assertTrue(log.contains("SHADOW_MODE"), "expected SHADOW_MODE audit, got: " + log);
+    }
+
+    /** S4: reconnect drops the cache and emits a {@code BRIDGE_RECONNECTED} alarm. */
+    @Test
+    void s4_reconnectClearsCacheAndEmitsAdvisoryEvent() throws Exception {
+        Ros2BridgeConfig cfg = baseConfig(
+                List.of(readBinding("ROBOT-ODOM", "/robot1/odom",
+                        "nav_msgs/msg/Odometry", "ROBOT.R1.ODOM")),
+                List.of(),
+                Map.of(),
+                false);
+        bring(cfg);
+
+        transport.deliver("/robot1/odom", odomJson(0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+        // Drop and reconnect.
+        svc.onReconnected();
+
+        // Cache cleared: a fresh drain returns empty.
+        assertTrue(svc.drain("ROBOT-ODOM").isEmpty());
+
+        List<IInputSignal> events = svc.drainEvents();
+        assertTrue(events.stream().anyMatch(e ->
+                e instanceof AlarmSignal a
+                        && Ros2ClientService.BRIDGE_RECONNECTED.equals(a.getConditionCode())));
+    }
+
+    /* ===== bridge-specific scenarios (§10) ================================== */
+
+    /** S7: turtlesim subscribe — a turtle pose is mapped to a ProprioceptiveSignal. */
+    @Test
+    void s7_turtlesimSubscribePopulatesCache() throws Exception {
+        Ros2BridgeConfig cfg = baseConfig(
+                List.of(readBinding("TURTLE-POSE", "/turtle1/pose",
+                        "turtlesim/msg/Pose", "TURTLE.T1.POSE")),
+                List.of(),
+                Map.of(),
+                false);
+        bring(cfg);
+
+        String poseJson = """
+                {"x":5.5,"y":4.2,"theta":1.57,"linear_velocity":0.3,"angular_velocity":0.0}""";
+        transport.deliver("/turtle1/pose", poseJson);
+
+        List<IInputSignal> signals = svc.drain("TURTLE-POSE");
+        assertEquals(1, signals.size());
+        ProprioceptiveSignal sig = (ProprioceptiveSignal) signals.get(0);
+        assertEquals(5.5, sig.getJointStates()[0], 1e-9);
+        assertEquals(1.57, sig.getJointStates()[2], 1e-9);
+    }
+
+    /** S8: a config with /cmd_vel without simulatorOnly cannot load. */
+    @Test
+    void s8_cmdVelRejectedAtLoad() {
+        String yaml = """
+                mode: ROSBRIDGE
+                rosbridgeUrl: "ws://localhost:9090"
+                simulatorOnly: false
+                writes:
+                  - bindingId: BAD
+                    topic: /cmd_vel
+                    msgType: geometry_msgs/msg/Twist
+                    signalTag: BAD.CMDVEL
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        assertThrows(Exception.class, () -> Ros2BridgeConfigLoader.load(yaml));
+    }
+
+    /** S9: peer odometry binding emits {@link PeerObservationSignal}, not Proprioceptive. */
+    @Test
+    void s9_peerObservationSignal() throws Exception {
+        Ros2BridgeConfig cfg = baseConfig(
+                List.of(readBindingPeer("PEER-ODOM-2", "/robot2/odom",
+                        "nav_msgs/msg/Odometry", "ROBOT.R2.PEER_ODOM", "r2")),
+                List.of(),
+                Map.of(),
+                false);
+        bring(cfg);
+
+        transport.deliver("/robot2/odom", odomJson(7.0, 8.0, 0.0, 1.5, 0.0, 0.0));
+        List<IInputSignal> signals = svc.drain("PEER-ODOM-2");
+        assertEquals(1, signals.size());
+        PeerObservationSignal sig = (PeerObservationSignal) signals.get(0);
+        assertEquals("r2", sig.getPeerId());
+        assertArrayEquals(new double[]{7.0, 8.0, 0.0}, sig.getPositionLocal(), 1e-9);
+        assertArrayEquals(new double[]{1.5, 0.0, 0.0}, sig.getVelocityLocal(), 1e-9);
+    }
+
+    /** S10: decimateBy=10 → only every 10th message becomes a signal. */
+    @Test
+    void s10_decimationDropsIntermediateMessages() throws Exception {
+        Ros2BridgeConfig cfg = baseConfig(
+                List.of(readBindingDecimate("CAM", "/camera/image_raw",
+                        "sensor_msgs/msg/Image", "ROBOT.R1.CAM", 10)),
+                List.of(),
+                Map.of(),
+                false);
+        bring(cfg);
+
+        for (int i = 0; i < 30; i++) {
+            transport.deliver("/camera/image_raw", "{\"data\":[" + i + "]}");
+        }
+        List<IInputSignal> signals = svc.drain("CAM");
+        // 30 messages, decimateBy=10 → 3 signals (counters 10, 20, 30).
+        assertEquals(3, signals.size());
+        assertTrue(signals.get(0) instanceof SensorySignal);
+    }
+
+    /** S11: simulator-only mode allows /cmd_vel publish. */
+    @Test
+    void s11_simulatorOnlyAllowsCmdVel() throws Exception {
+        Ros2BridgeConfig cfg = baseConfig(
+                List.of(),
+                List.of(writeBinding("SIM-CMDVEL", "/cmd_vel",
+                        "geometry_msgs/msg/Twist", "SIM.CMDVEL")),
+                Map.of(),
+                true);
+        bring(cfg);
+
+        Ros2AdvisoryOutputAggregator agg = new Ros2AdvisoryOutputAggregator(svc, audit);
+        MotorCommandSignal mc = new MotorCommandSignal(0, new double[]{0.5, 0.0, 0.0, 0.0, 0.0, 0.1});
+        mc.setName("SIM.CMDVEL");
+        mc.setExecute(true);
+        agg.save(List.of(result(mc)), System.currentTimeMillis(), 1L, null);
+
+        List<String> publishes = transport.published("/cmd_vel");
+        assertEquals(1, publishes.size());
+        assertTrue(publishes.get(0).contains("\"linear\""), "Twist payload expected: " + publishes.get(0));
+    }
+
+    /**
+     * Forbidden-topic backstop at runtime: rebuilding a config to flip
+     * {@code simulatorOnly} from {@code true} to {@code false} re-runs the
+     * check and throws. This is the second line of defence behind the
+     * load-time rejection — there is no path that constructs a non-simulator
+     * config with a forbidden write binding.
+     */
+    @Test
+    void runtimeBackstopForForbiddenTopic() {
+        Ros2BridgeConfig simCfg = baseConfig(
+                List.of(),
+                List.of(writeBinding("SIM-CMDVEL", "/cmd_vel",
+                        "geometry_msgs/msg/Twist", "SIM.CMDVEL")),
+                Map.of(),
+                true);
+        assertThrows(IllegalArgumentException.class, () -> new Ros2BridgeConfig(
+                simCfg.mode(), simCfg.rosbridgeUrl(), simCfg.domainId(),
+                simCfg.qosProfile(),
+                false,
+                simCfg.reads(), simCfg.writes(), simCfg.audit(),
+                simCfg.perTagSafetyMode(), simCfg.tickInterval()));
+    }
+
+    /** Audit shape conforms to 00-FRAMEWORK §4. */
+    @Test
+    void auditShapeMatchesFramework() throws Exception {
+        Ros2BridgeConfig cfg = baseConfig(
+                List.of(),
+                List.of(writeBinding("MISSION-ADVICE",
+                        "/jneopallium/advisory/mission_advice",
+                        "std_msgs/msg/String", "ROBOT.R1.MISSION_ADV")),
+                Map.of("MISSION-ADVICE", BridgeSafetyMode.ADVISORY),
+                false);
+        bring(cfg);
+
+        Ros2AdvisoryOutputAggregator agg = new Ros2AdvisoryOutputAggregator(svc, audit);
+        HarmVetoSignal veto = new HarmVetoSignal();
+        veto.setName("ROBOT.R1.MISSION_ADV");
+        veto.setVetoReason("HARMFUL_ACTION");
+        agg.save(List.of(result(veto)), 1700000000000L, 42L, null);
+
+        // Force a flush, then read.
+        audit.close();
+        audit = null;
+        String log = Files.readString(tempDir.resolve("ros2-audit.jsonl"));
+        assertTrue(log.contains("\"bridge\":\"ros2\""), "missing bridge key: " + log);
+        assertTrue(log.contains("\"verdict\":\"APPLIED\""), "missing APPLIED verdict: " + log);
+        assertTrue(log.contains("\"tag\":\"ROBOT.R1.MISSION_ADV\""), "missing tag: " + log);
+    }
+
+    /** TransparencyLogSignal flows to the optional audit-mirror topic. */
+    @Test
+    void transparencyLogMirrorsToAuditTopic() throws Exception {
+        Ros2BridgeConfig cfg = new Ros2BridgeConfig(
+                Ros2BridgeConfig.TransportMode.ROSBRIDGE,
+                "ws://localhost:9090", null,
+                Ros2BridgeConfig.QosProfile.SENSOR_DATA,
+                false,
+                List.of(),
+                List.of(),
+                new Ros2BridgeConfig.AuditConfig(
+                        tempDir.resolve("ros2-audit.jsonl").toString(),
+                        "/jneopallium/advisory/audit"),
+                Map.of(),
+                null);
+        bring(cfg);
+
+        Ros2AdvisoryOutputAggregator agg = new Ros2AdvisoryOutputAggregator(svc, audit);
+        TransparencyLogSignal tl = new TransparencyLogSignal();
+        tl.setActionPlanId("plan-1");
+        agg.save(List.of(result(tl)), System.currentTimeMillis(), 1L, null);
+
+        assertFalse(transport.published("/jneopallium/advisory/audit").isEmpty(),
+                "audit-mirror topic should have a publish");
+    }
+
+    /* ===== helpers ============================================================ */
+
+    private void bring(Ros2BridgeConfig cfg) {
+        Path file = tempDir.resolve("ros2-audit.jsonl");
+        audit = new Ros2AuditOutput(file);
+        svc = new Ros2ClientService(cfg, transport, mapper, audit);
+        svc.start();
+    }
+
+    private static Ros2BridgeConfig baseConfig(
+            List<Ros2BridgeConfig.ReadBindingConfig> reads,
+            List<Ros2BridgeConfig.WriteBindingConfig> writes,
+            Map<String, BridgeSafetyMode> safetyModes,
+            boolean simulatorOnly) {
+        return new Ros2BridgeConfig(
+                Ros2BridgeConfig.TransportMode.ROSBRIDGE,
+                "ws://localhost:9090", null,
+                Ros2BridgeConfig.QosProfile.SENSOR_DATA,
+                simulatorOnly,
+                reads, writes,
+                new Ros2BridgeConfig.AuditConfig(
+                        java.nio.file.Path.of(System.getProperty("java.io.tmpdir"),
+                                "ros2-audit.jsonl").toString(), null),
+                safetyModes,
+                null);
+    }
+
+    private static Ros2BridgeConfig.ReadBindingConfig readBinding(
+            String id, String topic, String msgType, String signalTag) {
+        return new Ros2BridgeConfig.ReadBindingConfig(
+                id, topic, msgType, signalTag, null, false, null, 1, 720, 1_048_576);
+    }
+
+    private static Ros2BridgeConfig.ReadBindingConfig readBindingPeer(
+            String id, String topic, String msgType, String signalTag, String peerId) {
+        return new Ros2BridgeConfig.ReadBindingConfig(
+                id, topic, msgType, signalTag, null, true, peerId, 1, 720, 1_048_576);
+    }
+
+    private static Ros2BridgeConfig.ReadBindingConfig readBindingDecimate(
+            String id, String topic, String msgType, String signalTag, int decimate) {
+        return new Ros2BridgeConfig.ReadBindingConfig(
+                id, topic, msgType, signalTag, null, false, null, decimate, 720, 1_048_576);
+    }
+
+    private static Ros2BridgeConfig.WriteBindingConfig writeBinding(
+            String id, String topic, String msgType, String signalTag) {
+        return new Ros2BridgeConfig.WriteBindingConfig(
+                id, topic, msgType, signalTag, null, null, null, null);
+    }
+
+    private static String odomJson(double px, double py, double pz, double vx, double vy, double vz) {
+        return ("{\"pose\":{\"pose\":{\"position\":{\"x\":%s,\"y\":%s,\"z\":%s}}},"
+                + "\"twist\":{\"twist\":{\"linear\":{\"x\":%s,\"y\":%s,\"z\":%s}}}}")
+                .formatted(px, py, pz, vx, vy, vz);
+    }
+
+    private static IResult<IResultSignal> result(IResultSignal<?> s) {
+        return new IResult<>() {
+            @Override public IResultSignal getResult() { return s; }
+            @Override public Long getNeuronId() { return 1L; }
+        };
+    }
+}


### PR DESCRIPTION
Strategy B (rosbridge_suite over the JDK's built-in java.net.http.WebSocket). Strategy A (rcljava) is left as a feature flag in RcljavaClientService and is not built into the worker jar.

Key safety rules:
- /cmd_vel, /joint_trajectory, /joint_command write bindings rejected at config load AND at runtime unless simulatorOnly: true.
- AUTONOMOUS per-tag promotion rejected unless simulatorOnly: true (the simulator-with-watchdog escape).
- ADVISORY ceiling enforced by the aggregator; SHADOW mode drops publishes with a SHADOW_MODE audit; MotorCommandSignal forwarded only when execute=true.
- Decimation (decimateBy) and per-binding payload caps (maxPayloadBytes) applied in Ros2ClientService; oversized payloads audited at most once per minute per binding.
- Reconnect drops the latest-value cache and emits a BRIDGE_RECONNECTED AlarmSignal.

Signal mapping reuses existing types: SensorySignal, ProprioceptiveSignal, EfficiencySignal, PeerObservationSignal, MotorCommandSignal, FormationSignal, HarmVetoSignal, TransparencyLogSignal. Four signals (Sensory, Proprioceptive, PeerObservation, Efficiency) gain IInputSignal so they flow through IInitInput as the framework defines; BaseSignal gains IResultSignal so the fast-signal hierarchy can be passed through IOutputAggregator.save().

Tests: 19 ROS 2 bridge tests cover the framework universal scenarios that apply (S1, S3, S4) plus the bridge-specific scenarios S7-S11 from §10. Full mvn verify passes (worker + master).