### PR TITLE
Implement MAVLink bridge (12-MAVLINK.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ every loop.
 | 09 | OpenTelemetry | observability | spec | EXPORT-ONLY (no writeback) |
 | 10 | Eclipse Ditto | digital twins | shipped | ADVISORY |
 | 11 | IEC 61850 | power grid | spec | READ-ONLY initially |
-| 12 | MAVLink | drones | spec | SIM-ONLY initially |
+| 12 | MAVLink | drones | shipped | SIM-ONLY initially |
 | 13 | CANopen | embedded | spec | ADVISORY |
 | 14 | LTI / xAPI | adaptive tutoring | spec | ADVISORY |
 
@@ -281,6 +281,26 @@ the actual control feature. The advisory-prefix rule is enforced both at
 config load and at runtime; `AUTONOMOUS` per-tag promotion is rejected by
 the config validator. See [`docs/ditto-bridge.md`](docs/ditto-bridge.md)
 and [`10-DITTO.md`](10-DITTO.md).
+
+### MAVLink bridge
+
+For drones and small autonomous vehicles the MAVLink bridge wraps the
+`dronefleet/mavlink` Java codec and routes messages from one or more SITL
+or hardware MAVLink connections (UDP / TCP) onto the Jneopallium signal
+bus: `GLOBAL_POSITION_INT` / `ATTITUDE` → `ProprioceptiveSignal`,
+peer `GLOBAL_POSITION_INT` → `PeerObservationSignal`, `BATTERY_STATUS` →
+`EfficiencySignal`, `STATUSTEXT` / `SYS_STATUS` → `AlarmSignal`,
+`RADIO_STATUS` → `AnomalyScoreSignal`, missed `HEARTBEAT` → `PEER_OFFLINE`
+alarm. Egress is restricted to advisory message types (`STATUSTEXT`,
+`NAMED_VALUE_FLOAT`, custom `JNEO_*` dialect) consumed by an external
+supervisor or ground station — never `COMMAND_LONG`, `SET_MODE`,
+`MISSION_*`, `MANUAL_CONTROL`, `RC_CHANNELS_OVERRIDE` directly to a flying
+autopilot. The forbidden-message-type rule and the `expectedSystems`
+whitelist are enforced both at config load and at runtime; per-tag
+`AUTONOMOUS` promotion is rejected unless `simulatorOnly: true` is set,
+which models the simulator-with-watchdog escape. See
+[`docs/mavlink-bridge.md`](docs/mavlink-bridge.md) and
+[`12-MAVLINK.md`](12-MAVLINK.md).
 
 ## Applications
 

--- a/docs/mavlink-bridge.md
+++ b/docs/mavlink-bridge.md
@@ -1,0 +1,182 @@
+# MAVLink bridge
+
+> Companion to [`12-MAVLINK.md`](../12-MAVLINK.md) (the spec) and
+> [`00-FRAMEWORK.md`](../00-FRAMEWORK.md) (the universal contract). This file
+> documents the MAVLink bridge's domain context, YAML schema, manual demo
+> procedure, and regulatory posture — i.e. the §10 Definition-of-Done items
+> that don't belong in the spec itself.
+
+## Domain context
+
+[MAVLink](https://mavlink.io/) (Micro Air Vehicle Link) is the lightweight
+binary messaging protocol used by ArduPilot, PX4, QGroundControl, Mission
+Planner and most open-source ground stations. The bridge wraps the pure-Java
+[`dronefleet/mavlink`](https://github.com/dronefleet/mavlink) codec, which
+covers MAVLink 1 + 2, the `common.xml` dialect and the `ardupilotmega.xml`
+extensions, and surfaces those messages onto the Jneopallium signal bus.
+
+The bridge is **SIM-ONLY** by construction (12-MAVLINK.md §3): it subscribes
+to drone telemetry (`HEARTBEAT`, `GLOBAL_POSITION_INT`, `ATTITUDE`,
+`BATTERY_STATUS`, `SYS_STATUS`, `STATUSTEXT`, `RADIO_STATUS`,
+`MISSION_CURRENT`), emits typed `ProprioceptiveSignal` /
+`PeerObservationSignal` / `EfficiencySignal` / `AlarmSignal` /
+`AnomalyScoreSignal` instances, and publishes neuron-derived
+`HarmVetoSignal` / `FormationSignal` / `TaskAnnouncementSignal` decisions as
+**advisory** MAVLink messages (`STATUSTEXT`, `NAMED_VALUE_FLOAT`, custom
+`JNEO_*` dialect) consumed by an external supervisor or ground station — never
+as `COMMAND_LONG`, `SET_MODE`, `MANUAL_CONTROL`, `RC_CHANNELS_OVERRIDE`,
+`MISSION_*`, `COMMAND_INT` directly to a flying autopilot.
+
+The forbidden-message-type rule is enforced both at config load (in
+`MavlinkBridgeConfig`) and at runtime (in `MavlinkClientService.send`);
+per-tag `AUTONOMOUS` promotion is rejected unless `simulatorOnly: true` is
+set, which models the simulator-with-watchdog escape from §3. A
+non-whitelisted `system_id` (a stranger drone on the shared UDP segment) is
+dropped with one audit per minute (§11 R1).
+
+## Components
+
+```
+worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/
+├── MavlinkBridgeConfig.java               ← YAML record (immutable, COMMAND_LONG rejected)
+├── MavlinkBridgeConfigLoader.java         ← Jackson YAML loader, FAIL_ON_UNKNOWN
+├── MavlinkConnectionBinding.java          ← per-connection routing record
+├── MavlinkMessageBinding.java             ← read/event/write binding (BridgeBinding)
+├── MavlinkSignalMapper.java               ← MAVLink payload ↔ typed signal (pure)
+├── MavlinkTransport.java                  ← test-seam interface
+├── MavlinkClientService.java              ← lifecycle, multi-system routing, heartbeat watchdog
+├── MavlinkTelemetryInput.java             ← IInitInput → ProprioceptiveSignal/EfficiencySignal
+├── MavlinkSwarmInput.java                 ← IInitInput → PeerObservationSignal
+├── MavlinkEventInput.java                 ← IInitInput → AlarmSignal/AnomalyScoreSignal
+├── MavlinkAuditOutput.java                ← local JSONL audit (no in-band mirror — §5)
+├── MavlinkAdvisoryOutputAggregator.java   ← IOutputAggregator (STATUSTEXT/NAMED_VALUE_FLOAT only)
+└── package-info.java
+```
+
+## YAML schema
+
+Refer to 12-MAVLINK.md §6 for the canonical example. Key points:
+
+* `connections` is a list — one MAVLink connection per entry. `transport`
+  is `UDP` (bind on `bindAddress` + `bindPort`, e.g. `0.0.0.0:14550` for
+  ArduPilot SITL) or `TCP` (connect to `host:port`, e.g. `127.0.0.1:5760`
+  for PX4 SITL). Serial is hardware-only and out of scope.
+* `expectedSystems` whitelists the `system_id`s that can talk on the
+  connection. Any other system is dropped silently with a single audit per
+  minute. **Always set this** when sharing a UDP segment with anything
+  else (§11 R1).
+* `simulatorOnly: false` (the production default) forbids `writes` whose
+  `messageType` names an actuating command. Setting `simulatorOnly: true`
+  unlocks them — only do that when (a) the connection points at a SITL
+  instance and (b) the operator runbook documents the watchdog node.
+* Each `read` binding maps one `(systemId, messageType)` tuple to one
+  signal class. The class is inferred from `messageType` if `targetSignal`
+  is not set:
+  - `GLOBAL_POSITION_INT`, `ATTITUDE`, `GPS_RAW_INT` → `ProprioceptiveSignal`
+    (own-MAV) or `PeerObservationSignal` (when `targetSignal:
+    PEER_OBSERVATION` and `messageType: GLOBAL_POSITION_INT`)
+  - `BATTERY_STATUS` → `EfficiencySignal` (`batteryRemaining` / 100)
+  - `SYS_STATUS` → `AlarmSignal` when an enabled sensor is unhealthy
+  - `STATUSTEXT` → `AlarmSignal` (severity → `AlarmPriority`)
+  - `RADIO_STATUS` → `AnomalyScoreSignal` when RSSI < 30 or noise > 80
+* `events` are message types whose binding is system-agnostic: a single
+  `STATUSTEXT` binding fires for every drone on the connection. The
+  resulting signal's tag is `<signalTagPrefix>.<systemId>`.
+* `decimateBy` on a read binding drops all but every Nth message.
+* Each `write` binding clamps to `[minClampValue, maxClampValue]` and
+  rate-limits to `rampRateMaxPerSec`. The bridge encodes outbound
+  advisory traffic as `STATUSTEXT` for `HarmVetoSignal` / `FormationSignal`
+  / `TaskAnnouncementSignal`. Once the `jneo.xml` dialect is generated and
+  committed (§7), swap the encoder helpers in
+  `MavlinkAdvisoryOutputAggregator.MavlinkAdvisoryEncoder` for the typed
+  custom-dialect payloads.
+
+## Heartbeat liveness
+
+`MavlinkClientService.checkHeartbeats(nowMs)` should be called once per tick
+by the host loop. For every `(connectionId, systemId)` from which a
+`HEARTBEAT` has ever arrived, if more than 2s elapses without a fresh one,
+the bridge emits a `PEER_OFFLINE` `AlarmSignal` (priority `HIGH`) on the
+advisory event channel and remembers it so the alarm is not duplicated until
+the next online → offline transition.
+
+## Manual demo (ArduPilot SITL)
+
+Phase 1 acceptance test for the bridge follows §10 S7. Outside of
+unit/integration tests, the manual demo is:
+
+```bash
+# 1. Bring up ArduPilot SITL bound to UDP 14550.
+sim_vehicle.py -v ArduCopter --console --map
+
+# 2. Point the bridge at the SITL endpoint and bind GLOBAL_POSITION_INT.
+cat <<EOF > /tmp/mavlink-bridge.yaml
+connections:
+  - id: SITL
+    transport: UDP
+    bindAddress: "0.0.0.0"
+    bindPort: 14550
+    expectedSystems: [1]
+simulatorOnly: true
+reads:
+  - bindingId: DRONE-1-POS
+    connectionId: SITL
+    systemId: 1
+    componentId: 1
+    messageType: GLOBAL_POSITION_INT
+    targetSignal: PROPRIOCEPTIVE
+    signalTag: DRONE.1.POS
+  - bindingId: DRONE-1-ATT
+    connectionId: SITL
+    systemId: 1
+    messageType: ATTITUDE
+    signalTag: DRONE.1.ATT
+  - bindingId: DRONE-1-BATT
+    connectionId: SITL
+    systemId: 1
+    messageType: BATTERY_STATUS
+    signalTag: DRONE.1.BATT
+events:
+  - bindingId: STATUS-TEXTS
+    connectionId: SITL
+    messageType: STATUSTEXT
+    targetSignal: ALARM
+    signalTagPrefix: DRONE.STATUS
+audit:
+  localAuditFile: /tmp/jneopallium/mavlink-audit.jsonl
+EOF
+
+# 3. Run a small Java program that loads the config, builds
+#    MavlinkClientService + MavlinkTelemetryInput/MavlinkEventInput, and
+#    prints the signals it drains each tick. After ~2s the cache should
+#    contain ProprioceptiveSignal / EfficiencySignal instances reflecting
+#    SITL telemetry; takeoff in the SITL console produces ATTITUDE and
+#    GLOBAL_POSITION_INT updates at the configured telemetry rate.
+```
+
+A multi-system swarm demo (§10 S8) follows the same recipe with N copies of
+SITL on different ports / `system_id`s and `expectedSystems: [1, 2, 3, 4, 5]`.
+For PX4 SITL substitute the `transport: TCP` form and point `host`/`port` at
+`127.0.0.1:5760`.
+
+## Regulatory posture
+
+The bridge ceiling is `SIM-ONLY` (12-MAVLINK.md §3, §11.12). A drone in the
+air is a kinetic-energy hazard: the bridge does **not** emit
+`COMMAND_LONG`, `COMMAND_INT`, `SET_MODE`, `MANUAL_CONTROL`,
+`RC_CHANNELS_OVERRIDE`, `MISSION_ITEM`, `MISSION_ITEM_INT`, `MISSION_COUNT`,
+`MISSION_CLEAR_ALL`, `MISSION_SET_CURRENT` or `MISSION_WRITE_PARTIAL_LIST`
+in any production environment. The intended steady state is:
+
+* Bridge subscribes to telemetry → produces typed signals.
+* Jneopallium swarm/planning module reasons over them.
+* Bridge publishes `STATUSTEXT` and `NAMED_VALUE_FLOAT` (and, once
+  generated, `JNEO_FORMATION` / `JNEO_TASK_ANNOUNCEMENT` / `JNEO_HARM_VETO`)
+  to a ground station or autonomy supervisor that decides whether to forward
+  the advice to the autopilot.
+
+`TransparencyLogSignal` is intentionally never written to MAVLink (§5):
+audit records belong on a dedicated channel (the JSONL file plus, if
+configured, a Kafka topic via the OpenTelemetry/Kafka bridges) — not on
+the flight bus. Hardware deployment requires a separate, certified bridge;
+that work is explicitly out of scope here.

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <opentelemetry-instrumentation.version>2.9.0</opentelemetry-instrumentation.version>
         <hivemq-mqtt-client.version>1.3.3</hivemq-mqtt-client.version>
         <tahu.version>1.0.7</tahu.version>
+        <dronefleet-mavlink.version>1.1.11</dronefleet-mavlink.version>
 
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
@@ -98,6 +99,14 @@
                 <groupId>org.eclipse.tahu</groupId>
                 <artifactId>tahu-core</artifactId>
                 <version>${tahu.version}</version>
+            </dependency>
+            <!-- MAVLink (Bridge 12 — 12-MAVLINK.md §2). dronefleet/mavlink is
+                 a pure-Java codec for MAVLink 1 + 2 covering common.xml and
+                 ardupilotmega.xml. -->
+            <dependency>
+                <groupId>io.dronefleet.mavlink</groupId>
+                <artifactId>mavlink</artifactId>
+                <version>${dronefleet-mavlink.version}</version>
             </dependency>
             <!-- Spring Boot 3 BOM -->
             <dependency>

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -134,6 +134,15 @@
             <artifactId>tahu-core</artifactId>
         </dependency>
 
+        <!-- ============== MAVLink (Bridge 12) ==============
+             dronefleet/mavlink Java library — pure Java, supports MAVLink 1
+             + 2, covers common.xml and ardupilotmega.xml. Version pinned in
+             the parent BOM (12-MAVLINK.md §2). -->
+        <dependency>
+            <groupId>io.dronefleet.mavlink</groupId>
+            <artifactId>mavlink</artifactId>
+        </dependency>
+
         <!-- ============== OPC UA (Phase 2) ============== -->
         <!-- Versions come from the milo-bom imported in the parent. -->
         <dependency>

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkAdvisoryOutputAggregator.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkAdvisoryOutputAggregator.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.mavlink;
+
+import com.rakovpublic.jneuropallium.ai.signals.fast.HarmVetoSignal;
+import com.rakovpublic.jneuropallium.ai.signals.fast.TransparencyLogSignal;
+import com.rakovpublic.jneuropallium.worker.application.IOutputAggregator;
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import com.rakovpublic.jneuropallium.worker.net.layers.IResult;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.FormationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.TaskAnnouncementSignal;
+import com.rakovpublic.jneuropallium.worker.util.IContext;
+import io.dronefleet.mavlink.common.MavSeverity;
+import io.dronefleet.mavlink.common.NamedValueFloat;
+import io.dronefleet.mavlink.common.Statustext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IOutputAggregator} for the MAVLink advisory egress (12-MAVLINK.md §3,
+ * §5 egress table).
+ *
+ * <p>Per §3 the bridge's structural ceiling is <b>SIM-ONLY</b>: outbound
+ * traffic is restricted to the advisory message types {@code STATUSTEXT},
+ * {@code NAMED_VALUE_FLOAT}, and the custom {@code JNEO_*} dialect. Writes
+ * to actuating message types ({@code COMMAND_LONG}, {@code SET_MODE}, etc.)
+ * are rejected at config load and again at runtime by
+ * {@link MavlinkClientService}.
+ *
+ * <p>This implementation encodes all advisory egress as the dronefleet
+ * {@link Statustext} or {@link NamedValueFloat} message records so the
+ * bridge ships with a working advisory channel out of the box. The custom
+ * {@code JNEO_*} dialect classes are stubbed via {@code STATUSTEXT} payloads
+ * with a structured {@code "JNEO_FORMATION:..."} prefix; once the
+ * {@code jneo.xml} dialect is generated and committed (§7), the encoder
+ * helpers in {@link MavlinkAdvisoryEncoder} are the single place to swap.
+ *
+ * <p>{@link TransparencyLogSignal} is intentionally NOT forwarded onto the
+ * MAVLink wire — §5 keeps the audit trail off the flight bus. The signal
+ * is dropped here so it does not accidentally reach the autopilot.
+ */
+public final class MavlinkAdvisoryOutputAggregator implements IOutputAggregator {
+
+    private static final Logger log = LoggerFactory.getLogger(MavlinkAdvisoryOutputAggregator.class);
+
+    private final MavlinkClientService svc;
+    private final AbstractBridgeAuditOutput audit;
+    private final MavlinkBridgeConfig config;
+    private final MavlinkAdvisoryEncoder encoder;
+
+    public MavlinkAdvisoryOutputAggregator(MavlinkClientService svc,
+                                           AbstractBridgeAuditOutput audit) {
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.audit = Objects.requireNonNull(audit, "audit");
+        this.config = svc.config();
+        this.encoder = new MavlinkAdvisoryEncoder();
+    }
+
+    @Override
+    public void save(List<IResult> results, long timestamp, long run, IContext context) {
+        if (results == null || results.isEmpty()) return;
+        for (IResult r : results) {
+            if (r == null) continue;
+            IResultSignal<?> s = r.getResult();
+            if (s == null) continue;
+            Long neuronId = r.getNeuronId();
+            try {
+                if (s instanceof FormationSignal fs) {
+                    handleFormation(fs, timestamp, run, neuronId);
+                } else if (s instanceof TaskAnnouncementSignal ta) {
+                    handleTaskAnnouncement(ta, timestamp, run, neuronId);
+                } else if (s instanceof HarmVetoSignal hv) {
+                    handleVeto(hv, timestamp, run, neuronId);
+                } else if (s instanceof TransparencyLogSignal) {
+                    // §5: keep audit OFF the flight bus. Silently drop.
+                    log.debug("TransparencyLogSignal not forwarded to MAVLink (12-MAVLINK.md §5)");
+                }
+            } catch (RuntimeException ex) {
+                audit.append(new BridgeAuditRecord(
+                        timestamp, run, MavlinkClientService.BRIDGE_NAME,
+                        BridgeAuditRecord.Verdict.FAILED,
+                        null, null, null, null,
+                        BridgeAuditRecord.RejectReason.EXCEPTION + ":" + ex.getClass().getSimpleName(),
+                        null, evidence(neuronId)));
+            }
+        }
+    }
+
+    /* ===== command paths ============================================== */
+
+    private void handleFormation(FormationSignal fs, long ts, long run, Long neuronId) {
+        String tag = fs.getName();
+        MavlinkMessageBinding b = tag == null ? null : svc.writeBindingForTag(tag);
+        if (b == null) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, MavlinkClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    null, tag, (double) fs.getSlotIndex(), null,
+                    BridgeAuditRecord.RejectReason.UNKNOWN_TAG, null, evidence(neuronId)));
+            return;
+        }
+        BridgeSafetyMode mode = config.perTagSafetyMode()
+                .getOrDefault(b.bindingId(), BridgeSafetyMode.ADVISORY);
+        if (mode == BridgeSafetyMode.SHADOW) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, MavlinkClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    b.loopId(), tag, (double) fs.getSlotIndex(), null,
+                    BridgeAuditRecord.RejectReason.SHADOW_MODE, mode, evidence(neuronId)));
+            return;
+        }
+        Object payload = encoder.encodeFormation(fs);
+        boolean ok = svc.send(b.bindingId(), payload, ts, run);
+        if (ok) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, MavlinkClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.APPLIED,
+                    b.loopId(), tag, (double) fs.getSlotIndex(), (double) fs.getSlotIndex(),
+                    null, mode, evidence(neuronId)));
+        }
+    }
+
+    private void handleTaskAnnouncement(TaskAnnouncementSignal ta, long ts, long run, Long neuronId) {
+        String tag = ta.getName();
+        MavlinkMessageBinding b = tag == null ? null : svc.writeBindingForTag(tag);
+        if (b == null) return;
+        BridgeSafetyMode mode = config.perTagSafetyMode()
+                .getOrDefault(b.bindingId(), BridgeSafetyMode.ADVISORY);
+        if (mode == BridgeSafetyMode.SHADOW) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, MavlinkClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    b.loopId(), tag, ta.getReward(), null,
+                    BridgeAuditRecord.RejectReason.SHADOW_MODE, mode, evidence(neuronId)));
+            return;
+        }
+        Object payload = encoder.encodeTaskAnnouncement(ta);
+        boolean ok = svc.send(b.bindingId(), payload, ts, run);
+        if (ok) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, MavlinkClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.APPLIED,
+                    b.loopId(), tag, ta.getReward(), ta.getReward(),
+                    null, mode, evidence(neuronId)));
+        }
+    }
+
+    private void handleVeto(HarmVetoSignal hv, long ts, long run, Long neuronId) {
+        // §5 — operator visibility on STATUSTEXT(severity=CRITICAL).
+        String tag = hv.getName();
+        MavlinkMessageBinding b = tag == null ? null : svc.writeBindingForTag(tag);
+        if (b == null) return;
+        BridgeSafetyMode mode = config.perTagSafetyMode()
+                .getOrDefault(b.bindingId(), BridgeSafetyMode.ADVISORY);
+        if (mode == BridgeSafetyMode.SHADOW) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, MavlinkClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    b.loopId(), tag, null, null,
+                    BridgeAuditRecord.RejectReason.SHADOW_MODE, mode, evidence(neuronId)));
+            return;
+        }
+        Statustext payload = encoder.encodeHarmVeto(hv);
+        boolean ok = svc.send(b.bindingId(), payload, ts, run);
+        if (ok) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, MavlinkClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.APPLIED,
+                    b.loopId(), tag, null, null, null, mode, evidence(neuronId)));
+        }
+    }
+
+    private static List<String> evidence(Long neuronId) {
+        return neuronId == null ? List.of() : List.of(String.valueOf(neuronId));
+    }
+
+    /**
+     * Centralised payload builders (12-MAVLINK.md §5, §7). Once the
+     * {@code jneo.xml} dialect is generated, swap the {@code Statustext}
+     * stubs here for the corresponding {@code JneoFormation},
+     * {@code JneoTaskAnnouncement}, {@code JneoHarmVeto} payloads.
+     */
+    public static final class MavlinkAdvisoryEncoder {
+
+        /** Truncate to the STATUSTEXT 50-byte limit. */
+        private static String fit(String s) {
+            if (s == null) return "";
+            return s.length() > 50 ? s.substring(0, 50) : s;
+        }
+
+        public Statustext encodeFormation(FormationSignal fs) {
+            String body = "JNEO_FORMATION:"
+                    + (fs.getTemplate() == null ? "FREE" : fs.getTemplate().name())
+                    + ":slot=" + fs.getSlotIndex();
+            return Statustext.builder()
+                    .severity(MavSeverity.MAV_SEVERITY_INFO)
+                    .text(fit(body))
+                    .build();
+        }
+
+        public Statustext encodeTaskAnnouncement(TaskAnnouncementSignal ta) {
+            String body = "JNEO_TASK_ANN:" + ta.getTaskId()
+                    + ":kind=" + (ta.getKind() == null ? "EXPLORE" : ta.getKind().name())
+                    + ":r=" + ta.getReward();
+            return Statustext.builder()
+                    .severity(MavSeverity.MAV_SEVERITY_INFO)
+                    .text(fit(body))
+                    .build();
+        }
+
+        public Statustext encodeHarmVeto(HarmVetoSignal hv) {
+            String reason = hv.getVetoReason() == null ? "VETO" : hv.getVetoReason();
+            return Statustext.builder()
+                    .severity(MavSeverity.MAV_SEVERITY_CRITICAL)
+                    .text(fit("JNEO_HARM_VETO:" + reason))
+                    .build();
+        }
+
+        public NamedValueFloat encodeNamedValue(String name, float value) {
+            return NamedValueFloat.builder()
+                    .timeBootMs(System.currentTimeMillis())
+                    .name(name == null ? "" : (name.length() > 10 ? name.substring(0, 10) : name))
+                    .value(value)
+                    .build();
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkAuditOutput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkAuditOutput.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.mavlink;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+
+import java.nio.file.Path;
+
+/**
+ * JSONL audit sink for the MAVLink bridge (00-FRAMEWORK §4, §6;
+ * 12-MAVLINK.md §6 {@code audit.localAuditFile}).
+ *
+ * <p>The MAVLink bridge does NOT mirror audits onto the flight bus
+ * (12-MAVLINK.md §5: "TransparencyLogSignal: dedicated log channel — NOT
+ * MAVLink — keep audit out of the flight bus"). The audit pipe is a local
+ * JSONL file only; downstream relays (Kafka via the OpenTelemetry/Kafka
+ * bridges) consume it out-of-band.
+ */
+public final class MavlinkAuditOutput extends AbstractBridgeAuditOutput {
+
+    public MavlinkAuditOutput(Path file) { super(file); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkBridgeConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkBridgeConfig.java
@@ -1,0 +1,368 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.mavlink;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Top-level configuration for the MAVLink bridge (12-MAVLINK.md §6).
+ * Loaded from YAML via {@link MavlinkBridgeConfigLoader}. Immutable.
+ *
+ * <p>Per 12-MAVLINK.md §3 the structural ceiling is {@code SIM-ONLY}: writes
+ * to the actuator-class MAVLink message types in
+ * {@link #FORBIDDEN_WRITE_MESSAGE_TYPES} are rejected at config load unless
+ * {@link #simulatorOnly()} is {@code true}, and {@code AUTONOMOUS} per-tag
+ * promotion is rejected for the same reason. Bindings whose {@code systemId}
+ * does not appear in their connection's {@code expectedSystems} whitelist
+ * are also rejected (§6, §11 R1) — this catches typos that would silently
+ * consume cross-talk on a shared UDP segment.
+ */
+public record MavlinkBridgeConfig(
+        List<ConnectionConfig> connections,
+        boolean simulatorOnly,
+        List<ReadBindingConfig> reads,
+        List<EventBindingConfig> events,
+        List<WriteBindingConfig> writes,
+        AuditConfig audit,
+        Map<String, BridgeSafetyMode> perTagSafetyMode,
+        Duration tickInterval
+) {
+
+    /**
+     * MAVLink message types whose write bindings are rejected unless
+     * {@link #simulatorOnly()} is {@code true}. These name commands that
+     * the bridge MUST NOT emit toward a physical autopilot
+     * (12-MAVLINK.md §3, §6).
+     */
+    public static final Set<String> FORBIDDEN_WRITE_MESSAGE_TYPES = Set.of(
+            "COMMAND_LONG",
+            "COMMAND_INT",
+            "SET_MODE",
+            "MANUAL_CONTROL",
+            "RC_CHANNELS_OVERRIDE",
+            "MISSION_ITEM",
+            "MISSION_ITEM_INT",
+            "MISSION_COUNT",
+            "MISSION_CLEAR_ALL",
+            "MISSION_SET_CURRENT",
+            "MISSION_WRITE_PARTIAL_LIST"
+    );
+
+    public MavlinkBridgeConfig {
+        connections = connections == null ? List.of() : List.copyOf(connections);
+        if (connections.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "MAVLink bridge: at least one connection must be configured (12-MAVLINK.md §6)");
+        }
+        reads = reads == null ? List.of() : List.copyOf(reads);
+        events = events == null ? List.of() : List.copyOf(events);
+        writes = writes == null ? List.of() : List.copyOf(writes);
+        tickInterval = tickInterval == null ? Duration.ofMillis(250) : tickInterval;
+
+        // Connection ids must be unique.
+        Set<String> connIds = new LinkedHashSet<>();
+        for (ConnectionConfig c : connections) {
+            if (!connIds.add(c.id())) {
+                throw new IllegalArgumentException("Duplicate connection id: " + c.id());
+            }
+        }
+        Map<String, ConnectionConfig> byId = new LinkedHashMap<>();
+        for (ConnectionConfig c : connections) byId.put(c.id(), c);
+
+        // Per-bindingId uniqueness across reads/events/writes (the runtime
+        // maps key on bindingId).
+        Set<String> seen = new LinkedHashSet<>();
+        for (ReadBindingConfig r : reads) {
+            if (!seen.add(r.bindingId())) {
+                throw new IllegalArgumentException("Duplicate bindingId: " + r.bindingId());
+            }
+            requireConnection(byId, r.connectionId(), r.bindingId());
+            requireExpectedSystem(byId.get(r.connectionId()), r.systemId(), r.bindingId());
+        }
+        for (EventBindingConfig e : events) {
+            if (!seen.add(e.bindingId())) {
+                throw new IllegalArgumentException("Duplicate bindingId: " + e.bindingId());
+            }
+            requireConnection(byId, e.connectionId(), e.bindingId());
+        }
+        for (WriteBindingConfig w : writes) {
+            if (!seen.add(w.bindingId())) {
+                throw new IllegalArgumentException("Duplicate bindingId: " + w.bindingId());
+            }
+            requireConnection(byId, w.connectionId(), w.bindingId());
+        }
+
+        // §3, §6: forbidden-message-type rule — sim-only required.
+        if (!simulatorOnly) {
+            for (WriteBindingConfig w : writes) {
+                if (w.messageType() != null
+                        && FORBIDDEN_WRITE_MESSAGE_TYPES.contains(w.messageType())) {
+                    throw new IllegalArgumentException(
+                            "MAVLink bridge: write binding '" + w.bindingId()
+                                    + "' targets actuating message type '" + w.messageType()
+                                    + "' but simulatorOnly=false (12-MAVLINK.md §3, §6)");
+                }
+            }
+        }
+
+        // §3: AUTONOMOUS per-tag promotion only allowed in simulatorOnly mode.
+        if (perTagSafetyMode == null) {
+            perTagSafetyMode = Map.of();
+        } else {
+            Map<String, BridgeSafetyMode> linked = new LinkedHashMap<>(perTagSafetyMode);
+            if (!simulatorOnly) {
+                for (Map.Entry<String, BridgeSafetyMode> ent : linked.entrySet()) {
+                    if (ent.getValue() == BridgeSafetyMode.AUTONOMOUS) {
+                        throw new IllegalArgumentException(
+                                "MAVLink bridge ceiling is SIM-ONLY (12-MAVLINK.md §3): "
+                                        + "binding '" + ent.getKey()
+                                        + "' was promoted to AUTONOMOUS but simulatorOnly=false");
+                    }
+                }
+            }
+            perTagSafetyMode = Map.copyOf(linked);
+        }
+    }
+
+    @JsonCreator
+    public static MavlinkBridgeConfig create(
+            @JsonProperty("connections") List<ConnectionConfig> connections,
+            @JsonProperty("simulatorOnly") Boolean simulatorOnly,
+            @JsonProperty("reads") List<ReadBindingConfig> reads,
+            @JsonProperty("events") List<EventBindingConfig> events,
+            @JsonProperty("writes") List<WriteBindingConfig> writes,
+            @JsonProperty("audit") AuditConfig audit,
+            @JsonProperty("perTagSafetyMode") Map<String, BridgeSafetyMode> perTagSafetyMode,
+            @JsonProperty("tickInterval") Duration tickInterval) {
+        return new MavlinkBridgeConfig(
+                connections,
+                simulatorOnly == null || simulatorOnly,
+                reads, events, writes, audit, perTagSafetyMode, tickInterval);
+    }
+
+    private static void requireConnection(Map<String, ConnectionConfig> byId, String id, String bindingId) {
+        if (id == null || !byId.containsKey(id)) {
+            throw new IllegalArgumentException(
+                    "Binding '" + bindingId + "' references unknown connectionId '" + id + "'");
+        }
+    }
+
+    private static void requireExpectedSystem(ConnectionConfig c, int systemId, String bindingId) {
+        if (c.expectedSystems() == null || c.expectedSystems().isEmpty()) return;
+        for (int s : c.expectedSystems()) if (s == systemId) return;
+        throw new IllegalArgumentException(
+                "Binding '" + bindingId + "' systemId=" + systemId
+                        + " not in connection '" + c.id() + "' expectedSystems"
+                        + c.expectedSystems()
+                        + " (12-MAVLINK.md §6, §11 R1)");
+    }
+
+    /** Transports supported in §4 / §6 (UDP and TCP only — serial is hardware-only). */
+    public enum Transport { UDP, TCP }
+
+    /** What signal class a {@link ReadBindingConfig} produces (§5). */
+    public enum ReadSignalKind {
+        /** Own-vehicle pose / motion / energy. */
+        PROPRIOCEPTIVE,
+        /** Battery / link efficiency. */
+        EFFICIENCY,
+        /** Observed pose of a peer MAV system. */
+        PEER_OBSERVATION,
+        /** Bridge-level liveness or sensor-health alarm. */
+        ALARM,
+        /** Anomaly score (RSSI/noise thresholds). */
+        ANOMALY
+    }
+
+    /** One MAVLink connection (§4). */
+    public record ConnectionConfig(
+            String id,
+            Transport transport,
+            String bindAddress,
+            Integer bindPort,
+            String host,
+            Integer port,
+            List<Integer> expectedSystems
+    ) {
+        public ConnectionConfig {
+            Objects.requireNonNull(id, "id");
+            Objects.requireNonNull(transport, "transport");
+            expectedSystems = expectedSystems == null ? List.of() : List.copyOf(expectedSystems);
+            if (transport == Transport.UDP && bindPort == null) {
+                throw new IllegalArgumentException(
+                        "UDP connection '" + id + "' requires bindPort (12-MAVLINK.md §6)");
+            }
+            if (transport == Transport.TCP && (host == null || port == null)) {
+                throw new IllegalArgumentException(
+                        "TCP connection '" + id + "' requires host and port (12-MAVLINK.md §6)");
+            }
+        }
+
+        @JsonCreator
+        public static ConnectionConfig of(
+                @JsonProperty("id") String id,
+                @JsonProperty("transport") Transport transport,
+                @JsonProperty("bindAddress") String bindAddress,
+                @JsonProperty("bindPort") Integer bindPort,
+                @JsonProperty("host") String host,
+                @JsonProperty("port") Integer port,
+                @JsonProperty("expectedSystems") List<Integer> expectedSystems) {
+            return new ConnectionConfig(id, transport, bindAddress, bindPort, host, port, expectedSystems);
+        }
+    }
+
+    /** One per-system telemetry read binding (§5, §6). */
+    public record ReadBindingConfig(
+            String bindingId,
+            String connectionId,
+            int systemId,
+            Integer componentId,
+            String messageType,
+            ReadSignalKind targetSignal,
+            String signalTag,
+            String peerId,
+            int decimateBy
+    ) {
+        public ReadBindingConfig {
+            Objects.requireNonNull(bindingId, "bindingId");
+            Objects.requireNonNull(connectionId, "connectionId");
+            Objects.requireNonNull(messageType, "messageType");
+            if (decimateBy <= 0) decimateBy = 1;
+            if (targetSignal == null) {
+                targetSignal = inferKind(messageType);
+            }
+            if (targetSignal == ReadSignalKind.PEER_OBSERVATION
+                    && !"GLOBAL_POSITION_INT".equals(messageType)) {
+                throw new IllegalArgumentException(
+                        "ReadBinding '" + bindingId
+                                + "' PEER_OBSERVATION requires messageType=GLOBAL_POSITION_INT (12-MAVLINK.md §5)");
+            }
+        }
+
+        @JsonCreator
+        public static ReadBindingConfig of(
+                @JsonProperty("bindingId") String bindingId,
+                @JsonProperty("connectionId") String connectionId,
+                @JsonProperty("systemId") Integer systemId,
+                @JsonProperty("componentId") Integer componentId,
+                @JsonProperty("messageType") String messageType,
+                @JsonProperty("targetSignal") ReadSignalKind targetSignal,
+                @JsonProperty("signalTag") String signalTag,
+                @JsonProperty("peerId") String peerId,
+                @JsonProperty("decimateBy") Integer decimateBy) {
+            return new ReadBindingConfig(
+                    bindingId, connectionId,
+                    systemId == null ? 1 : systemId,
+                    componentId,
+                    messageType, targetSignal, signalTag, peerId,
+                    decimateBy == null ? 1 : decimateBy);
+        }
+
+        private static ReadSignalKind inferKind(String messageType) {
+            return switch (messageType) {
+                case "GLOBAL_POSITION_INT", "ATTITUDE", "GPS_RAW_INT" -> ReadSignalKind.PROPRIOCEPTIVE;
+                case "BATTERY_STATUS" -> ReadSignalKind.EFFICIENCY;
+                case "SYS_STATUS", "STATUSTEXT" -> ReadSignalKind.ALARM;
+                case "RADIO_STATUS" -> ReadSignalKind.ANOMALY;
+                default -> ReadSignalKind.ALARM;
+            };
+        }
+    }
+
+    /** Multi-system event-class subscription (§6). */
+    public record EventBindingConfig(
+            String bindingId,
+            String connectionId,
+            String messageType,
+            ReadSignalKind targetSignal,
+            String signalTagPrefix
+    ) {
+        public EventBindingConfig {
+            Objects.requireNonNull(bindingId, "bindingId");
+            Objects.requireNonNull(connectionId, "connectionId");
+            Objects.requireNonNull(messageType, "messageType");
+            if (targetSignal == null) targetSignal = ReadSignalKind.ALARM;
+        }
+
+        @JsonCreator
+        public static EventBindingConfig of(
+                @JsonProperty("bindingId") String bindingId,
+                @JsonProperty("connectionId") String connectionId,
+                @JsonProperty("messageType") String messageType,
+                @JsonProperty("targetSignal") ReadSignalKind targetSignal,
+                @JsonProperty("signalTagPrefix") String signalTagPrefix) {
+            return new EventBindingConfig(bindingId, connectionId, messageType,
+                    targetSignal, signalTagPrefix);
+        }
+    }
+
+    /**
+     * One advisory egress binding. Egress to the message types in
+     * {@link MavlinkBridgeConfig#FORBIDDEN_WRITE_MESSAGE_TYPES} is rejected
+     * at config load unless {@code simulatorOnly == true} (§3, §6).
+     */
+    public record WriteBindingConfig(
+            String bindingId,
+            String connectionId,
+            int targetSystemId,
+            Integer targetComponentId,
+            String messageType,
+            String signalTag,
+            Double minClampValue,
+            Double maxClampValue,
+            Double rampRateMaxPerSec,
+            Double failSafeValue
+    ) {
+        public WriteBindingConfig {
+            Objects.requireNonNull(bindingId, "bindingId");
+            Objects.requireNonNull(connectionId, "connectionId");
+            Objects.requireNonNull(messageType, "messageType");
+            Objects.requireNonNull(signalTag, "signalTag");
+        }
+
+        @JsonCreator
+        public static WriteBindingConfig of(
+                @JsonProperty("bindingId") String bindingId,
+                @JsonProperty("connectionId") String connectionId,
+                @JsonProperty("targetSystemId") Integer targetSystemId,
+                @JsonProperty("targetComponentId") Integer targetComponentId,
+                @JsonProperty("messageType") String messageType,
+                @JsonProperty("signalTag") String signalTag,
+                @JsonProperty("minClampValue") Double minClampValue,
+                @JsonProperty("maxClampValue") Double maxClampValue,
+                @JsonProperty("rampRateMaxPerSec") Double rampRateMaxPerSec,
+                @JsonProperty("failSafeValue") Double failSafeValue) {
+            return new WriteBindingConfig(
+                    bindingId, connectionId,
+                    targetSystemId == null ? 0 : targetSystemId,
+                    targetComponentId,
+                    messageType, signalTag,
+                    minClampValue, maxClampValue, rampRateMaxPerSec, failSafeValue);
+        }
+    }
+
+    /** Audit channel (00-FRAMEWORK §3, §4; 12-MAVLINK.md §6). */
+    public record AuditConfig(
+            String localAuditFile
+    ) {
+        public AuditConfig {
+            Objects.requireNonNull(localAuditFile, "localAuditFile");
+        }
+
+        @JsonCreator
+        public static AuditConfig of(@JsonProperty("localAuditFile") String localAuditFile) {
+            return new AuditConfig(localAuditFile);
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkBridgeConfigLoader.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkBridgeConfigLoader.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.mavlink;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+/**
+ * Loads {@link MavlinkBridgeConfig} from YAML (12-MAVLINK.md §6).
+ *
+ * <p>{@code FAIL_ON_UNKNOWN_PROPERTIES = true} per 00-FRAMEWORK §3 — typos
+ * in a drone-bridge config must be caught at load.
+ */
+public final class MavlinkBridgeConfigLoader {
+
+    private MavlinkBridgeConfigLoader() {}
+
+    public static MavlinkBridgeConfig load(Path yaml) throws IOException {
+        return mapper().readValue(yaml.toFile(), MavlinkBridgeConfig.class);
+    }
+
+    public static MavlinkBridgeConfig load(InputStream in) throws IOException {
+        return mapper().readValue(in, MavlinkBridgeConfig.class);
+    }
+
+    public static MavlinkBridgeConfig load(String yamlContent) throws IOException {
+        return mapper().readValue(yamlContent, MavlinkBridgeConfig.class);
+    }
+
+    private static ObjectMapper mapper() {
+        return new ObjectMapper(new YAMLFactory())
+                .registerModule(new JavaTimeModule())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkClientService.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkClientService.java
@@ -1,0 +1,452 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.mavlink;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmPriority;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Owns the MAVLink connections and the per-system latest-value cache
+ * (12-MAVLINK.md §4). One service can speak to many MAV systems on many
+ * connections; routing is by {@code (connectionId, systemId)}.
+ *
+ * <p>Read flow: transport → handler → mapper → per-binding queue drained by
+ * {@link MavlinkTelemetryInput} / {@link MavlinkSwarmInput} /
+ * {@link MavlinkEventInput} on each tick (00-FRAMEWORK §2.1). Write flow:
+ * {@link MavlinkAdvisoryOutputAggregator} computes the advisory payload and
+ * calls {@link #send}.
+ *
+ * <p>Multi-system routing, the {@link MavlinkBridgeConfig.ConnectionConfig}
+ * {@code expectedSystems} whitelist (§11 R1), and the safety-critical runtime
+ * check that no write hits a forbidden actuating message type outside
+ * {@code simulatorOnly} mode (§3) all live here.
+ *
+ * <p>Heartbeat liveness (§5): a missing {@code HEARTBEAT} for more than
+ * {@link #HEARTBEAT_TIMEOUT_MS} surfaces an {@code AlarmSignal} with
+ * condition {@code PEER_OFFLINE}. The timeout is checked lazily by
+ * {@link #checkHeartbeats(long)} which the host loop calls each tick.
+ */
+public final class MavlinkClientService implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(MavlinkClientService.class);
+
+    public static final String BRIDGE_NAME = "mavlink";
+    public static final String BRIDGE_RECONNECTED = "BRIDGE_RECONNECTED";
+
+    /** §5 heartbeat-loss threshold. */
+    public static final long HEARTBEAT_TIMEOUT_MS = 2_000L;
+
+    /** §11 R1 — single audit per minute per unknown system. */
+    private static final long UNKNOWN_SYSTEM_WINDOW_MS = 60_000L;
+
+    /** MAVLink-specific reasons in addition to 00-FRAMEWORK §4 vocabulary. */
+    public static final class Reason {
+        private Reason() {}
+        public static final String FORBIDDEN_MESSAGE_TYPE = "FORBIDDEN_MESSAGE_TYPE";
+        public static final String UNKNOWN_SYSTEM         = "UNKNOWN_SYSTEM";
+        public static final String DECODER_ERROR          = "DECODER_ERROR";
+        public static final String PUBLISH_ERROR          = "PUBLISH_ERROR";
+        public static final String UNKNOWN_CONNECTION     = "UNKNOWN_CONNECTION";
+    }
+
+    private final MavlinkBridgeConfig config;
+    private final AbstractBridgeAuditOutput audit;
+    private final MavlinkSignalMapper mapper;
+
+    /** Connections keyed by id. */
+    private final Map<String, MavlinkConnectionBinding> connections = new LinkedHashMap<>();
+    private final Map<String, MavlinkTransport> transports = new ConcurrentHashMap<>();
+
+    /** Resolved bindings. */
+    private final Map<String, MavlinkMessageBinding> readBindings = new LinkedHashMap<>();
+    private final Map<String, MavlinkMessageBinding> eventBindings = new LinkedHashMap<>();
+    private final Map<String, MavlinkMessageBinding> writeBindings = new LinkedHashMap<>();
+
+    /**
+     * Index: (connectionId, systemId, messageType) → list of read bindings.
+     * Cross-product because one binding can match many bindings only when
+     * config repeats; we keep it as a list to preserve order.
+     */
+    private final Map<RouteKey, List<MavlinkMessageBinding>> readRoutes = new HashMap<>();
+
+    /** Index: (connectionId, messageType) → list of event bindings (system-agnostic). */
+    private final Map<EventKey, List<MavlinkMessageBinding>> eventRoutes = new HashMap<>();
+
+    /** Pending decoded signals per read/event binding. Drained per tick. */
+    private final Map<String, List<IInputSignal>> queueByBinding = new ConcurrentHashMap<>();
+
+    /** Pending alarm/event signals (advisory channel). */
+    private final List<IInputSignal> events = new ArrayList<>();
+
+    /** Per-binding decimation counters. */
+    private final Map<String, AtomicLong> decimationCounters = new ConcurrentHashMap<>();
+
+    /** Last HEARTBEAT timestamp (epoch ms) per (connectionId, systemId). */
+    private final Map<RouteKey, Long> heartbeats = new ConcurrentHashMap<>();
+
+    /** Sticky "we already alarmed offline" flag per (connectionId, systemId). */
+    private final Map<RouteKey, Boolean> offlineAlarmed = new ConcurrentHashMap<>();
+
+    /** Single-audit-per-minute throttle for unknown-system messages (§11 R1). */
+    private final Map<RouteKey, AtomicLong> unknownSystemWindow = new ConcurrentHashMap<>();
+
+    private final AtomicBoolean started = new AtomicBoolean();
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    public MavlinkClientService(MavlinkBridgeConfig config,
+                                Map<String, MavlinkTransport> transports,
+                                AbstractBridgeAuditOutput audit) {
+        this.config = Objects.requireNonNull(config, "config");
+        this.audit = Objects.requireNonNull(audit, "audit");
+        this.mapper = new MavlinkSignalMapper();
+
+        for (MavlinkBridgeConfig.ConnectionConfig c : config.connections()) {
+            connections.put(c.id(), MavlinkConnectionBinding.from(c));
+        }
+
+        Map<String, MavlinkTransport> safe = transports == null ? Map.of() : transports;
+        for (Map.Entry<String, MavlinkTransport> e : safe.entrySet()) {
+            if (!connections.containsKey(e.getKey())) {
+                throw new IllegalArgumentException(
+                        "Transport supplied for unknown connectionId '" + e.getKey() + "'");
+            }
+            this.transports.put(e.getKey(), e.getValue());
+        }
+
+        for (MavlinkBridgeConfig.ReadBindingConfig r : config.reads()) {
+            MavlinkMessageBinding b = MavlinkMessageBinding.fromRead(r);
+            readBindings.put(r.bindingId(), b);
+            queueByBinding.put(r.bindingId(), new ArrayList<>());
+            decimationCounters.put(r.bindingId(), new AtomicLong());
+            readRoutes.computeIfAbsent(
+                    new RouteKey(r.connectionId(), r.systemId(), r.messageType()),
+                    k -> new ArrayList<>()).add(b);
+        }
+        for (MavlinkBridgeConfig.EventBindingConfig ev : config.events()) {
+            MavlinkMessageBinding b = MavlinkMessageBinding.fromEvent(ev);
+            eventBindings.put(ev.bindingId(), b);
+            queueByBinding.put(ev.bindingId(), new ArrayList<>());
+            eventRoutes.computeIfAbsent(
+                    new EventKey(ev.connectionId(), ev.messageType()),
+                    k -> new ArrayList<>()).add(b);
+        }
+        for (MavlinkBridgeConfig.WriteBindingConfig w : config.writes()) {
+            writeBindings.put(w.bindingId(), MavlinkMessageBinding.fromWrite(w));
+        }
+    }
+
+    /** Open every transport and register the message handler. Idempotent. */
+    public synchronized void start() {
+        if (started.get()) return;
+        for (Map.Entry<String, MavlinkTransport> e : transports.entrySet()) {
+            String connId = e.getKey();
+            MavlinkTransport t = e.getValue();
+            t.setHandler(msg -> onMessage(connId, msg));
+            t.connect();
+        }
+        started.set(true);
+        log.info("MavlinkClientService started; {} connection(s), {} read + {} event + {} write bindings",
+                transports.size(), readBindings.size(), eventBindings.size(), writeBindings.size());
+    }
+
+    /**
+     * Drop in-flight latest-value cache and emit a {@code BRIDGE_RECONNECTED}
+     * advisory alarm. Called by the host after a transport reports a
+     * reconnect (00-FRAMEWORK §2.3).
+     */
+    public synchronized void onReconnected(String connectionId) {
+        for (Map.Entry<String, List<IInputSignal>> e : queueByBinding.entrySet()) {
+            synchronized (e.getValue()) { e.getValue().clear(); }
+        }
+        heartbeats.keySet().removeIf(k -> k.connectionId().equals(connectionId));
+        offlineAlarmed.keySet().removeIf(k -> k.connectionId().equals(connectionId));
+        synchronized (events) {
+            events.add(new AlarmSignal(AlarmPriority.LOW, BRIDGE_NAME,
+                    BRIDGE_RECONNECTED + ":" + connectionId, System.currentTimeMillis()));
+        }
+        log.info("MavlinkClientService: reconnect on {} — cache cleared, advisory event emitted",
+                connectionId);
+    }
+
+    /** Drain (and clear) all decoded signals for one binding. */
+    public List<IInputSignal> drain(String bindingId) {
+        List<IInputSignal> out = queueByBinding.get(bindingId);
+        if (out == null || out.isEmpty()) return List.of();
+        synchronized (out) {
+            List<IInputSignal> snap = new ArrayList<>(out);
+            out.clear();
+            return snap;
+        }
+    }
+
+    /** Drain (and clear) all advisory alarm/event signals. */
+    public List<IInputSignal> drainEvents() {
+        synchronized (events) {
+            if (events.isEmpty()) return List.of();
+            List<IInputSignal> snap = new ArrayList<>(events);
+            events.clear();
+            return snap;
+        }
+    }
+
+    /**
+     * Heartbeat watchdog (§5, §10 S9). Call once per tick. For every system
+     * we have ever heard a {@code HEARTBEAT} from, if more than
+     * {@link #HEARTBEAT_TIMEOUT_MS} has elapsed since the last one, emit a
+     * {@code PEER_OFFLINE} alarm (once per timeout).
+     */
+    public void checkHeartbeats(long nowMs) {
+        for (Map.Entry<RouteKey, Long> e : heartbeats.entrySet()) {
+            RouteKey k = e.getKey();
+            long last = e.getValue();
+            if (nowMs - last > HEARTBEAT_TIMEOUT_MS) {
+                Boolean prev = offlineAlarmed.put(k, Boolean.TRUE);
+                if (prev == null || !prev) {
+                    AlarmSignal alarm = mapper.peerOffline(k.systemId(), nowMs);
+                    synchronized (events) { events.add(alarm); }
+                }
+            } else {
+                offlineAlarmed.put(k, Boolean.FALSE);
+            }
+        }
+    }
+
+    /**
+     * Encode and send a MAVLink message via the named connection. The caller
+     * (the aggregator) has already audited the verdict; this method enforces
+     * the §3 forbidden-message-type runtime backstop and the
+     * {@code expectedSystems} whitelist.
+     *
+     * @return {@code true} on a successful transport-level publish.
+     */
+    public boolean send(String bindingId, Object payload, long ts, long run) {
+        if (closed.get() || !started.get()) return false;
+        MavlinkMessageBinding b = writeBindings.get(bindingId);
+        if (b == null) {
+            audit.append(new BridgeAuditRecord(
+                    System.currentTimeMillis(), run, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    bindingId, null, null, null,
+                    BridgeAuditRecord.RejectReason.UNKNOWN_TAG, null, List.of()));
+            return false;
+        }
+        MavlinkConnectionBinding conn = connections.get(b.connectionId());
+        if (conn == null) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    b.loopId(), b.signalTag(), null, null,
+                    Reason.UNKNOWN_CONNECTION, null, List.of()));
+            return false;
+        }
+
+        // Hard runtime backstop for the §3 forbidden-message-type rule.
+        if (!config.simulatorOnly()
+                && b.messageType() != null
+                && MavlinkBridgeConfig.FORBIDDEN_WRITE_MESSAGE_TYPES.contains(b.messageType())) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    b.loopId(), b.signalTag(), null, null,
+                    Reason.FORBIDDEN_MESSAGE_TYPE, null, List.of()));
+            return false;
+        }
+
+        MavlinkTransport t = transports.get(b.connectionId());
+        if (t == null) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.FAILED,
+                    b.loopId(), b.signalTag(), null, null,
+                    Reason.PUBLISH_ERROR + ":no transport", null, List.of()));
+            return false;
+        }
+        try {
+            int sys = b.systemId() == null ? 0 : b.systemId();
+            int comp = b.componentId() == null ? 0 : b.componentId();
+            t.send(sys, comp, payload);
+            return true;
+        } catch (RuntimeException ex) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.FAILED,
+                    b.loopId(), b.signalTag(), null, null,
+                    Reason.PUBLISH_ERROR + ":" + ex.getMessage(),
+                    null, List.of()));
+            return false;
+        }
+    }
+
+    /* ===== accessors ===================================================== */
+
+    public MavlinkBridgeConfig config() { return config; }
+    public MavlinkMessageBinding readBinding(String id) { return readBindings.get(id); }
+    public MavlinkMessageBinding eventBinding(String id) { return eventBindings.get(id); }
+    public MavlinkMessageBinding writeBinding(String id) { return writeBindings.get(id); }
+    public MavlinkMessageBinding writeBindingForTag(String tag) {
+        for (MavlinkMessageBinding b : writeBindings.values()) {
+            if (Objects.equals(tag, b.signalTag())) return b;
+        }
+        return null;
+    }
+    public List<String> readBindingIds() { return List.copyOf(readBindings.keySet()); }
+    public List<String> eventBindingIds() { return List.copyOf(eventBindings.keySet()); }
+
+    @Override
+    public synchronized void close() {
+        if (!closed.compareAndSet(false, true)) return;
+        for (MavlinkTransport t : transports.values()) {
+            try { t.close(); } catch (RuntimeException e) {
+                log.warn("MavlinkTransport.close() threw: {}", e.getMessage());
+            }
+        }
+    }
+
+    /* ===== inbound message dispatch ====================================== */
+
+    private void onMessage(String connectionId, MavlinkTransport.InboundMessage message) {
+        if (message == null) return;
+        Object payload = message.payload();
+        if (payload == null) return;
+        int systemId = message.systemId();
+        long now = System.currentTimeMillis();
+        MavlinkConnectionBinding conn = connections.get(connectionId);
+
+        // §11 R1: drop messages from unknown systems with a single audit per minute.
+        if (conn != null && !conn.isExpected(systemId)) {
+            RouteKey k = new RouteKey(connectionId, systemId, "*");
+            AtomicLong window = unknownSystemWindow.computeIfAbsent(k, key -> new AtomicLong());
+            long last = window.get();
+            if (now - last > UNKNOWN_SYSTEM_WINDOW_MS) {
+                window.set(now);
+                audit.append(new BridgeAuditRecord(
+                        now, 0, BRIDGE_NAME,
+                        BridgeAuditRecord.Verdict.REJECTED,
+                        connectionId, null, null, null,
+                        Reason.UNKNOWN_SYSTEM + ":" + systemId, null, List.of()));
+            }
+            return;
+        }
+
+        String messageType = mavlinkMessageTypeOf(payload);
+
+        // §5: track HEARTBEAT for the watchdog.
+        if (payload instanceof io.dronefleet.mavlink.minimal.Heartbeat) {
+            heartbeats.put(new RouteKey(connectionId, systemId, "HEARTBEAT"), now);
+            offlineAlarmed.put(new RouteKey(connectionId, systemId, "HEARTBEAT"), Boolean.FALSE);
+        }
+
+        // Dispatch to event bindings first (system-agnostic).
+        List<MavlinkMessageBinding> evList = eventRoutes.get(new EventKey(connectionId, messageType));
+        if (evList != null) {
+            for (MavlinkMessageBinding b : evList) deliver(b, payload, systemId, now);
+        }
+
+        // Dispatch to read bindings (system-specific).
+        List<MavlinkMessageBinding> rdList = readRoutes.get(new RouteKey(connectionId, systemId, messageType));
+        if (rdList != null) {
+            for (MavlinkMessageBinding b : rdList) {
+                if (b.decimateBy() > 1) {
+                    AtomicLong c = decimationCounters.get(b.bindingId());
+                    long n = c == null ? 0 : c.incrementAndGet();
+                    if (n % b.decimateBy() != 0) continue;
+                }
+                deliver(b, payload, systemId, now);
+            }
+        }
+    }
+
+    private void deliver(MavlinkMessageBinding b, Object payload, int systemId, long now) {
+        try {
+            IInputSignal signal = mapPayload(b, payload, systemId, now);
+            if (signal == null) return;
+            if (signal instanceof AlarmSignal) {
+                synchronized (events) { events.add(signal); }
+                return;
+            }
+            List<IInputSignal> q = queueByBinding.get(b.bindingId());
+            if (q != null) {
+                synchronized (q) { q.add(signal); }
+            }
+        } catch (RuntimeException ex) {
+            audit.append(new BridgeAuditRecord(
+                    now, 0, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.FAILED,
+                    b.loopId(), b.signalTag(), null, null,
+                    Reason.DECODER_ERROR + ":" + ex.getClass().getSimpleName(),
+                    null, List.of()));
+        }
+    }
+
+    private IInputSignal mapPayload(MavlinkMessageBinding b, Object payload, int systemId, long now) {
+        if (payload instanceof io.dronefleet.mavlink.common.GlobalPositionInt gp) {
+            if (b.targetSignal() == MavlinkBridgeConfig.ReadSignalKind.PEER_OBSERVATION) {
+                return mapper.toPeerObservation(b, gp, systemId);
+            }
+            return mapper.toOwnPosition(b, gp, systemId, now);
+        }
+        if (payload instanceof io.dronefleet.mavlink.common.Attitude att) {
+            return mapper.toAttitude(b, att, systemId, now);
+        }
+        if (payload instanceof io.dronefleet.mavlink.common.BatteryStatus bs) {
+            return mapper.toBattery(b, bs);
+        }
+        if (payload instanceof io.dronefleet.mavlink.common.SysStatus ss) {
+            return mapper.toSysStatus(b, ss, systemId, now);
+        }
+        if (payload instanceof io.dronefleet.mavlink.common.Statustext st) {
+            return mapper.toStatusText(b, st, systemId, now);
+        }
+        if (payload instanceof io.dronefleet.mavlink.common.RadioStatus rs) {
+            return mapper.toRadioStatus(b, rs, systemId);
+        }
+        if (payload instanceof io.dronefleet.mavlink.common.GpsRawInt gr) {
+            return mapper.toGpsRaw(b, gr, systemId, now);
+        }
+        if (payload instanceof io.dronefleet.mavlink.minimal.Heartbeat) {
+            return null;
+        }
+        return null;
+    }
+
+    /**
+     * Convention used by both dronefleet codegen and the MAVLink XML
+     * dialects: a payload class' simple name in CamelCase corresponds to
+     * the message type in SCREAMING_SNAKE_CASE. We compute the latter once
+     * per message so the dispatch keys can use the canonical MAVLink name
+     * the YAML config uses.
+     */
+    static String mavlinkMessageTypeOf(Object payload) {
+        if (payload == null) return null;
+        String simple = payload.getClass().getSimpleName();
+        StringBuilder out = new StringBuilder(simple.length() + 4);
+        for (int i = 0; i < simple.length(); i++) {
+            char c = simple.charAt(i);
+            if (Character.isUpperCase(c) && i > 0) out.append('_');
+            out.append(Character.toUpperCase(c));
+        }
+        return out.toString();
+    }
+
+    /** Multi-key hash key for read routes. */
+    private record RouteKey(String connectionId, int systemId, String messageType) {}
+
+    /** Multi-key hash key for event routes (system-agnostic). */
+    private record EventKey(String connectionId, String messageType) {}
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkConnectionBinding.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkConnectionBinding.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.mavlink;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Resolved per-connection binding (12-MAVLINK.md §4, §8). Wraps the
+ * {@link MavlinkBridgeConfig.ConnectionConfig} record with helpers used by
+ * {@link MavlinkClientService}.
+ */
+public record MavlinkConnectionBinding(
+        String id,
+        MavlinkBridgeConfig.Transport transport,
+        String bindAddress,
+        Integer bindPort,
+        String host,
+        Integer port,
+        List<Integer> expectedSystems
+) {
+
+    public MavlinkConnectionBinding {
+        Objects.requireNonNull(id, "id");
+        Objects.requireNonNull(transport, "transport");
+        expectedSystems = expectedSystems == null ? List.of() : List.copyOf(expectedSystems);
+    }
+
+    public static MavlinkConnectionBinding from(MavlinkBridgeConfig.ConnectionConfig c) {
+        return new MavlinkConnectionBinding(
+                c.id(), c.transport(),
+                c.bindAddress(), c.bindPort(),
+                c.host(), c.port(),
+                c.expectedSystems());
+    }
+
+    /** {@code true} if {@code systemId} is allowed on this connection. Empty whitelist = allow-all. */
+    public boolean isExpected(int systemId) {
+        if (expectedSystems.isEmpty()) return true;
+        for (int s : expectedSystems) if (s == systemId) return true;
+        return false;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkEventInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkEventInput.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.mavlink;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IInitInput} for the bridge-level event/alarm channel
+ * (12-MAVLINK.md §5): drains the {@code AlarmSignal}s produced by
+ * {@code STATUSTEXT}, {@code SYS_STATUS}, {@code RADIO_STATUS} bindings as
+ * well as the {@code BRIDGE_RECONNECTED} and {@code PEER_OFFLINE} advisory
+ * alarms emitted by {@link MavlinkClientService} itself.
+ */
+public final class MavlinkEventInput implements IInitInput {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private final String name;
+    private final MavlinkClientService svc;
+    private final List<String> bindingIds;
+
+    public MavlinkEventInput(String name, MavlinkClientService svc, List<String> bindingIds) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.bindingIds = bindingIds == null ? List.of() : List.copyOf(bindingIds);
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        List<IInputSignal> out = new ArrayList<>(svc.drainEvents());
+        for (String b : bindingIds) out.addAll(svc.drain(b));
+        return out;
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() { return new HashMap<>(); }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() { return PROCESSING_FREQUENCY; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkMessageBinding.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkMessageBinding.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.mavlink;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeBinding;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeBindingDirection;
+
+/**
+ * One MAVLink (system, component, messageType) ↔ signal-tag binding
+ * (12-MAVLINK.md §5, §6, §8).
+ *
+ * <p>Implements {@link BridgeBinding} so the universal audit record
+ * (00-FRAMEWORK §4) can identify the binding by tag and loop, and so write
+ * bindings can carry their clamp / rate / fail-safe metadata.
+ *
+ * <p>For {@code READ} and event-class bindings only the routing fields are
+ * meaningful; clamp and rate fields are {@code null}. For {@code WRITE}
+ * bindings the {@code targetSystemId}/{@code targetComponentId} pair names
+ * the destination system on the connection.
+ */
+public record MavlinkMessageBinding(
+        String bindingId,
+        String connectionId,
+        BridgeBindingDirection direction,
+        Integer systemId,
+        Integer componentId,
+        String messageType,
+        String signalTag,
+        MavlinkBridgeConfig.ReadSignalKind targetSignal,
+        String peerId,
+        String signalTagPrefix,
+        int decimateBy,
+        Double minClampValue,
+        Double maxClampValue,
+        Double rampRateMaxPerSec,
+        Double failSafeValue
+) implements BridgeBinding {
+
+    public static MavlinkMessageBinding fromRead(MavlinkBridgeConfig.ReadBindingConfig r) {
+        return new MavlinkMessageBinding(
+                r.bindingId(), r.connectionId(),
+                BridgeBindingDirection.READ,
+                r.systemId(), r.componentId(),
+                r.messageType(), r.signalTag(),
+                r.targetSignal(), r.peerId(), null,
+                r.decimateBy(),
+                null, null, null, null);
+    }
+
+    public static MavlinkMessageBinding fromEvent(MavlinkBridgeConfig.EventBindingConfig e) {
+        return new MavlinkMessageBinding(
+                e.bindingId(), e.connectionId(),
+                BridgeBindingDirection.READ,
+                null, null,
+                e.messageType(), null,
+                e.targetSignal(), null, e.signalTagPrefix(),
+                1,
+                null, null, null, null);
+    }
+
+    public static MavlinkMessageBinding fromWrite(MavlinkBridgeConfig.WriteBindingConfig w) {
+        return new MavlinkMessageBinding(
+                w.bindingId(), w.connectionId(),
+                BridgeBindingDirection.WRITE,
+                w.targetSystemId(), w.targetComponentId(),
+                w.messageType(), w.signalTag(),
+                null, null, null,
+                1,
+                w.minClampValue(), w.maxClampValue(),
+                w.rampRateMaxPerSec(), w.failSafeValue());
+    }
+
+    @Override public String loopId() { return bindingId; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkSignalMapper.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkSignalMapper.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.mavlink;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmPriority;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.ProprioceptiveSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.EfficiencySignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.security.AnomalyScoreSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerObservationSignal;
+
+import java.util.List;
+
+/**
+ * Pure functions: MAVLink message ↔ Jneopallium typed signal
+ * (12-MAVLINK.md §5).
+ *
+ * <p>The mapper is intentionally minimal: each method takes the already-decoded
+ * MAVLink payload (one of the dronefleet records) plus the binding and
+ * returns a typed Jneopallium signal. Connection-level concerns (system_id
+ * routing, decimation, expected-systems whitelist) live in
+ * {@link MavlinkClientService}.
+ */
+public final class MavlinkSignalMapper {
+
+    /** RADIO_STATUS thresholds at which we mark the link "anomalous" (§5). */
+    private static final int RSSI_LOW_THRESHOLD = 30;
+    private static final int NOISE_HIGH_THRESHOLD = 80;
+
+    /** GLOBAL_POSITION_INT → ProprioceptiveSignal (own MAV) (§5). */
+    public IInputSignal toOwnPosition(MavlinkMessageBinding b,
+                                      io.dronefleet.mavlink.common.GlobalPositionInt msg,
+                                      int systemId,
+                                      long ts) {
+        // lat/lon scaled by 1e7; alt mm; vx/vy/vz cm/s.
+        double lat = msg.lat() / 1e7;
+        double lon = msg.lon() / 1e7;
+        double alt = msg.alt() / 1000.0;
+        double relAlt = msg.relativeAlt() / 1000.0;
+        double vx = msg.vx() / 100.0;
+        double vy = msg.vy() / 100.0;
+        double vz = msg.vz() / 100.0;
+        double hdg = msg.hdg() / 100.0;
+        ProprioceptiveSignal sig = new ProprioceptiveSignal(
+                systemId, new double[]{lat, lon, alt, relAlt, vx, vy, vz, hdg}, ts);
+        sig.setName(b.signalTag() == null ? b.bindingId() : b.signalTag());
+        return sig;
+    }
+
+    /** GLOBAL_POSITION_INT → PeerObservationSignal (drone observed by another) (§5). */
+    public IInputSignal toPeerObservation(MavlinkMessageBinding b,
+                                          io.dronefleet.mavlink.common.GlobalPositionInt msg,
+                                          int systemId) {
+        double lat = msg.lat() / 1e7;
+        double lon = msg.lon() / 1e7;
+        double alt = msg.alt() / 1000.0;
+        double vx = msg.vx() / 100.0;
+        double vy = msg.vy() / 100.0;
+        double vz = msg.vz() / 100.0;
+        String peerId = b.peerId() == null ? Integer.toString(systemId) : b.peerId();
+        PeerObservationSignal sig = new PeerObservationSignal(
+                peerId, new double[]{lat, lon, alt}, new double[]{vx, vy, vz}, 1.0);
+        sig.setName(b.signalTag() == null ? b.bindingId() : b.signalTag());
+        return sig;
+    }
+
+    /** ATTITUDE → ProprioceptiveSignal (§5). */
+    public IInputSignal toAttitude(MavlinkMessageBinding b,
+                                   io.dronefleet.mavlink.common.Attitude msg,
+                                   int systemId,
+                                   long ts) {
+        ProprioceptiveSignal sig = new ProprioceptiveSignal(
+                systemId,
+                new double[]{
+                        msg.roll(), msg.pitch(), msg.yaw(),
+                        msg.rollspeed(), msg.pitchspeed(), msg.yawspeed()
+                },
+                ts);
+        sig.setName(b.signalTag() == null ? b.bindingId() : b.signalTag());
+        return sig;
+    }
+
+    /** BATTERY_STATUS → EfficiencySignal (§5). */
+    public IInputSignal toBattery(MavlinkMessageBinding b,
+                                  io.dronefleet.mavlink.common.BatteryStatus msg) {
+        // batteryRemaining: 0..100 percent (-1 for unknown).
+        int remaining = msg.batteryRemaining();
+        double pct = remaining < 0 ? 0.0 : remaining / 100.0;
+        String unit = b.signalTag() == null ? b.bindingId() : b.signalTag();
+        return new EfficiencySignal(unit, pct, 1.0);
+    }
+
+    /** SYS_STATUS → AlarmSignal when any sensor-health flag is set (§5). */
+    public IInputSignal toSysStatus(MavlinkMessageBinding b,
+                                    io.dronefleet.mavlink.common.SysStatus msg,
+                                    int systemId,
+                                    long ts) {
+        long present = msg.onboardControlSensorsPresent() == null
+                ? 0L : msg.onboardControlSensorsPresent().value();
+        long enabled = msg.onboardControlSensorsEnabled() == null
+                ? 0L : msg.onboardControlSensorsEnabled().value();
+        long health = msg.onboardControlSensorsHealth() == null
+                ? 0L : msg.onboardControlSensorsHealth().value();
+        // Healthy = (enabled & present) ⊆ health. Anything enabled-but-unhealthy → alarm.
+        long unhealthy = (enabled & present) & ~health;
+        if (unhealthy == 0 && msg.dropRateComm() == 0) return null;
+
+        AlarmPriority pri = unhealthy != 0 ? AlarmPriority.HIGH : AlarmPriority.LOW;
+        String tag = (b.signalTag() != null ? b.signalTag()
+                : (b.signalTagPrefix() != null ? b.signalTagPrefix() : b.bindingId()))
+                + "." + systemId;
+        return new AlarmSignal(pri, tag,
+                "SENSOR_UNHEALTHY:0x" + Long.toHexString(unhealthy)
+                        + " drop=" + msg.dropRateComm(),
+                ts);
+    }
+
+    /** STATUSTEXT → AlarmSignal (severity → priority) (§5). */
+    public IInputSignal toStatusText(MavlinkMessageBinding b,
+                                     io.dronefleet.mavlink.common.Statustext msg,
+                                     int systemId,
+                                     long ts) {
+        AlarmPriority pri = mapSeverity(msg.severity() == null ? null : msg.severity().entry());
+        String prefix = b.signalTagPrefix() != null ? b.signalTagPrefix()
+                : (b.signalTag() != null ? b.signalTag() : b.bindingId());
+        String tag = prefix + "." + systemId;
+        String text = msg.text() == null ? "" : msg.text();
+        return new AlarmSignal(pri, tag, "STATUSTEXT:" + text, ts);
+    }
+
+    /** RADIO_STATUS → AnomalyScoreSignal when RSSI/noise crosses thresholds (§5). */
+    public IInputSignal toRadioStatus(MavlinkMessageBinding b,
+                                      io.dronefleet.mavlink.common.RadioStatus msg,
+                                      int systemId) {
+        int rssi = msg.rssi();
+        int noise = msg.noise();
+        if (rssi >= RSSI_LOW_THRESHOLD && noise <= NOISE_HIGH_THRESHOLD) return null;
+
+        double rssiPart = rssi >= RSSI_LOW_THRESHOLD ? 0.0
+                : (RSSI_LOW_THRESHOLD - rssi) / (double) RSSI_LOW_THRESHOLD;
+        double noisePart = noise <= NOISE_HIGH_THRESHOLD ? 0.0
+                : (noise - NOISE_HIGH_THRESHOLD) / (double) (255 - NOISE_HIGH_THRESHOLD);
+        double score = Math.max(0.0, Math.min(1.0, Math.max(rssiPart, noisePart)));
+
+        String entity = (b.signalTag() != null ? b.signalTag() : b.bindingId()) + "." + systemId;
+        return new AnomalyScoreSignal(entity, score,
+                List.of("rssi=" + rssi, "noise=" + noise, "rxerrors=" + msg.rxerrors()));
+    }
+
+    /** Heartbeat-loss alarm (§5; emitted by {@link MavlinkClientService}). */
+    public AlarmSignal peerOffline(int systemId, long ts) {
+        return new AlarmSignal(AlarmPriority.HIGH,
+                "DRONE." + systemId, "PEER_OFFLINE", ts);
+    }
+
+    /** GPS_RAW_INT → ProprioceptiveSignal — partial fix info; map similarly to GLOBAL_POSITION_INT. */
+    public IInputSignal toGpsRaw(MavlinkMessageBinding b,
+                                 io.dronefleet.mavlink.common.GpsRawInt msg,
+                                 int systemId,
+                                 long ts) {
+        double lat = msg.lat() / 1e7;
+        double lon = msg.lon() / 1e7;
+        double alt = msg.alt() / 1000.0;
+        ProprioceptiveSignal sig = new ProprioceptiveSignal(
+                systemId, new double[]{lat, lon, alt, msg.satellitesVisible()}, ts);
+        sig.setName(b.signalTag() == null ? b.bindingId() : b.signalTag());
+        return sig;
+    }
+
+    private static AlarmPriority mapSeverity(io.dronefleet.mavlink.common.MavSeverity sev) {
+        if (sev == null) return AlarmPriority.JOURNAL;
+        return switch (sev) {
+            case MAV_SEVERITY_EMERGENCY, MAV_SEVERITY_ALERT, MAV_SEVERITY_CRITICAL -> AlarmPriority.URGENT;
+            case MAV_SEVERITY_ERROR, MAV_SEVERITY_WARNING -> AlarmPriority.HIGH;
+            case MAV_SEVERITY_NOTICE -> AlarmPriority.LOW;
+            case MAV_SEVERITY_INFO, MAV_SEVERITY_DEBUG -> AlarmPriority.JOURNAL;
+        };
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkSwarmInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkSwarmInput.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.mavlink;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IInitInput} for swarm-side reads (12-MAVLINK.md §5): drains the
+ * {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerObservationSignal}s
+ * produced by per-peer {@code GLOBAL_POSITION_INT} bindings whose
+ * {@code targetSignal} is {@code PEER_OBSERVATION}.
+ *
+ * <p>The HEARTBEAT-driven peer table (online/offline) lives in
+ * {@link MavlinkClientService} and surfaces through the advisory event
+ * channel ({@code drainEvents}); {@link MavlinkEventInput} reads that
+ * channel and combines it with {@code STATUSTEXT}-derived alarms.
+ */
+public final class MavlinkSwarmInput implements IInitInput {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
+
+    private final String name;
+    private final MavlinkClientService svc;
+    private final List<String> bindingIds;
+
+    public MavlinkSwarmInput(String name, MavlinkClientService svc, List<String> bindingIds) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.bindingIds = List.copyOf(Objects.requireNonNull(bindingIds, "bindingIds"));
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        List<IInputSignal> out = new ArrayList<>();
+        for (String b : bindingIds) out.addAll(svc.drain(b));
+        return out;
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() { return new HashMap<>(); }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() { return PROCESSING_FREQUENCY; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkTelemetryInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkTelemetryInput.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.mavlink;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IInitInput} that drains decoded telemetry signals
+ * ({@link com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.ProprioceptiveSignal}
+ * and
+ * {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.EfficiencySignal})
+ * from {@link MavlinkClientService} (12-MAVLINK.md §5).
+ *
+ * <p>One instance binds to one or more PROPRIOCEPTIVE/EFFICIENCY-class read
+ * bindings. {@code readSignals()} returns a snapshot — the connection
+ * service maintains the cache asynchronously; this method does not block
+ * on the network.
+ */
+public final class MavlinkTelemetryInput implements IInitInput {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private final String name;
+    private final MavlinkClientService svc;
+    private final List<String> bindingIds;
+
+    public MavlinkTelemetryInput(String name, MavlinkClientService svc, List<String> bindingIds) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.bindingIds = List.copyOf(Objects.requireNonNull(bindingIds, "bindingIds"));
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        List<IInputSignal> out = new ArrayList<>();
+        for (String b : bindingIds) out.addAll(svc.drain(b));
+        return out;
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() { return new HashMap<>(); }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() { return PROCESSING_FREQUENCY; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkTransport.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkTransport.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.mavlink;
+
+/**
+ * Test seam between {@link MavlinkClientService} and the actual MAVLink wire
+ * (12-MAVLINK.md §4). One transport instance corresponds to one MAVLink
+ * connection (a UDP bind, a TCP socket, or — out of scope here — a serial
+ * port) and surfaces inbound MAVLink messages as already-typed dronefleet
+ * payload objects via {@link InboundMessage}.
+ *
+ * <p>Egress takes an already-encoded payload — the service hands the
+ * transport the source/component ids and an {@code Object} payload that the
+ * dronefleet codec knows how to serialize. The transport is responsible for
+ * pushing the resulting bytes to the underlying socket.
+ *
+ * <p>Tests inject {@code InMemoryMavlinkTransport} so the §10 scenarios can
+ * run without a real SITL instance.
+ */
+public interface MavlinkTransport extends AutoCloseable {
+
+    /**
+     * One MAVLink message observed on this connection. The
+     * {@link io.dronefleet.mavlink.MavlinkMessage} type is package-private
+     * to construct, so the transport contract surfaces just the routing
+     * fields plus the typed payload (one of the dronefleet message
+     * records).
+     */
+    record InboundMessage(int systemId, int componentId, Object payload) {}
+
+    /** Callback invoked for every received MAVLink message. */
+    @FunctionalInterface
+    interface MessageHandler { void onMessage(InboundMessage message); }
+
+    /**
+     * Open the connection. Idempotent. Implementations doing real network
+     * work block until connected or fail with {@link MavlinkTransportException}.
+     */
+    void connect();
+
+    /** Set (or replace) the inbound message handler. */
+    void setHandler(MessageHandler handler);
+
+    /**
+     * Encode {@code payload} as a MAVLink message and push it onto the wire.
+     * Throws {@link MavlinkTransportException} on protocol/transport failure.
+     */
+    void send(int systemId, int componentId, Object payload);
+
+    /** {@code true} once {@link #connect} succeeded and no disconnect has occurred since. */
+    boolean isConnected();
+
+    /** Shut down. Idempotent. */
+    @Override
+    void close();
+
+    /** Wraps any client throwable so the bridge can audit it uniformly. */
+    final class MavlinkTransportException extends RuntimeException {
+        public MavlinkTransportException(String message) { super(message); }
+        public MavlinkTransportException(String message, Throwable cause) { super(message, cause); }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/package-info.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * MAVLink bridge (12-MAVLINK.md). Read-and-advisory-only adapter between a
+ * MAVLink-speaking system (ArduPilot SITL, PX4 SITL, or — once the safety
+ * ceiling is satisfied — a hardware autopilot) and the Jneopallium signal
+ * pipeline.
+ *
+ * <p>Structural ceiling per 12-MAVLINK.md §3 is <b>SIM-ONLY</b>. Egress is
+ * limited to advisory message types ({@code STATUSTEXT},
+ * {@code NAMED_VALUE_FLOAT}, custom {@code JNEO_*} dialect); writes that
+ * would arm, take off, or otherwise drive an autopilot are rejected at
+ * config load and again at runtime unless {@code simulatorOnly: true}.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.mavlink;

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/InMemoryMavlinkTransport.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/InMemoryMavlinkTransport.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.mavlink;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * In-memory {@link MavlinkTransport} for the MAVLink bridge integration
+ * tests. Mirrors enough of the wire to validate the §10 scenarios in
+ * 12-MAVLINK.md without a real SITL instance.
+ */
+public final class InMemoryMavlinkTransport implements MavlinkTransport {
+
+    private MessageHandler handler;
+    private boolean connected;
+    private final List<Sent> sent = new ArrayList<>();
+    private final AtomicLong failsRemaining = new AtomicLong();
+
+    public record Sent(int systemId, int componentId, Object payload) {}
+
+    @Override public synchronized void connect() { connected = true; }
+    @Override public synchronized void setHandler(MessageHandler h) { this.handler = h; }
+    @Override public synchronized boolean isConnected() { return connected; }
+
+    @Override
+    public synchronized void send(int systemId, int componentId, Object payload) {
+        if (failsRemaining.get() > 0) {
+            failsRemaining.decrementAndGet();
+            throw new MavlinkTransportException("simulated send failure");
+        }
+        sent.add(new Sent(systemId, componentId, payload));
+    }
+
+    @Override public synchronized void close() { connected = false; }
+
+    /* ===== test helpers ============================================== */
+
+    /** Deliver an already-typed message to the handler. */
+    public synchronized <T> void deliver(int systemId, int componentId, T payload) {
+        if (handler == null) return;
+        handler.onMessage(new InboundMessage(systemId, componentId, payload));
+    }
+
+    /** Number of messages we have sent on this transport. */
+    public synchronized int sendCount() { return sent.size(); }
+
+    public synchronized List<Sent> sentMessages() { return new ArrayList<>(sent); }
+
+    /** Make the next {@code n} sends throw — used for PUBLISH_ERROR tests. */
+    public void failNextSends(int n) { failsRemaining.set(n); }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkBridgeConfigLoaderTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkBridgeConfigLoaderTest.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.mavlink;
+
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests for {@link MavlinkBridgeConfigLoader} (12-MAVLINK.md §6, §10 S10). */
+final class MavlinkBridgeConfigLoaderTest {
+
+    private static Throwable rootCause(Throwable t) {
+        Throwable cur = t;
+        while (cur.getCause() != null && cur.getCause() != cur) cur = cur.getCause();
+        return cur;
+    }
+
+    private static final String HAPPY = """
+            connections:
+              - id: FLEET-A
+                transport: UDP
+                bindAddress: "0.0.0.0"
+                bindPort: 14550
+                expectedSystems: [1, 2, 3]
+            simulatorOnly: true
+            reads:
+              - bindingId: DRONE-1-POS
+                connectionId: FLEET-A
+                systemId: 1
+                componentId: 1
+                messageType: GLOBAL_POSITION_INT
+                targetSignal: PROPRIOCEPTIVE
+                signalTag: DRONE.1.POS
+              - bindingId: DRONE-1-SEES-2
+                connectionId: FLEET-A
+                systemId: 2
+                messageType: GLOBAL_POSITION_INT
+                targetSignal: PEER_OBSERVATION
+                signalTag: DRONE.1.PEER.2.POS
+                peerId: drone-2
+              - bindingId: DRONE-1-BATT
+                connectionId: FLEET-A
+                systemId: 1
+                messageType: BATTERY_STATUS
+                targetSignal: EFFICIENCY
+                signalTag: DRONE.1.BATT
+            events:
+              - bindingId: STATUS-TEXTS
+                connectionId: FLEET-A
+                messageType: STATUSTEXT
+                targetSignal: ALARM
+                signalTagPrefix: DRONE.STATUS
+            writes:
+              - bindingId: FORMATION-ADV
+                connectionId: FLEET-A
+                targetSystemId: 0
+                messageType: JNEO_FORMATION
+                signalTag: FLEET.FORMATION.ADV
+            audit:
+              localAuditFile: /tmp/jneopallium/mavlink-audit.jsonl
+            perTagSafetyMode:
+              FORMATION-ADV: ADVISORY
+            """;
+
+    @Test
+    void loadsHappyPath() throws IOException {
+        MavlinkBridgeConfig cfg = MavlinkBridgeConfigLoader.load(HAPPY);
+        assertEquals(1, cfg.connections().size());
+        assertEquals(MavlinkBridgeConfig.Transport.UDP, cfg.connections().get(0).transport());
+        assertEquals(3, cfg.reads().size());
+        assertEquals(1, cfg.events().size());
+        assertEquals(1, cfg.writes().size());
+        assertTrue(cfg.simulatorOnly());
+        assertEquals(BridgeSafetyMode.ADVISORY, cfg.perTagSafetyMode().get("FORMATION-ADV"));
+        assertNotNull(cfg.audit());
+    }
+
+    @Test
+    void simulatorOnlyDefaultsTrue() throws IOException {
+        String yaml = """
+                connections:
+                  - id: C1
+                    transport: UDP
+                    bindPort: 14550
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        MavlinkBridgeConfig cfg = MavlinkBridgeConfigLoader.load(yaml);
+        assertTrue(cfg.simulatorOnly(),
+                "simulatorOnly defaults to true (12-MAVLINK.md §3, §6: safe-by-default).");
+    }
+
+    /** §10 S10: a write binding for COMMAND_LONG without simulatorOnly must fail loading. */
+    @Test
+    void rejectsCommandLongWithoutSimulatorOnly() {
+        String yaml = """
+                connections:
+                  - id: C1
+                    transport: UDP
+                    bindPort: 14550
+                simulatorOnly: false
+                writes:
+                  - bindingId: BAD-CMDLONG
+                    connectionId: C1
+                    messageType: COMMAND_LONG
+                    signalTag: T.X
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        Exception ex = assertThrows(Exception.class, () -> MavlinkBridgeConfigLoader.load(yaml));
+        assertTrue(rootCause(ex).getMessage().contains("COMMAND_LONG"));
+    }
+
+    @Test
+    void rejectsSetModeWithoutSimulatorOnly() {
+        String yaml = """
+                connections:
+                  - id: C1
+                    transport: UDP
+                    bindPort: 14550
+                simulatorOnly: false
+                writes:
+                  - bindingId: BAD-SETMODE
+                    connectionId: C1
+                    messageType: SET_MODE
+                    signalTag: T.X
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        assertThrows(Exception.class, () -> MavlinkBridgeConfigLoader.load(yaml));
+    }
+
+    @Test
+    void allowsCommandLongInSimulatorOnlyMode() throws IOException {
+        String yaml = """
+                connections:
+                  - id: C1
+                    transport: UDP
+                    bindPort: 14550
+                simulatorOnly: true
+                writes:
+                  - bindingId: SIM-CMDLONG
+                    connectionId: C1
+                    messageType: COMMAND_LONG
+                    signalTag: SIM.CMDLONG
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        MavlinkBridgeConfig cfg = MavlinkBridgeConfigLoader.load(yaml);
+        assertTrue(cfg.simulatorOnly());
+        assertEquals(1, cfg.writes().size());
+    }
+
+    @Test
+    void rejectsAutonomousPromotionOutsideSimulatorOnly() {
+        String yaml = """
+                connections:
+                  - id: C1
+                    transport: UDP
+                    bindPort: 14550
+                simulatorOnly: false
+                writes:
+                  - bindingId: ADV
+                    connectionId: C1
+                    messageType: STATUSTEXT
+                    signalTag: T.A
+                audit:
+                  localAuditFile: /tmp/x
+                perTagSafetyMode:
+                  ADV: AUTONOMOUS
+                """;
+        assertThrows(Exception.class, () -> MavlinkBridgeConfigLoader.load(yaml));
+    }
+
+    @Test
+    void unknownPropertyFailsLoading() {
+        String yaml = """
+                connections:
+                  - id: C1
+                    transport: UDP
+                    bindPort: 14550
+                bogusKey: 42
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        assertThrows(UnrecognizedPropertyException.class, () -> MavlinkBridgeConfigLoader.load(yaml));
+    }
+
+    @Test
+    void rejectsDuplicateBindingIds() {
+        String yaml = """
+                connections:
+                  - id: C1
+                    transport: UDP
+                    bindPort: 14550
+                reads:
+                  - bindingId: SAME
+                    connectionId: C1
+                    systemId: 1
+                    messageType: ATTITUDE
+                    signalTag: T.A
+                writes:
+                  - bindingId: SAME
+                    connectionId: C1
+                    messageType: STATUSTEXT
+                    signalTag: T.B
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        assertThrows(Exception.class, () -> MavlinkBridgeConfigLoader.load(yaml));
+    }
+
+    /** §6, §11 R1: systemId not in expectedSystems must fail loading. */
+    @Test
+    void rejectsSystemIdNotInExpectedSystems() {
+        String yaml = """
+                connections:
+                  - id: C1
+                    transport: UDP
+                    bindPort: 14550
+                    expectedSystems: [1, 2]
+                reads:
+                  - bindingId: ROGUE
+                    connectionId: C1
+                    systemId: 99
+                    messageType: ATTITUDE
+                    signalTag: T.X
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        Exception ex = assertThrows(Exception.class, () -> MavlinkBridgeConfigLoader.load(yaml));
+        assertTrue(rootCause(ex).getMessage().contains("expectedSystems"));
+    }
+
+    @Test
+    void rejectsPeerObservationOnNonGlobalPositionMessageType() {
+        String yaml = """
+                connections:
+                  - id: C1
+                    transport: UDP
+                    bindPort: 14550
+                reads:
+                  - bindingId: PEER
+                    connectionId: C1
+                    systemId: 2
+                    messageType: ATTITUDE
+                    targetSignal: PEER_OBSERVATION
+                    signalTag: T.X
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        assertThrows(Exception.class, () -> MavlinkBridgeConfigLoader.load(yaml));
+    }
+
+    @Test
+    void rejectsBindingForUnknownConnection() {
+        String yaml = """
+                connections:
+                  - id: C1
+                    transport: UDP
+                    bindPort: 14550
+                reads:
+                  - bindingId: ORPHAN
+                    connectionId: NOPE
+                    systemId: 1
+                    messageType: ATTITUDE
+                    signalTag: T.X
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        Exception ex = assertThrows(Exception.class, () -> MavlinkBridgeConfigLoader.load(yaml));
+        assertTrue(rootCause(ex).getMessage().contains("connectionId"));
+    }
+
+    @Test
+    void rejectsTcpWithoutHostPort() {
+        String yaml = """
+                connections:
+                  - id: C1
+                    transport: TCP
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        assertThrows(Exception.class, () -> MavlinkBridgeConfigLoader.load(yaml));
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkBridgeIntegrationTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/mavlink/MavlinkBridgeIntegrationTest.java
@@ -1,0 +1,573 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.mavlink;
+
+import com.rakovpublic.jneuropallium.ai.signals.fast.HarmVetoSignal;
+import com.rakovpublic.jneuropallium.ai.signals.fast.TransparencyLogSignal;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import com.rakovpublic.jneuropallium.worker.net.layers.IResult;
+import com.rakovpublic.jneuropallium.worker.net.layers.impl.SimpleResultWrapper;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmPriority;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.swarm.FormationTemplate;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.ProprioceptiveSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.EfficiencySignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.security.AnomalyScoreSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.FormationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.swarm.PeerObservationSignal;
+import io.dronefleet.mavlink.common.Attitude;
+import io.dronefleet.mavlink.common.BatteryStatus;
+import io.dronefleet.mavlink.common.GlobalPositionInt;
+import io.dronefleet.mavlink.common.MavSeverity;
+import io.dronefleet.mavlink.common.RadioStatus;
+import io.dronefleet.mavlink.common.Statustext;
+import io.dronefleet.mavlink.common.SysStatus;
+import io.dronefleet.mavlink.minimal.Heartbeat;
+import io.dronefleet.mavlink.util.EnumValue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for the MAVLink bridge (12-MAVLINK.md §10). Covers the
+ * universal 00-FRAMEWORK §5 scenarios that apply (S1, S3, S4, S5) plus the
+ * bridge-specific scenarios S7–S12. Runs against
+ * {@link InMemoryMavlinkTransport} — no SITL required.
+ */
+class MavlinkBridgeIntegrationTest {
+
+    private static final String CONN = "FLEET-A";
+
+    @TempDir Path tempDir;
+
+    private InMemoryMavlinkTransport transport;
+    private MavlinkAuditOutput audit;
+    private MavlinkClientService svc;
+
+    @BeforeEach
+    void setUp() {
+        transport = new InMemoryMavlinkTransport();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (svc != null) svc.close();
+        if (audit != null) audit.close();
+    }
+
+    /* ===== framework universal scenarios ===================================== */
+
+    /**
+     * S1: a GLOBAL_POSITION_INT delivers a typed Proprioceptive signal within
+     * one drain.
+     */
+    @Test
+    void s1_pureReadEmitsTypedSignal() {
+        MavlinkBridgeConfig cfg = baseConfig(
+                List.of(read("DRONE-1-POS", 1, "GLOBAL_POSITION_INT",
+                        MavlinkBridgeConfig.ReadSignalKind.PROPRIOCEPTIVE,
+                        "DRONE.1.POS", null, 1)),
+                List.of(),
+                List.of(),
+                Map.of(),
+                true);
+        bring(cfg);
+
+        // 47.123 deg lat, 8.456 deg lon, 100m alt, 1 m/s east velocity.
+        GlobalPositionInt gp = GlobalPositionInt.builder()
+                .timeBootMs(1000)
+                .lat(471230000)
+                .lon(84560000)
+                .alt(100_000)
+                .relativeAlt(50_000)
+                .vx(100).vy(0).vz(0)
+                .hdg(9000)
+                .build();
+        transport.deliver(1, 1, gp);
+
+        List<IInputSignal> signals = svc.drain("DRONE-1-POS");
+        assertEquals(1, signals.size());
+        ProprioceptiveSignal sig = (ProprioceptiveSignal) signals.get(0);
+        assertEquals(47.123, sig.getJointStates()[0], 1e-6);
+        assertEquals(8.456, sig.getJointStates()[1], 1e-6);
+        assertEquals(100.0, sig.getJointStates()[2], 1e-6);
+        assertEquals(1.0, sig.getJointStates()[4], 1e-6);
+    }
+
+    /** S3: SHADOW mode rejects writes; nothing reaches the wire. */
+    @Test
+    void s3_shadowModeRejectsWrite() throws IOException {
+        MavlinkBridgeConfig cfg = baseConfig(
+                List.of(),
+                List.of(),
+                List.of(write("HARM-VETO", 0, "STATUSTEXT", "FLEET.HARM_VETO")),
+                Map.of("HARM-VETO", BridgeSafetyMode.SHADOW),
+                true);
+        bring(cfg);
+
+        MavlinkAdvisoryOutputAggregator agg = new MavlinkAdvisoryOutputAggregator(svc, audit);
+        HarmVetoSignal hv = new HarmVetoSignal();
+        hv.setName("FLEET.HARM_VETO");
+        hv.setVetoReason("TEST");
+        agg.save(List.of(result(hv)), System.currentTimeMillis(), 1L, null);
+
+        assertEquals(0, transport.sendCount(), "SHADOW mode must not send");
+        String log = Files.readString(tempDir.resolve("mavlink-audit.jsonl"));
+        assertTrue(log.contains("SHADOW_MODE"), "expected SHADOW_MODE audit, got: " + log);
+    }
+
+    /** S4: reconnect drops cache and emits a {@code BRIDGE_RECONNECTED} alarm. */
+    @Test
+    void s4_reconnectClearsCacheAndEmitsAdvisoryEvent() {
+        MavlinkBridgeConfig cfg = baseConfig(
+                List.of(read("DRONE-1-POS", 1, "GLOBAL_POSITION_INT", null,
+                        "DRONE.1.POS", null, 1)),
+                List.of(), List.of(), Map.of(), true);
+        bring(cfg);
+
+        transport.deliver(1, 1, GlobalPositionInt.builder().build());
+        svc.onReconnected(CONN);
+
+        assertTrue(svc.drain("DRONE-1-POS").isEmpty());
+        List<IInputSignal> events = svc.drainEvents();
+        assertTrue(events.stream().anyMatch(e ->
+                        e instanceof AlarmSignal a
+                                && a.getConditionCode() != null
+                                && a.getConditionCode().startsWith(MavlinkClientService.BRIDGE_RECONNECTED)),
+                "expected BRIDGE_RECONNECTED advisory");
+    }
+
+    /* ===== bridge-specific scenarios (12-MAVLINK §10) ======================= */
+
+    /** S7: full SITL-style telemetry produces a typed Proprioceptive signal. */
+    @Test
+    void s7_sitlTelemetryAttitude() {
+        MavlinkBridgeConfig cfg = baseConfig(
+                List.of(read("DRONE-1-ATT", 1, "ATTITUDE", null, "DRONE.1.ATT", null, 1)),
+                List.of(), List.of(), Map.of(), true);
+        bring(cfg);
+
+        Attitude att = Attitude.builder()
+                .timeBootMs(1000)
+                .roll(0.1f).pitch(0.2f).yaw(0.3f)
+                .rollspeed(0.01f).pitchspeed(0.02f).yawspeed(0.03f)
+                .build();
+        transport.deliver(1, 1, att);
+
+        ProprioceptiveSignal sig = (ProprioceptiveSignal) svc.drain("DRONE-1-ATT").get(0);
+        assertEquals(0.1, sig.getJointStates()[0], 1e-6);
+        assertEquals(0.3, sig.getJointStates()[2], 1e-6);
+    }
+
+    /** S8: multi-system swarm — system 1 sees system 2 as a PeerObservationSignal. */
+    @Test
+    void s8_multiSystemPeerObservation() {
+        MavlinkBridgeConfig cfg = baseConfig(
+                List.of(
+                        read("DRONE-1-POS", 1, "GLOBAL_POSITION_INT",
+                                MavlinkBridgeConfig.ReadSignalKind.PROPRIOCEPTIVE,
+                                "DRONE.1.POS", null, 1),
+                        read("DRONE-1-SEES-2", 2, "GLOBAL_POSITION_INT",
+                                MavlinkBridgeConfig.ReadSignalKind.PEER_OBSERVATION,
+                                "DRONE.1.PEER.2.POS", "drone-2", 1)),
+                List.of(), List.of(),
+                Map.of(),
+                true,
+                List.of(1, 2, 3));
+        bring(cfg);
+
+        GlobalPositionInt gp2 = GlobalPositionInt.builder()
+                .lat(471230000).lon(84560000).alt(50_000)
+                .vx(0).vy(100).vz(0)
+                .build();
+        transport.deliver(2, 1, gp2);
+
+        List<IInputSignal> peer = svc.drain("DRONE-1-SEES-2");
+        assertEquals(1, peer.size());
+        PeerObservationSignal sig = (PeerObservationSignal) peer.get(0);
+        assertEquals("drone-2", sig.getPeerId());
+        assertEquals(47.123, sig.getPositionLocal()[0], 1e-6);
+        assertEquals(1.0, sig.getVelocityLocal()[1], 1e-6);
+
+        // Cross-talk check: system 1's read binding is unaffected.
+        assertTrue(svc.drain("DRONE-1-POS").isEmpty());
+    }
+
+    /** S9: heartbeat loss → PEER_OFFLINE alarm. */
+    @Test
+    void s9_heartbeatLossEmitsAlarm() {
+        MavlinkBridgeConfig cfg = baseConfig(
+                List.of(),
+                List.of(), List.of(),
+                Map.of(),
+                true);
+        bring(cfg);
+
+        // Establish liveness for system 7.
+        transport.deliver(7, 1, Heartbeat.builder().build());
+        long now = System.currentTimeMillis();
+        svc.checkHeartbeats(now);
+        assertTrue(svc.drainEvents().stream().noneMatch(e ->
+                e instanceof AlarmSignal a && "PEER_OFFLINE".equals(a.getConditionCode())));
+
+        // 5 s later — past the 2 s timeout.
+        svc.checkHeartbeats(now + 5_000L);
+        List<IInputSignal> events = svc.drainEvents();
+        assertTrue(events.stream().anyMatch(e ->
+                e instanceof AlarmSignal a
+                        && "PEER_OFFLINE".equals(a.getConditionCode())
+                        && a.getPriority() == AlarmPriority.HIGH),
+                "expected PEER_OFFLINE alarm after heartbeat timeout");
+    }
+
+    /** S10: forbidden write rejected at config load (COMMAND_LONG, simulatorOnly=false). */
+    @Test
+    void s10_forbiddenWriteRejectedAtLoad() {
+        String yaml = """
+                connections:
+                  - id: FLEET-A
+                    transport: UDP
+                    bindPort: 14550
+                simulatorOnly: false
+                writes:
+                  - bindingId: BAD
+                    connectionId: FLEET-A
+                    messageType: COMMAND_LONG
+                    signalTag: BAD.CMDLONG
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        assertThrows(Exception.class, () -> MavlinkBridgeConfigLoader.load(yaml));
+    }
+
+    /** S11: battery low advisory → EfficiencySignal + downstream HarmVetoSignal → STATUSTEXT. */
+    @Test
+    void s11_batteryLowAndHarmVetoStatusText() {
+        MavlinkBridgeConfig cfg = baseConfig(
+                List.of(read("DRONE-1-BATT", 1, "BATTERY_STATUS", null, "DRONE.1.BATT", null, 1)),
+                List.of(),
+                List.of(write("HARM-VETO", 0, "STATUSTEXT", "DRONE.1.HARM_VETO")),
+                Map.of("HARM-VETO", BridgeSafetyMode.ADVISORY),
+                true);
+        bring(cfg);
+
+        BatteryStatus bs = BatteryStatus.builder()
+                .id(0)
+                .batteryRemaining(20)
+                .currentBattery(500)
+                .build();
+        transport.deliver(1, 1, bs);
+
+        EfficiencySignal eff = (EfficiencySignal) svc.drain("DRONE-1-BATT").get(0);
+        assertEquals(0.20, eff.getEfficiency(), 1e-9);
+
+        // Downstream emits a HarmVetoSignal.
+        MavlinkAdvisoryOutputAggregator agg = new MavlinkAdvisoryOutputAggregator(svc, audit);
+        HarmVetoSignal veto = new HarmVetoSignal();
+        veto.setName("DRONE.1.HARM_VETO");
+        veto.setVetoReason("BATTERY_CRITICAL");
+        agg.save(List.of(result(veto)), System.currentTimeMillis(), 1L, null);
+
+        List<InMemoryMavlinkTransport.Sent> sent = transport.sentMessages();
+        assertEquals(1, sent.size());
+        Statustext st = (Statustext) sent.get(0).payload();
+        assertEquals(MavSeverity.MAV_SEVERITY_CRITICAL, st.severity().entry());
+        assertTrue(st.text().contains("BATTERY_CRITICAL"), "veto text: " + st.text());
+    }
+
+    /**
+     * S12: custom dialect roundtrip — the formation encoder produces a
+     * {@code STATUSTEXT} payload carrying the template name and slot index.
+     * The formation-encoder is exercised directly because
+     * {@link FormationSignal} is an {@code ISignal}, not an
+     * {@code IResultSignal}, and so cannot reach an aggregator through the
+     * {@link IResult} flow today; the encoder here is the seam where the
+     * generated {@code jneo.xml} dialect classes will swap in (12-MAVLINK
+     * §7).
+     */
+    @Test
+    void s12_customDialectFormationEncoding() {
+        var encoder = new MavlinkAdvisoryOutputAggregator.MavlinkAdvisoryEncoder();
+        FormationSignal fs = new FormationSignal(FormationTemplate.DIAMOND, 4, null);
+        Statustext st = encoder.encodeFormation(fs);
+        assertTrue(st.text().contains("DIAMOND"), "formation template: " + st.text());
+        assertTrue(st.text().contains("slot=4"), "slot index: " + st.text());
+    }
+
+    /* ===== additional defensive scenarios ==================================== */
+
+    /** §11 R1: messages from a system not in expectedSystems are dropped. */
+    @Test
+    void unexpectedSystemDropped() throws IOException {
+        MavlinkBridgeConfig cfg = baseConfig(
+                List.of(read("DRONE-1-POS", 1, "GLOBAL_POSITION_INT", null,
+                        "DRONE.1.POS", null, 1)),
+                List.of(), List.of(),
+                Map.of(),
+                true,
+                List.of(1, 2));
+        bring(cfg);
+
+        // System 99 is not in expectedSystems → must be dropped.
+        transport.deliver(99, 1, GlobalPositionInt.builder().build());
+        assertTrue(svc.drain("DRONE-1-POS").isEmpty());
+
+        String log = Files.readString(tempDir.resolve("mavlink-audit.jsonl"));
+        assertTrue(log.contains("UNKNOWN_SYSTEM"), "expected UNKNOWN_SYSTEM audit, got: " + log);
+    }
+
+    /** STATUSTEXT events surface as AlarmSignal on the advisory event channel. */
+    @Test
+    void statusTextEventsSurfaceAsAlarm() {
+        MavlinkBridgeConfig cfg = baseConfig(
+                List.of(),
+                List.of(eventBinding("STATUS-TEXTS", "STATUSTEXT", "DRONE.STATUS")),
+                List.of(),
+                Map.of(),
+                true);
+        bring(cfg);
+
+        Statustext st = Statustext.builder()
+                .severity(MavSeverity.MAV_SEVERITY_WARNING)
+                .text("Pre-arm: not armed")
+                .build();
+        transport.deliver(1, 1, st);
+
+        List<IInputSignal> events = svc.drainEvents();
+        AlarmSignal alarm = (AlarmSignal) events.stream()
+                .filter(e -> e instanceof AlarmSignal a && a.getTag() != null
+                        && a.getTag().startsWith("DRONE.STATUS"))
+                .findFirst().orElseThrow();
+        assertEquals(AlarmPriority.HIGH, alarm.getPriority());
+        assertTrue(alarm.getConditionCode().contains("Pre-arm"));
+    }
+
+    /** RADIO_STATUS below RSSI threshold → AnomalyScoreSignal. */
+    @Test
+    void radioStatusBelowThresholdEmitsAnomaly() {
+        MavlinkBridgeConfig cfg = baseConfig(
+                List.of(read("LINK-1", 1, "RADIO_STATUS",
+                        MavlinkBridgeConfig.ReadSignalKind.ANOMALY,
+                        "DRONE.1.LINK", null, 1)),
+                List.of(), List.of(),
+                Map.of(),
+                true);
+        bring(cfg);
+
+        RadioStatus rs = RadioStatus.builder()
+                .rssi(10).remrssi(10).noise(10).rxerrors(0).build();
+        transport.deliver(1, 1, rs);
+
+        AnomalyScoreSignal a = (AnomalyScoreSignal) svc.drain("LINK-1").get(0);
+        assertTrue(a.getDeviationScore() > 0.5,
+                "expected high anomaly for low RSSI, got " + a.getDeviationScore());
+    }
+
+    /** SYS_STATUS with unhealthy enabled sensor → AlarmSignal on the event channel. */
+    @Test
+    void sysStatusUnhealthyEmitsAlarm() {
+        MavlinkBridgeConfig cfg = baseConfig(
+                List.of(),
+                List.of(eventBinding("SYS-HEALTH", "SYS_STATUS", "DRONE.HEALTH")),
+                List.of(),
+                Map.of(),
+                true);
+        bring(cfg);
+
+        // present=0xff, enabled=0xff, health=0x0f — top 4 sensors enabled but unhealthy.
+        SysStatus ss = SysStatus.builder()
+                .onboardControlSensorsPresent(EnumValue.create(0xff))
+                .onboardControlSensorsEnabled(EnumValue.create(0xff))
+                .onboardControlSensorsHealth(EnumValue.create(0x0f))
+                .dropRateComm(0)
+                .build();
+        transport.deliver(1, 1, ss);
+
+        List<IInputSignal> events = svc.drainEvents();
+        assertTrue(events.stream().anyMatch(e ->
+                e instanceof AlarmSignal a
+                        && a.getConditionCode() != null
+                        && a.getConditionCode().startsWith("SENSOR_UNHEALTHY")),
+                "expected SENSOR_UNHEALTHY alarm");
+    }
+
+    /**
+     * S5 / framework: an unwritable audit file degrades the audit channel
+     * but does not block traffic. We force the writer into degraded mode
+     * by pointing the audit path at a child of an existing regular file —
+     * {@code Files.createDirectories} cannot create a directory under a
+     * file, so the open fails and the bridge keeps running.
+     */
+    @Test
+    void s5_auditFailureDoesNotBlockTraffic() throws IOException {
+        Path blockerFile = tempDir.resolve("blocker");
+        Files.createFile(blockerFile);
+        Path bogusFile = blockerFile.resolve("audit.jsonl");
+
+        MavlinkBridgeConfig cfg = baseConfig(
+                List.of(read("DRONE-1-POS", 1, "GLOBAL_POSITION_INT", null,
+                        "DRONE.1.POS", null, 1)),
+                List.of(), List.of(), Map.of(), true);
+        audit = new MavlinkAuditOutput(bogusFile);
+        svc = new MavlinkClientService(cfg, Map.of(CONN, transport), audit);
+        svc.start();
+
+        transport.deliver(1, 1, GlobalPositionInt.builder()
+                .lat(0).lon(0).alt(0).build());
+        assertEquals(1, svc.drain("DRONE-1-POS").size(),
+                "bridge must keep emitting signals even with a degraded audit channel");
+        assertTrue(audit.isDegraded(), "audit channel should be degraded");
+    }
+
+    /** TransparencyLogSignal must NEVER be forwarded onto MAVLink (§5). */
+    @Test
+    void transparencyLogIsNotForwardedToMavlink() {
+        MavlinkBridgeConfig cfg = baseConfig(
+                List.of(), List.of(),
+                List.of(write("AUDIT", 0, "STATUSTEXT", "AUDIT.TAG")),
+                Map.of("AUDIT", BridgeSafetyMode.ADVISORY),
+                true);
+        bring(cfg);
+
+        MavlinkAdvisoryOutputAggregator agg = new MavlinkAdvisoryOutputAggregator(svc, audit);
+        TransparencyLogSignal tl = new TransparencyLogSignal();
+        tl.setActionPlanId("plan-1");
+        tl.setName("AUDIT.TAG");
+        agg.save(List.of(result(tl)), System.currentTimeMillis(), 1L, null);
+
+        assertEquals(0, transport.sendCount(),
+                "TransparencyLogSignal must not be sent on MAVLink (12-MAVLINK.md §5)");
+    }
+
+    /** Audit shape conforms to 00-FRAMEWORK §4. */
+    @Test
+    void auditShapeMatchesFramework() throws IOException {
+        MavlinkBridgeConfig cfg = baseConfig(
+                List.of(), List.of(),
+                List.of(write("HARM-VETO", 0, "STATUSTEXT", "FLEET.HARM_VETO")),
+                Map.of("HARM-VETO", BridgeSafetyMode.ADVISORY),
+                true);
+        bring(cfg);
+
+        MavlinkAdvisoryOutputAggregator agg = new MavlinkAdvisoryOutputAggregator(svc, audit);
+        HarmVetoSignal hv = new HarmVetoSignal();
+        hv.setName("FLEET.HARM_VETO");
+        hv.setVetoReason("UNIT_TEST");
+        agg.save(List.of(result(hv)), 1700000000000L, 42L, null);
+
+        audit.close();
+        audit = null;
+        String log = Files.readString(tempDir.resolve("mavlink-audit.jsonl"));
+        assertTrue(log.contains("\"bridge\":\"mavlink\""), "missing bridge key: " + log);
+        assertTrue(log.contains("\"verdict\":\"APPLIED\""), "missing APPLIED verdict: " + log);
+        assertTrue(log.contains("\"tag\":\"FLEET.HARM_VETO\""), "missing tag: " + log);
+    }
+
+    /** §3 runtime backstop: rebuilding the config to flip simulatorOnly throws. */
+    @Test
+    void runtimeBackstopForForbiddenMessageType() {
+        MavlinkBridgeConfig simCfg = baseConfig(
+                List.of(), List.of(),
+                List.of(write("SIM-CMDLONG", 0, "COMMAND_LONG", "SIM.CMDLONG")),
+                Map.of(),
+                true);
+        assertThrows(IllegalArgumentException.class, () -> new MavlinkBridgeConfig(
+                simCfg.connections(),
+                false,
+                simCfg.reads(), simCfg.events(), simCfg.writes(), simCfg.audit(),
+                simCfg.perTagSafetyMode(), simCfg.tickInterval()));
+    }
+
+    /** mavlinkMessageTypeOf converts CamelCase payload class names to MAVLink names. */
+    @Test
+    void messageTypeNameConversion() {
+        assertEquals("GLOBAL_POSITION_INT",
+                MavlinkClientService.mavlinkMessageTypeOf(GlobalPositionInt.builder().build()));
+        assertEquals("ATTITUDE",
+                MavlinkClientService.mavlinkMessageTypeOf(Attitude.builder().build()));
+        assertEquals("HEARTBEAT",
+                MavlinkClientService.mavlinkMessageTypeOf(Heartbeat.builder().build()));
+        assertNull(MavlinkClientService.mavlinkMessageTypeOf(null));
+    }
+
+    /* ===== helpers =========================================================== */
+
+    private void bring(MavlinkBridgeConfig cfg) {
+        Path file = tempDir.resolve("mavlink-audit.jsonl");
+        audit = new MavlinkAuditOutput(file);
+        svc = new MavlinkClientService(cfg, Map.of(CONN, transport), audit);
+        svc.start();
+    }
+
+    private static MavlinkBridgeConfig baseConfig(
+            List<MavlinkBridgeConfig.ReadBindingConfig> reads,
+            List<MavlinkBridgeConfig.EventBindingConfig> events,
+            List<MavlinkBridgeConfig.WriteBindingConfig> writes,
+            Map<String, BridgeSafetyMode> safetyModes,
+            boolean simulatorOnly) {
+        return baseConfig(reads, events, writes, safetyModes, simulatorOnly, List.of());
+    }
+
+    private static MavlinkBridgeConfig baseConfig(
+            List<MavlinkBridgeConfig.ReadBindingConfig> reads,
+            List<MavlinkBridgeConfig.EventBindingConfig> events,
+            List<MavlinkBridgeConfig.WriteBindingConfig> writes,
+            Map<String, BridgeSafetyMode> safetyModes,
+            boolean simulatorOnly,
+            List<Integer> expectedSystems) {
+        return new MavlinkBridgeConfig(
+                List.of(new MavlinkBridgeConfig.ConnectionConfig(
+                        CONN, MavlinkBridgeConfig.Transport.UDP,
+                        "0.0.0.0", 14550, null, null, expectedSystems)),
+                simulatorOnly,
+                reads, events, writes,
+                new MavlinkBridgeConfig.AuditConfig(
+                        Path.of(System.getProperty("java.io.tmpdir"),
+                                "mavlink-audit.jsonl").toString()),
+                safetyModes,
+                null);
+    }
+
+    private static MavlinkBridgeConfig.ReadBindingConfig read(
+            String id, int systemId, String messageType,
+            MavlinkBridgeConfig.ReadSignalKind kind,
+            String tag, String peerId, int decimateBy) {
+        return new MavlinkBridgeConfig.ReadBindingConfig(
+                id, CONN, systemId, 1, messageType, kind, tag, peerId, decimateBy);
+    }
+
+    private static MavlinkBridgeConfig.EventBindingConfig eventBinding(
+            String id, String messageType, String prefix) {
+        return new MavlinkBridgeConfig.EventBindingConfig(
+                id, CONN, messageType,
+                MavlinkBridgeConfig.ReadSignalKind.ALARM, prefix);
+    }
+
+    private static MavlinkBridgeConfig.WriteBindingConfig write(
+            String id, int targetSysId, String messageType, String tag) {
+        return new MavlinkBridgeConfig.WriteBindingConfig(
+                id, CONN, targetSysId, 0, messageType, tag,
+                null, null, null, null);
+    }
+
+    private static <K extends com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal>
+            IResult<K> result(K s) {
+        return new SimpleResultWrapper<>(s, 1L);
+    }
+}


### PR DESCRIPTION
SIM-ONLY by construction: forbidden actuating message types (COMMAND_LONG, SET_MODE, MISSION_*, MANUAL_CONTROL, RC_CHANNELS_OVERRIDE) are rejected at config load and again at runtime, expectedSystems whitelist drops cross-talk, AUTONOMOUS per-tag promotion is gated by simulatorOnly, and TransparencyLogSignal is kept off the flight bus.

https://claude.ai/code/session_01RfZBZX8S1HKo2hYU4mNqqz