### PR TITLE
Implement CANopen bridge (13-CANOPEN.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ every loop.
 | 10 | Eclipse Ditto | digital twins | shipped | ADVISORY |
 | 11 | IEC 61850 | power grid | spec | READ-ONLY initially |
 | 12 | MAVLink | drones | shipped | SIM-ONLY initially |
-| 13 | CANopen | embedded | spec | ADVISORY |
+| 13 | CANopen | embedded | shipped | ADVISORY |
 | 14 | LTI / xAPI | adaptive tutoring | spec | ADVISORY |
 
 ### OPC UA bridge
@@ -301,6 +301,26 @@ whitelist are enforced both at config load and at runtime; per-tag
 which models the simulator-with-watchdog escape. See
 [`docs/mavlink-bridge.md`](docs/mavlink-bridge.md) and
 [`12-MAVLINK.md`](12-MAVLINK.md).
+
+### CANopen bridge
+
+For embedded networks (mobile robots, AGVs, industrial drives, BMS packs)
+the CANopen bridge surfaces TPDO scalar payloads, EMCY emergency frames,
+and per-node heartbeat liveness onto the Jneopallium signal bus:
+CiA-402 `position_actual` → `ProprioceptiveSignal`, CiA-401 sensor PDO →
+`MeasurementSignal`, CiA-418 SoC → `EfficiencySignal`, EMCY frame →
+`AlarmSignal` (with the standard CiA-301 §7.2.1 description), missed
+heartbeat → `NODE_OFFLINE` alarm. Subsequent reads from a node past the
+heartbeat timeout carry `Quality.UNCERTAIN`. Egress is restricted to
+**non-actuating** OD indices: writes to `controlword` (`0x6040`) are
+rejected at config load unconditionally, and every other write must
+appear on the per-node `writeIndexAllowList` to be loaded — both gates
+are re-checked at runtime by the platform service. The Linux SocketCAN
+backend (`SocketCanClientService`) is the production target; the
+Lawicel-style USB-CAN backend (`UsbCanClientService`) is the
+cross-platform escape hatch (CANable / Korlan / PCAN). See
+[`docs/canopen-bridge.md`](docs/canopen-bridge.md) and
+[`13-CANOPEN.md`](13-CANOPEN.md).
 
 ## Applications
 

--- a/docs/canopen-bridge.md
+++ b/docs/canopen-bridge.md
@@ -1,0 +1,212 @@
+# CANopen bridge
+
+> Companion to [`13-CANOPEN.md`](../13-CANOPEN.md) (the spec) and
+> [`00-FRAMEWORK.md`](../00-FRAMEWORK.md) (the universal contract). This
+> file documents the CANopen bridge's domain context, YAML schema, manual
+> demo procedure, and regulatory posture — i.e. the §10
+> Definition-of-Done items that don't belong in the spec itself.
+
+## Domain context
+
+[CANopen](https://www.can-cia.org/canopen/) is the application-layer
+protocol on top of the CAN bus (CiA, CAN in Automation). It addresses
+device-internal state via an Object Dictionary indexed by 16-bit object
+index plus 8-bit subindex (e.g. `0x6041:00 statusword`,
+`0x6064:00 position_actual`). The dominant device profiles are CiA-301
+(generic), CiA-401 (I/O), CiA-402 (motion control), and CiA-418 (battery
+management).
+
+The bridge surfaces TPDO scalar payloads, EMCY emergency frames, and
+heartbeat liveness onto the Jneopallium signal bus and writes neuron-
+derived setpoints back through SDO or RPDO — but *only* to non-actuating
+indices that an operator has explicitly placed on the per-node
+`writeIndexAllowList`. The CiA-402 `controlword` (`0x6040`) is on a
+hard-coded **forbidden** list and is rejected at config load even when
+re-allowed in the user-facing list.
+
+## Components
+
+```
+worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/
+├── CanopenBridgeConfig.java                ← YAML record (immutable, 0x6040 rejected)
+├── CanopenBridgeConfigLoader.java          ← Jackson YAML loader, FAIL_ON_UNKNOWN
+├── EdsParser.java                          ← Permissive Electronic Data Sheet parser (CiA-306)
+├── ObjectDictionaryEntry.java              ← One OD entry: index, subindex, type, access
+├── CanopenNodeBinding.java                 ← read/event/write binding (BridgeBinding)
+├── CanopenSignalMapper.java                ← PDO/EMCY/heartbeat ↔ typed signal (pure)
+├── CanFrame.java                           ← raw CAN frame record
+├── CanopenClientService.java               ← interface (orchestrator surface)
+├── AbstractCanopenClientService.java       ← shared orchestration: routing, watchdog, audit, queueing
+├── SocketCanClientService.java             ← Linux SocketCAN backend (sink-injected)
+├── UsbCanClientService.java                ← Cross-platform Lawicel USB-CAN backend (sink-injected)
+├── CanopenMeasurementInput.java            ← IInitInput → MeasurementSignal/EfficiencySignal
+├── CanopenStateInput.java                  ← IInitInput → ProprioceptiveSignal + statusword carrier
+├── CanopenEventInput.java                  ← IInitInput → AlarmSignal (EMCY, heartbeat-loss)
+├── CanopenAuditOutput.java                 ← local JSONL audit
+├── CanopenAdvisoryOutputAggregator.java    ← IOutputAggregator (SDO + RPDO advisory egress)
+└── package-info.java
+```
+
+## YAML schema
+
+Refer to 13-CANOPEN.md §6 for the canonical example. Key points:
+
+* `canBus.type` is `SOCKETCAN` (Linux production) or `USB_CAN`
+  (cross-platform dev hardware: CANable / Korlan / PCAN-USB in Lawicel
+  mode). `device` is an interface name (`vcan0`, `can0`) for SocketCAN
+  or a serial port path (`/dev/ttyACM0`, `COM4`) for USB-CAN.
+* `nodes` lists every CANopen node id (1..127) the bridge expects to
+  see. `profileEdsFile` is optional — when present the bridge parses
+  the EDS via `EdsParser` so the OD entry types are available for
+  cross-checks against the per-binding `odType`.
+* Each `read` binding maps one `(nodeId, odIndex, subIndex, pdoSource)`
+  tuple to one signal class. The class is set by `targetSignal`:
+  - `PROPRIOCEPTIVE` — joint state / encoder PDO from a CiA-402 drive
+  - `MEASUREMENT` — generic CiA-401 I/O / sensor PDO; carries
+    `Quality.UNCERTAIN` while the source node is past heartbeat timeout
+  - `EFFICIENCY` — CiA-418 battery / pack metric (the mapper assumes
+    0..100 % SoC inputs and divides by 100 to land in 0..1)
+  - `BATCH_STATE` — CiA-402 statusword; the queue carries a
+    `MeasurementSignal` (because `BatchStateSignal` is not an
+    `IInputSignal`) plus an `AlarmSignal` if bit 3 (`FAULT`) is set; the
+    typed `BatchStateSignal` is available via
+    `AbstractCanopenClientService.lastDriveState(bindingId)`.
+* `events` are EMCY (CiA-301 emergency frame, COB-ID `0x080 + nodeId`)
+  or `HEARTBEAT_LOSS` (synthesised by the bridge's watchdog).
+* Each `write` binding clamps to `[minClampValue, maxClampValue]` and
+  rate-limits to `rampRateMaxPerSec`. The egress path is `SDO` (acyclic,
+  audited per write) or `RPDO` (cyclic). **Every write binding must clear
+  two structural gates**:
+  1. The hard-coded forbidden-OD-index list rejects `controlword`
+     (`0x6040`) unconditionally.
+  2. The per-node `writeIndexAllowList` must include the index. A typo
+     here is caught at load.
+* `decimateBy` on a read binding drops all but every Nth message.
+
+## Heartbeat liveness
+
+`AbstractCanopenClientService.checkHeartbeats(nowMs)` should be called
+once per tick by the host loop. For every node from which a heartbeat
+frame (COB-ID `0x700 + nodeId`) has ever arrived, if more than 2 s
+elapses without a fresh one, the bridge:
+
+* Emits a `NODE_OFFLINE` `AlarmSignal` (priority `HIGH`) on the global
+  event channel.
+* Marks the node "offline" — subsequent `MeasurementSignal` reads from
+  bindings on that node carry `Quality.UNCERTAIN` per 00-FRAMEWORK
+  §0.5.
+* If a `HEARTBEAT_LOSS` event-binding is configured for the node, the
+  alarm also lands on that binding's queue (so a per-binding input
+  drains it).
+
+The alarm is sticky — it fires once per online → offline transition,
+not on every tick — so the audit channel doesn't drown in repeats.
+
+## Manual demo (vcan0)
+
+Phase 1 acceptance test for the bridge follows §10 S7. Outside of
+unit/integration tests, the manual demo is:
+
+```bash
+# 1. Bring up a virtual CAN interface on Linux.
+sudo modprobe vcan
+sudo ip link add dev vcan0 type vcan
+sudo ip link set up vcan0
+
+# 2. Point the bridge at vcan0.
+cat <<EOF > /tmp/canopen-bridge.yaml
+canBus:
+  type: SOCKETCAN
+  device: vcan0
+  bitrate: 500000
+
+nodes:
+  - id: 1
+    type: CiA-402
+  - id: 2
+    type: CiA-418
+
+reads:
+  - bindingId: DRIVE-1-POS
+    nodeId: 1
+    odIndex: 24676   # 0x6064 position_actual
+    subIndex: 0
+    pdoSource: TPDO1
+    odType: INT32
+    targetSignal: PROPRIOCEPTIVE
+    signalTag: DRIVE.1.POS_ACTUAL
+  - bindingId: BMS-SOC
+    nodeId: 2
+    odIndex: 8193   # 0x2001 vendor SOC
+    subIndex: 0
+    pdoSource: TPDO1
+    odType: UINT16
+    targetSignal: EFFICIENCY
+    signalTag: BMS.PACK_A.SOC
+
+events:
+  - bindingId: DRIVE-1-FAULT
+    nodeId: 1
+    source: EMCY
+    targetSignal: ALARM
+    signalTagPrefix: DRIVE.FAULT
+
+writes:
+  - bindingId: DRIVE-1-PROFILE-VEL
+    nodeId: 1
+    odIndex: 24705   # 0x6081 profile_velocity
+    subIndex: 0
+    odType: UINT32
+    via: SDO
+    signalTag: DRIVE.1.PROFILE_VEL
+    minClampValue: 0
+    maxClampValue: 5000
+
+writeIndexAllowList:
+  1:
+    - 24705   # 0x6081 profile_velocity (controlword 0x6040 deliberately omitted)
+
+audit:
+  localAuditFile: /var/log/jneopallium/canopen-audit.jsonl
+
+perTagSafetyMode:
+  DRIVE-1-PROFILE-VEL: ADVISORY
+EOF
+
+# 3. Generate traffic with the canutils — cangen for periodic random
+#    frames, cansend for shaped frames:
+cangen -g 50 -I 0x181 -L 4 vcan0   # TPDO1 from node 1, 4-byte payload
+cansend vcan0 081#0023020000000000  # EMCY from node 1, code 0x2300
+cansend vcan0 701#05                # NMT operational heartbeat from node 1
+
+# 4. Run a small Java program that loads the YAML, builds
+#    SocketCanClientService + CanopenStateInput / CanopenMeasurementInput
+#    / CanopenEventInput, and prints the signals it drains each tick.
+```
+
+A real-hardware demo (§10 phase 2) follows the same recipe with
+`device: can0` and a Maxon EPOS4 / Igus dryve D1 drive on a USB-CAN
+dongle (`device: /dev/ttyACM0`, `type: USB_CAN`).
+
+## Regulatory posture
+
+The bridge ceiling is `ADVISORY` (13-CANOPEN.md §3, §11.13). CANopen
+sits a metre or two from a moving motor, so:
+
+* The **forbidden-OD-index list** is the structural, code-level defence.
+  Adding to it requires editing
+  `CanopenBridgeConfig.FORBIDDEN_WRITE_OD_INDICES` — a code change with a
+  PR and a review, not a config tweak.
+* The **per-node writeIndexAllowList** is the operator-facing gate.
+  Adding an index there requires vendor confirmation that the index is
+  safe to write at runtime; the procedure belongs in the deployment
+  runbook.
+* PDO writes go through the universal §2.2 algorithm; SDO writes are
+  slow enough (millisecond-scale, bus-arbitration limited) to log every
+  one.
+* Cyclic motion-trajectory writes (the kind a CiA-402 servo controller
+  expects 1 kHz) are explicitly out of scope (§8 phase 4) — they
+  require a separately scoped bridge with its own safety case.
+
+A CANopen bridge that writes a CiA-402 trajectory to a real drive
+without an external safety supervisor is misuse.

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/AbstractCanopenClientService.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/AbstractCanopenClientService.java
@@ -1,0 +1,480 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmPriority;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.Quality;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.BatchStateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Shared orchestration for every CANopen platform backend
+ * (13-CANOPEN.md §4 architecture diagram). Owns:
+ *
+ * <ul>
+ *   <li>Binding tables (read / event / write) and the COB-ID-keyed
+ *       routing index.</li>
+ *   <li>Per-node heartbeat watchdog (§5, §10 S9).</li>
+ *   <li>Per-node "online" flag (§5: {@code Quality.UNCERTAIN} when a
+ *       node is offline).</li>
+ *   <li>The runtime backstop on the {@code writeIndexAllowList}
+ *       (§3, §6, §10 R3).</li>
+ *   <li>Audit emission for unknown-binding sends, decoder errors, and
+ *       publish failures.</li>
+ * </ul>
+ *
+ * <p>Subclasses provide raw frame I/O via {@link #sendRawFrame(CanFrame)}
+ * and call {@link #onCanFrame(CanFrame)} from their reader thread (or, for
+ * tests, directly from the test method).
+ */
+public abstract class AbstractCanopenClientService implements CanopenClientService {
+
+    private static final Logger log = LoggerFactory.getLogger(AbstractCanopenClientService.class);
+
+    /** CANopen-specific reasons in addition to 00-FRAMEWORK §4 vocabulary. */
+    public static final class Reason {
+        private Reason() {}
+        public static final String FORBIDDEN_OD_INDEX  = "FORBIDDEN_OD_INDEX";
+        public static final String NOT_ON_ALLOW_LIST   = "NOT_ON_ALLOW_LIST";
+        public static final String NODE_OFFLINE        = "NODE_OFFLINE";
+        public static final String DECODER_ERROR       = "DECODER_ERROR";
+        public static final String PUBLISH_ERROR       = "PUBLISH_ERROR";
+        public static final String SDO_ABORT           = "SDO_ABORT";
+        public static final String UNKNOWN_BINDING     = "UNKNOWN_BINDING";
+    }
+
+    private final CanopenBridgeConfig config;
+    private final AbstractBridgeAuditOutput audit;
+    private final CanopenSignalMapper mapper = new CanopenSignalMapper();
+
+    /** Resolved bindings keyed by bindingId. */
+    private final Map<String, CanopenNodeBinding> readBindings = new LinkedHashMap<>();
+    private final Map<String, CanopenNodeBinding> eventBindings = new LinkedHashMap<>();
+    private final Map<String, CanopenNodeBinding> writeBindings = new LinkedHashMap<>();
+
+    /**
+     * Index: COB-ID → bindings to fire for that COB. Built from
+     * (nodeId, pdoSource): TPDO1=0x180+n, TPDO2=0x280+n, TPDO3=0x380+n,
+     * TPDO4=0x480+n.
+     */
+    private final Map<Integer, List<CanopenNodeBinding>> readRoutes = new HashMap<>();
+
+    /**
+     * Index for synthetic statusword routing — the bindings that map a
+     * {@code BATCH_STATE} CiA-402 statusword PDO. Stored separately so the
+     * decoder can also emit a fault {@code AlarmSignal} from bit 3.
+     */
+    private final Map<Integer, List<CanopenNodeBinding>> stateRoutes = new HashMap<>();
+
+    /** Index: nodeId → EMCY-class event bindings. EMCY COB-ID = 0x080 + nodeId. */
+    private final Map<Integer, List<CanopenNodeBinding>> emcyRoutes = new HashMap<>();
+
+    /** Index: nodeId → HEARTBEAT_LOSS-class event bindings. */
+    private final Map<Integer, List<CanopenNodeBinding>> heartbeatLossRoutes = new HashMap<>();
+
+    /** Pending decoded signals per binding. Drained per tick. */
+    private final Map<String, List<IInputSignal>> queueByBinding = new ConcurrentHashMap<>();
+
+    /** Pending alarm / event signals (advisory channel). */
+    private final List<IInputSignal> events = new ArrayList<>();
+
+    /** Per-binding decimation counters. */
+    private final Map<String, AtomicLong> decimationCounters = new ConcurrentHashMap<>();
+
+    /** Last heartbeat timestamp per nodeId. */
+    private final Map<Integer, Long> heartbeats = new ConcurrentHashMap<>();
+
+    /** Sticky "we already alarmed offline" per nodeId. */
+    private final Map<Integer, Boolean> offlineAlarmed = new ConcurrentHashMap<>();
+
+    /**
+     * Most-recent decoded {@link BatchStateSignal} per state-binding. The
+     * carrier on the queue is a {@link MeasurementSignal} (because
+     * {@code BatchStateSignal} is not an {@code IInputSignal}); downstream
+     * code that wants the typed phase reads it from here via
+     * {@link #lastDriveState(String)}.
+     */
+    private final Map<String, BatchStateSignal> lastDriveState = new ConcurrentHashMap<>();
+
+    private final AtomicBoolean started = new AtomicBoolean();
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    protected AbstractCanopenClientService(CanopenBridgeConfig config,
+                                           AbstractBridgeAuditOutput audit) {
+        this.config = Objects.requireNonNull(config, "config");
+        this.audit = Objects.requireNonNull(audit, "audit");
+
+        for (CanopenBridgeConfig.ReadBindingConfig r : config.reads()) {
+            CanopenNodeBinding b = CanopenNodeBinding.fromRead(r);
+            readBindings.put(r.bindingId(), b);
+            queueByBinding.put(r.bindingId(), new ArrayList<>());
+            decimationCounters.put(r.bindingId(), new AtomicLong());
+            int cob = pdoCobId(b.pdoSource(), b.nodeId());
+            if (cob >= 0) {
+                if (b.targetSignal() == CanopenBridgeConfig.ReadSignalKind.BATCH_STATE) {
+                    stateRoutes.computeIfAbsent(cob, k -> new ArrayList<>()).add(b);
+                } else {
+                    readRoutes.computeIfAbsent(cob, k -> new ArrayList<>()).add(b);
+                }
+            }
+        }
+        for (CanopenBridgeConfig.EventBindingConfig ev : config.events()) {
+            CanopenNodeBinding b = CanopenNodeBinding.fromEvent(ev);
+            eventBindings.put(ev.bindingId(), b);
+            queueByBinding.put(ev.bindingId(), new ArrayList<>());
+            switch (ev.source()) {
+                case EMCY -> emcyRoutes.computeIfAbsent(ev.nodeId(), k -> new ArrayList<>()).add(b);
+                case HEARTBEAT_LOSS -> heartbeatLossRoutes.computeIfAbsent(ev.nodeId(), k -> new ArrayList<>()).add(b);
+            }
+        }
+        for (CanopenBridgeConfig.WriteBindingConfig w : config.writes()) {
+            writeBindings.put(w.bindingId(), CanopenNodeBinding.fromWrite(w));
+        }
+    }
+
+    /* ===== platform-specific raw I/O ====================================== */
+
+    /**
+     * Send a raw CAN frame on the underlying bus. Implementations MUST
+     * NOT throw on protocol-level failures — wrap them and return
+     * {@code false}.
+     *
+     * @return {@code true} on a successful transport-level publish.
+     */
+    protected abstract boolean sendRawFrame(CanFrame frame);
+
+    /**
+     * Open the underlying CAN interface. Default: no-op (test subclasses
+     * skip this). Real implementations open a SocketCAN socket / a USB-CAN
+     * dongle here.
+     */
+    protected void openTransport() { /* no-op */ }
+
+    /**
+     * Close the underlying CAN interface. Default: no-op. Real
+     * implementations release the socket / USB device here.
+     */
+    protected void closeTransport() { /* no-op */ }
+
+    /* ===== lifecycle ===================================================== */
+
+    @Override
+    public synchronized void start() {
+        if (started.get() || closed.get()) return;
+        openTransport();
+        started.set(true);
+        log.info("CanopenClientService started; {} read + {} event + {} write bindings on {} ({} bps)",
+                readBindings.size(), eventBindings.size(), writeBindings.size(),
+                config.canBus().device(), config.canBus().bitrate());
+    }
+
+    @Override
+    public synchronized void close() {
+        if (!closed.compareAndSet(false, true)) return;
+        try { closeTransport(); } catch (RuntimeException e) {
+            log.warn("Canopen transport close threw: {}", e.getMessage());
+        }
+    }
+
+    /** Whether the orchestrator has been opened and not yet closed. */
+    public final boolean isStarted() { return started.get() && !closed.get(); }
+
+    @Override
+    public synchronized void onReconnected() {
+        for (Map.Entry<String, List<IInputSignal>> e : queueByBinding.entrySet()) {
+            synchronized (e.getValue()) { e.getValue().clear(); }
+        }
+        heartbeats.clear();
+        offlineAlarmed.clear();
+        synchronized (events) {
+            events.add(new AlarmSignal(AlarmPriority.LOW, BRIDGE_NAME,
+                    BRIDGE_RECONNECTED, System.currentTimeMillis()));
+        }
+        log.info("CanopenClientService: reconnect — cache cleared, advisory event emitted");
+    }
+
+    /* ===== read-side ===================================================== */
+
+    @Override
+    public List<IInputSignal> drain(String bindingId) {
+        List<IInputSignal> out = queueByBinding.get(bindingId);
+        if (out == null || out.isEmpty()) return List.of();
+        synchronized (out) {
+            List<IInputSignal> snap = new ArrayList<>(out);
+            out.clear();
+            return snap;
+        }
+    }
+
+    @Override
+    public List<IInputSignal> drainEvents() {
+        synchronized (events) {
+            if (events.isEmpty()) return List.of();
+            List<IInputSignal> snap = new ArrayList<>(events);
+            events.clear();
+            return snap;
+        }
+    }
+
+    @Override
+    public void checkHeartbeats(long nowMs) {
+        for (Map.Entry<Integer, Long> e : heartbeats.entrySet()) {
+            int nodeId = e.getKey();
+            long last = e.getValue();
+            if (nowMs - last > HEARTBEAT_TIMEOUT_MS) {
+                Boolean prev = offlineAlarmed.put(nodeId, Boolean.TRUE);
+                if (prev == null || !prev) {
+                    AlarmSignal alarm = mapper.nodeOffline(nodeId, nowMs);
+                    synchronized (events) { events.add(alarm); }
+                    // Also fire any HEARTBEAT_LOSS event-binding queues.
+                    List<CanopenNodeBinding> hl = heartbeatLossRoutes.get(nodeId);
+                    if (hl != null) {
+                        for (CanopenNodeBinding b : hl) {
+                            String tag = (b.signalTagPrefix() == null ? "NODE" : b.signalTagPrefix())
+                                    + "." + nodeId;
+                            AlarmSignal a = new AlarmSignal(
+                                    AlarmPriority.HIGH, tag, "NODE_OFFLINE", nowMs);
+                            List<IInputSignal> q = queueByBinding.get(b.bindingId());
+                            if (q != null) synchronized (q) { q.add(a); }
+                        }
+                    }
+                }
+            } else {
+                offlineAlarmed.put(nodeId, Boolean.FALSE);
+            }
+        }
+    }
+
+    /** {@code true} if the node has gone past the heartbeat timeout (used for §5 quality propagation). */
+    public final boolean isOffline(int nodeId) {
+        return Boolean.TRUE.equals(offlineAlarmed.get(nodeId));
+    }
+
+    @Override
+    public void onCanFrame(CanFrame frame) {
+        if (frame == null) return;
+        long now = frame.arrivalTimeMs() == 0 ? System.currentTimeMillis() : frame.arrivalTimeMs();
+        int cob = frame.cobId();
+        int fc = frame.functionCode();
+        int nodeId = frame.nodeId();
+
+        // Heartbeat: COB = 0x700 + nodeId.
+        if ((cob & 0x780) == 0x700) {
+            heartbeats.put(nodeId, now);
+            offlineAlarmed.put(nodeId, Boolean.FALSE);
+            return;
+        }
+        // EMCY: COB = 0x080 + nodeId (function code 1, but with non-zero node).
+        if (fc == 1 && nodeId != 0) {
+            List<CanopenNodeBinding> list = emcyRoutes.get(nodeId);
+            if (list == null) return;
+            for (CanopenNodeBinding b : list) {
+                try {
+                    AlarmSignal a = mapper.toEmcyAlarm(b, frame.data(), now);
+                    if (a == null) continue;
+                    List<IInputSignal> q = queueByBinding.get(b.bindingId());
+                    if (q != null) synchronized (q) { q.add(a); }
+                    synchronized (events) { events.add(a); }
+                } catch (RuntimeException ex) {
+                    auditDecoderError(b, ex, now);
+                }
+            }
+            return;
+        }
+
+        // PDO state route (statusword) — emits the raw statusword as a MeasurementSignal
+        // (downstream consumers can rebuild the typed BatchStateSignal via
+        //  CanopenSignalMapper.toDriveState if they need it; the queue itself is
+        //  IInputSignal-typed, and BatchStateSignal is an ISignal not an IInputSignal,
+        //  so the carrier here is the numeric statusword) plus an AlarmSignal
+        //  whenever bit 3 of the statusword reports DRIVE_FAULT.
+        List<CanopenNodeBinding> stateList = stateRoutes.get(cob);
+        if (stateList != null) {
+            for (CanopenNodeBinding b : stateList) {
+                try {
+                    int sw = (int) CanopenSignalMapper.readRaw(b.odType(), frame.data(), 0);
+                    Quality q = isOffline(b.nodeId()) ? Quality.UNCERTAIN : Quality.GOOD;
+                    MeasurementSignal carrier = (MeasurementSignal) mapper.toMeasurement(
+                            b, (double) (sw & 0xffff), q, now);
+                    List<IInputSignal> queue = queueByBinding.get(b.bindingId());
+                    if (queue != null) synchronized (queue) { queue.add(carrier); }
+                    BatchStateSignal phase = mapper.toDriveState(b, sw, now);
+                    lastDriveState.put(b.bindingId(), phase);
+                    AlarmSignal fault = mapper.statuswordFault(b, sw, now);
+                    if (fault != null) {
+                        synchronized (events) { events.add(fault); }
+                    }
+                } catch (RuntimeException ex) {
+                    auditDecoderError(b, ex, now);
+                }
+            }
+        }
+
+        // PDO scalar route — fires whatever bindings map this COB-ID.
+        List<CanopenNodeBinding> rdList = readRoutes.get(cob);
+        if (rdList == null) return;
+        for (CanopenNodeBinding b : rdList) {
+            if (b.decimateBy() > 1) {
+                AtomicLong c = decimationCounters.get(b.bindingId());
+                long n = c == null ? 0 : c.incrementAndGet();
+                if (n % b.decimateBy() != 0) continue;
+            }
+            try {
+                deliverPdoScalar(b, frame.data(), now);
+            } catch (RuntimeException ex) {
+                auditDecoderError(b, ex, now);
+            }
+        }
+    }
+
+    private void deliverPdoScalar(CanopenNodeBinding b, byte[] payload, long now) {
+        double value = mapper.decodeScalar(b, payload);
+        Quality q = isOffline(b.nodeId()) ? Quality.UNCERTAIN : Quality.GOOD;
+        IInputSignal sig = switch (b.targetSignal()) {
+            case PROPRIOCEPTIVE -> mapper.toProprioceptive(b, value, now);
+            case EFFICIENCY -> mapper.toEfficiency(b, value);
+            case MEASUREMENT -> mapper.toMeasurement(b, value, q, now);
+            case ALARM -> mapper.toMeasurement(b, value, q, now);
+            case BATCH_STATE -> null; // state route handled it
+        };
+        if (sig instanceof MeasurementSignal ms && q == Quality.UNCERTAIN) {
+            ms.setQuality(Quality.UNCERTAIN);
+        }
+        if (sig == null) return;
+        List<IInputSignal> queue = queueByBinding.get(b.bindingId());
+        if (queue != null) synchronized (queue) { queue.add(sig); }
+    }
+
+    /* ===== write-side ==================================================== */
+
+    @Override
+    public boolean send(String bindingId, double value, long ts, long run) {
+        if (!isStarted()) return false;
+        CanopenNodeBinding b = writeBindings.get(bindingId);
+        if (b == null) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, BRIDGE_NAME, BridgeAuditRecord.Verdict.REJECTED,
+                    bindingId, null, value, null,
+                    Reason.UNKNOWN_BINDING, null, List.of()));
+            return false;
+        }
+        // §3 / §6 / §10 R3 — runtime backstop. Even if the index slipped past
+        // the loader (e.g. a hot-reload that bypasses the validator) the
+        // platform service must refuse the write.
+        if (CanopenBridgeConfig.FORBIDDEN_WRITE_OD_INDICES.contains(b.odIndex())) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, BRIDGE_NAME, BridgeAuditRecord.Verdict.REJECTED,
+                    b.loopId(), b.signalTag(), value, null,
+                    Reason.FORBIDDEN_OD_INDEX + ":0x" + Integer.toHexString(b.odIndex()),
+                    null, List.of()));
+            return false;
+        }
+        List<Integer> allowed = config.writeIndexAllowList().get(b.nodeId());
+        if (allowed == null || !allowed.contains(b.odIndex())) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, BRIDGE_NAME, BridgeAuditRecord.Verdict.REJECTED,
+                    b.loopId(), b.signalTag(), value, null,
+                    Reason.NOT_ON_ALLOW_LIST + ":(node=0x" + Integer.toHexString(b.nodeId())
+                            + ",idx=0x" + Integer.toHexString(b.odIndex()) + ")",
+                    null, List.of()));
+            return false;
+        }
+        try {
+            byte[] payload = mapper.encodeScalar(b.odType(), value);
+            int cob = switch (b.writeVia()) {
+                case SDO -> 0x600 + b.nodeId();
+                case RPDO -> 0x200 + b.nodeId(); // RPDO1 by default
+            };
+            byte[] frame = b.writeVia() == CanopenBridgeConfig.WriteVia.SDO
+                    ? sdoDownloadExpedited(b, payload)
+                    : payload;
+            return sendRawFrame(new CanFrame(cob, frame, false, ts));
+        } catch (RuntimeException ex) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, BRIDGE_NAME, BridgeAuditRecord.Verdict.FAILED,
+                    b.loopId(), b.signalTag(), value, null,
+                    Reason.PUBLISH_ERROR + ":" + ex.getClass().getSimpleName(),
+                    null, List.of()));
+            return false;
+        }
+    }
+
+    /**
+     * Build an SDO expedited download frame (CiA-301 §7.2.4.3.3) for up to
+     * 4 data bytes. Layout: command-specifier byte + 2 index bytes (LE) +
+     * subindex byte + up to 4 data bytes.
+     */
+    static byte[] sdoDownloadExpedited(CanopenNodeBinding b, byte[] payload) {
+        int n = payload.length;
+        if (n == 0 || n > 4) {
+            throw new IllegalArgumentException(
+                    "SDO expedited download requires 1..4 data bytes, got " + n);
+        }
+        // 0x22 = expedited + size-not-indicated; for size-indicated use 0x23 + ((4-n) << 2).
+        int cs = 0x23 | ((4 - n) << 2);
+        byte[] frame = new byte[8];
+        frame[0] = (byte) cs;
+        frame[1] = (byte) (b.odIndex() & 0xff);
+        frame[2] = (byte) ((b.odIndex() >>> 8) & 0xff);
+        frame[3] = (byte) (b.subIndex() & 0xff);
+        System.arraycopy(payload, 0, frame, 4, n);
+        return frame;
+    }
+
+    /* ===== accessors ===================================================== */
+
+    @Override public CanopenBridgeConfig config() { return config; }
+    @Override public CanopenNodeBinding readBinding(String id) { return readBindings.get(id); }
+    @Override public CanopenNodeBinding writeBinding(String id) { return writeBindings.get(id); }
+    @Override public CanopenNodeBinding writeBindingForTag(String tag) {
+        for (CanopenNodeBinding b : writeBindings.values()) {
+            if (Objects.equals(tag, b.signalTag())) return b;
+        }
+        return null;
+    }
+    @Override public List<String> readBindingIds() { return List.copyOf(readBindings.keySet()); }
+
+    public final List<String> eventBindingIds() { return List.copyOf(eventBindings.keySet()); }
+    public final CanopenNodeBinding eventBinding(String id) { return eventBindings.get(id); }
+    public final BatchStateSignal lastDriveState(String bindingId) { return lastDriveState.get(bindingId); }
+    protected final AbstractBridgeAuditOutput audit() { return audit; }
+
+    /* ===== helpers ======================================================= */
+
+    /** COB-ID for a TPDO source (CiA-301 default ranges). Returns -1 for SDO source. */
+    static int pdoCobId(CanopenBridgeConfig.PdoSource source, int nodeId) {
+        if (source == null) return -1;
+        return switch (source) {
+            case TPDO1 -> 0x180 + nodeId;
+            case TPDO2 -> 0x280 + nodeId;
+            case TPDO3 -> 0x380 + nodeId;
+            case TPDO4 -> 0x480 + nodeId;
+            case SDO -> -1;
+        };
+    }
+
+    private void auditDecoderError(CanopenNodeBinding b, RuntimeException ex, long now) {
+        audit.append(new BridgeAuditRecord(
+                now, 0, BRIDGE_NAME, BridgeAuditRecord.Verdict.FAILED,
+                b.loopId(), b.signalTag(), null, null,
+                Reason.DECODER_ERROR + ":" + ex.getClass().getSimpleName(),
+                null, List.of()));
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanFrame.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanFrame.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * One raw CAN frame as observed on the bus (13-CANOPEN.md §4). The
+ * COB-ID is the 11-bit (or 29-bit extended) identifier; the payload is at
+ * most 8 bytes for classic CAN. The bridge derives the CANopen meaning of
+ * the frame (PDO / SDO / EMCY / heartbeat / NMT / SYNC) from the COB-ID
+ * range, not from the payload.
+ *
+ * <p>A {@code CanFrame} is what the platform-specific
+ * {@link CanopenClientService} emits inbound; the orchestrator decodes it.
+ */
+public record CanFrame(int cobId, byte[] data, boolean extended, long arrivalTimeMs) {
+
+    public CanFrame {
+        Objects.requireNonNull(data, "data");
+        if (data.length > 8) {
+            throw new IllegalArgumentException(
+                    "Classic CAN payload must be <= 8 bytes, got " + data.length);
+        }
+        data = data.clone();
+    }
+
+    public CanFrame(int cobId, byte[] data) {
+        this(cobId, data, false, System.currentTimeMillis());
+    }
+
+    @Override public byte[] data() { return data.clone(); }
+
+    /** Decoded CANopen function code (top 4 bits of an 11-bit COB-ID). */
+    public int functionCode() { return (cobId >>> 7) & 0x0F; }
+
+    /** Decoded source/target node id (low 7 bits of an 11-bit COB-ID). */
+    public int nodeId() { return cobId & 0x7F; }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("CanFrame{cobId=0x");
+        sb.append(Integer.toHexString(cobId)).append(", data=").append(Arrays.toString(data));
+        sb.append(", ext=").append(extended).append('}');
+        return sb.toString();
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenAdvisoryOutputAggregator.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenAdvisoryOutputAggregator.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import com.rakovpublic.jneuropallium.worker.application.IOutputAggregator;
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import com.rakovpublic.jneuropallium.worker.net.layers.IResult;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.InterlockSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.OperatorOverrideSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+import com.rakovpublic.jneuropallium.worker.util.IContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * {@link IOutputAggregator} for the CANopen advisory egress
+ * (13-CANOPEN.md §3, §5 egress table).
+ *
+ * <p>Per 13-CANOPEN.md §3 the bridge ceiling is structurally
+ * <b>ADVISORY</b> — it never autonomously promotes a write to
+ * {@code AUTONOMOUS}. The structural defences are layered:
+ *
+ * <ol>
+ *   <li>{@link CanopenBridgeConfig} rejects forbidden indices and any
+ *       write whose {@code (nodeId, odIndex)} is not on the
+ *       {@code writeIndexAllowList} at config load (§6, §10 R3).</li>
+ *   <li>{@link AbstractCanopenClientService#send} re-checks both gates at
+ *       runtime — a config that bypasses the loader (e.g. constructed
+ *       in-process) still cannot punch a write through.</li>
+ *   <li>This aggregator enforces the universal §2.2 algorithm: SHADOW
+ *       drops, override holds, clamp, ramp, diff-suppress, audit.</li>
+ * </ol>
+ *
+ * <p>Signal handling:
+ *
+ * <ul>
+ *   <li>{@link InterlockSignal} → fail-safe value written to every binding
+ *       whose loop matches; no veto (00-FRAMEWORK §0.2).</li>
+ *   <li>{@link OperatorOverrideSignal} → registered for the matching tag
+ *       (§0.3).</li>
+ *   <li>{@link SetpointSignal} / {@link ActuatorCommandSignal} → resolved
+ *       to a write binding, clamped, rate-limited, diff-suppressed,
+ *       written, audited.</li>
+ * </ul>
+ */
+public final class CanopenAdvisoryOutputAggregator implements IOutputAggregator {
+
+    private static final Logger log = LoggerFactory.getLogger(CanopenAdvisoryOutputAggregator.class);
+
+    /** §2.2.4f diff-suppression window. */
+    public static final long DIFF_WINDOW_MS = 5_000L;
+
+    /** §2.2.4f diff-suppression epsilon. */
+    public static final double DIFF_EPSILON = 1e-9;
+
+    private final CanopenClientService svc;
+    private final AbstractBridgeAuditOutput audit;
+    private final CanopenBridgeConfig config;
+
+    /** Per-tag last-applied-value cache used by rate-limit and diff-suppress. */
+    private final Map<String, double[]> lastApplied = new HashMap<>();
+    private long lastTickTimestampMs = -1L;
+
+    public CanopenAdvisoryOutputAggregator(CanopenClientService svc,
+                                           AbstractBridgeAuditOutput audit) {
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.audit = Objects.requireNonNull(audit, "audit");
+        this.config = svc.config();
+    }
+
+    @Override
+    public synchronized void save(List<IResult> results, long timestamp, long run, IContext context) {
+        if (results == null || results.isEmpty()) {
+            this.lastTickTimestampMs = timestamp;
+            return;
+        }
+        // §0.2 first — interlocks have direct authority and bypass every veto.
+        for (IResult r : results) {
+            if (r == null) continue;
+            IResultSignal<?> s = r.getResult();
+            if (s instanceof InterlockSignal il && il.isTripped()) {
+                applyInterlock(il, r.getNeuronId(), timestamp, run);
+            }
+        }
+        // §0.3 next — register operator overrides so subsequent commands see them.
+        // (For simplicity the registry is tag-keyed and tick-scoped; the bridge does not
+        //  carry an OverrideRegistry instance because CANopen overrides are typically
+        //  hardware-asserted estop / mode-select switches, not persistent neuron signals.)
+        // §0.1, §0.4 — partition + handle the commands.
+        for (IResult r : results) {
+            if (r == null) continue;
+            IResultSignal<?> s = r.getResult();
+            Long neuronId = r.getNeuronId();
+            try {
+                if (s instanceof SetpointSignal sp) {
+                    handleNumeric(sp.getTag(), sp.getSetpoint(), true, timestamp, run, neuronId);
+                } else if (s instanceof ActuatorCommandSignal ac) {
+                    handleNumeric(ac.getTag(), ac.getTargetValue(), ac.isExecute(), timestamp, run, neuronId);
+                }
+            } catch (RuntimeException ex) {
+                audit.append(new BridgeAuditRecord(
+                        timestamp, run, CanopenClientService.BRIDGE_NAME,
+                        BridgeAuditRecord.Verdict.FAILED,
+                        null, tagOf(s), null, null,
+                        BridgeAuditRecord.RejectReason.EXCEPTION + ":" + ex.getClass().getSimpleName(),
+                        null, evidence(neuronId)));
+            }
+        }
+        this.lastTickTimestampMs = timestamp;
+    }
+
+    private void applyInterlock(InterlockSignal il, Long neuronId, long ts, long run) {
+        String loop = il.getInterlockId();
+        if (loop == null) return;
+        // CANopen bindings carry loopId == bindingId (the binding *is* the loop).
+        for (String bid : config.writes().stream().map(CanopenBridgeConfig.WriteBindingConfig::bindingId).toList()) {
+            CanopenNodeBinding b = svc.writeBinding(bid);
+            if (b == null) continue;
+            if (!Objects.equals(loop, b.loopId())) continue;
+            Double fs = b.failSafeValue();
+            if (fs == null) {
+                audit.append(new BridgeAuditRecord(
+                        ts, run, CanopenClientService.BRIDGE_NAME,
+                        BridgeAuditRecord.Verdict.REJECTED,
+                        b.loopId(), b.signalTag(), null, null,
+                        "INTERLOCK_NO_FAILSAFE", BridgeSafetyMode.ADVISORY,
+                        evidence(neuronId)));
+                continue;
+            }
+            boolean ok = svc.send(bid, fs, ts, run);
+            BridgeAuditRecord.Verdict verdict = ok
+                    ? BridgeAuditRecord.Verdict.INTERLOCK_TRIP
+                    : BridgeAuditRecord.Verdict.FAILED;
+            audit.append(new BridgeAuditRecord(
+                    ts, run, CanopenClientService.BRIDGE_NAME, verdict,
+                    b.loopId(), b.signalTag(), null, fs,
+                    null, BridgeSafetyMode.ADVISORY, evidence(neuronId)));
+            if (ok) lastApplied.put(b.signalTag(), new double[]{fs, ts});
+        }
+    }
+
+    private void handleNumeric(String tag, double proposed, boolean execute,
+                               long ts, long run, Long neuronId) {
+        if (tag == null) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, CanopenClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    null, null, proposed, null,
+                    BridgeAuditRecord.RejectReason.UNKNOWN_TAG, null, evidence(neuronId)));
+            return;
+        }
+        CanopenNodeBinding b = svc.writeBindingForTag(tag);
+        if (b == null) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, CanopenClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    null, tag, proposed, null,
+                    BridgeAuditRecord.RejectReason.UNKNOWN_TAG, null, evidence(neuronId)));
+            return;
+        }
+
+        BridgeSafetyMode mode = config.perTagSafetyMode().getOrDefault(b.bindingId(), BridgeSafetyMode.ADVISORY);
+        if (mode == BridgeSafetyMode.SHADOW) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, CanopenClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    b.loopId(), tag, proposed, null,
+                    BridgeAuditRecord.RejectReason.SHADOW_MODE, mode, evidence(neuronId)));
+            return;
+        }
+        if (mode == BridgeSafetyMode.ADVISORY && !execute) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, CanopenClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.REJECTED,
+                    b.loopId(), tag, proposed, null,
+                    BridgeAuditRecord.RejectReason.ADVISORY_HOLD, mode, evidence(neuronId)));
+            return;
+        }
+
+        // §2.2.4d clamp.
+        String modifyReason = null;
+        double effective = proposed;
+        if (b.maxClampValue() != null && effective > b.maxClampValue()) {
+            effective = b.maxClampValue();
+            modifyReason = BridgeAuditRecord.ModifyReason.CLAMPED_HIGH;
+        } else if (b.minClampValue() != null && effective < b.minClampValue()) {
+            effective = b.minClampValue();
+            modifyReason = BridgeAuditRecord.ModifyReason.CLAMPED_LOW;
+        }
+
+        // §2.2.4e rate limit.
+        double[] last = lastApplied.get(tag);
+        double dtSec = (lastTickTimestampMs > 0 && ts > lastTickTimestampMs)
+                ? (ts - lastTickTimestampMs) / 1000.0 : 0.0;
+        if (b.rampRateMaxPerSec() != null && last != null && dtSec > 0) {
+            double maxStep = b.rampRateMaxPerSec() * dtSec;
+            double delta = effective - last[0];
+            if (Math.abs(delta) > maxStep) {
+                effective = last[0] + Math.signum(delta) * maxStep;
+                modifyReason = BridgeAuditRecord.ModifyReason.RATE_LIMITED;
+            }
+        }
+
+        // §2.2.4f diff suppression.
+        if (last != null && (ts - (long) last[1]) <= DIFF_WINDOW_MS
+                && Math.abs(effective - last[0]) <= DIFF_EPSILON) {
+            audit.append(new BridgeAuditRecord(
+                    ts, run, CanopenClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.APPLIED,
+                    b.loopId(), tag, proposed, effective,
+                    BridgeAuditRecord.ModifyReason.DIFF_SUPPRESSED, mode, evidence(neuronId)));
+            return;
+        }
+
+        boolean ok = svc.send(b.bindingId(), effective, ts, run);
+        if (ok) {
+            lastApplied.put(tag, new double[]{effective, ts});
+            audit.append(new BridgeAuditRecord(
+                    ts, run, CanopenClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.APPLIED,
+                    b.loopId(), tag, proposed, effective,
+                    modifyReason, mode, evidence(neuronId)));
+        }
+        // Failure paths are audited inside AbstractCanopenClientService.send.
+    }
+
+    private static String tagOf(IResultSignal<?> s) {
+        if (s instanceof SetpointSignal sp) return sp.getTag();
+        if (s instanceof ActuatorCommandSignal ac) return ac.getTag();
+        return null;
+    }
+
+    private static List<String> evidence(Long neuronId) {
+        return neuronId == null ? List.of() : List.of(String.valueOf(neuronId));
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenAuditOutput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenAuditOutput.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+
+import java.nio.file.Path;
+
+/**
+ * JSONL audit sink for the CANopen bridge (00-FRAMEWORK §4, §6;
+ * 13-CANOPEN.md §6 {@code audit.localAuditFile}).
+ *
+ * <p>Per §3 the bridge audits every SDO write — they are slow enough
+ * (millisecond-scale, bus-arbitration limited) that a per-write JSONL
+ * record is not a throughput problem. PDO writes go through the universal
+ * §2.2 algorithm in {@link CanopenAdvisoryOutputAggregator}; that algorithm
+ * already audits accepted, suppressed, clamped, rate-limited, and rejected
+ * verdicts — so the only extra audit responsibility this sink has is the
+ * runtime backstop for the index allow-list, which
+ * {@link AbstractCanopenClientService} writes directly when it refuses a
+ * disallowed write.
+ */
+public final class CanopenAuditOutput extends AbstractBridgeAuditOutput {
+    public CanopenAuditOutput(Path file) { super(file); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenBridgeConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenBridgeConfig.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Top-level CANopen bridge configuration (13-CANOPEN.md §6).
+ *
+ * <p>Loaded from YAML via {@link CanopenBridgeConfigLoader}. Immutable; the
+ * loader uses {@code FAIL_ON_UNKNOWN_PROPERTIES = true} per 00-FRAMEWORK §3
+ * — typos in a config that addresses motors, brakes, and BMS packs are not
+ * caught at runtime, they're caught at load.
+ *
+ * <p>The bridge's structural ceiling is {@code ADVISORY} (13-CANOPEN.md §3,
+ * §11.13). The {@code controlword} index ({@code 0x6040}) is on the
+ * {@link #FORBIDDEN_WRITE_OD_INDICES} list and is rejected at config load
+ * unless explicitly listed in {@link #writeIndexAllowList} per node id.
+ * Even if a write binding is present and clamped, the per-(nodeId, odIndex)
+ * pair must appear in {@link #writeIndexAllowList} for it to be loaded —
+ * this is the "structural defence" of §10 R3.
+ */
+public record CanopenBridgeConfig(
+        CanBusConfig canBus,
+        List<NodeConfig> nodes,
+        List<ReadBindingConfig> reads,
+        List<EventBindingConfig> events,
+        List<WriteBindingConfig> writes,
+        Map<Integer, List<Integer>> writeIndexAllowList,
+        AuditConfig audit,
+        Map<String, BridgeSafetyMode> perTagSafetyMode,
+        Duration tickInterval
+) {
+
+    /**
+     * Hard-coded safety-critical OD indices that the bridge MUST NOT write
+     * unless they're individually re-allowed in
+     * {@link #writeIndexAllowList} per node (13-CANOPEN.md §3, §5 egress
+     * table). The {@code controlword} (0x6040) tops the list — autonomous
+     * cyclic writes to it would arm the drive without external supervision.
+     */
+    public static final Set<Integer> FORBIDDEN_WRITE_OD_INDICES = Set.of(
+            0x6040  // CiA-402 controlword
+    );
+
+    public CanopenBridgeConfig {
+        Objects.requireNonNull(canBus, "canBus");
+        nodes = nodes == null ? List.of() : List.copyOf(nodes);
+        reads = reads == null ? List.of() : List.copyOf(reads);
+        events = events == null ? List.of() : List.copyOf(events);
+        writes = writes == null ? List.of() : List.copyOf(writes);
+        tickInterval = tickInterval == null ? Duration.ofMillis(250) : tickInterval;
+
+        if (writeIndexAllowList == null) {
+            writeIndexAllowList = Map.of();
+        } else {
+            Map<Integer, List<Integer>> normalised = new LinkedHashMap<>();
+            for (Map.Entry<Integer, List<Integer>> e : writeIndexAllowList.entrySet()) {
+                normalised.put(e.getKey(),
+                        e.getValue() == null ? List.of() : List.copyOf(e.getValue()));
+            }
+            writeIndexAllowList = Map.copyOf(normalised);
+        }
+
+        // Node ids must be unique.
+        Set<Integer> nodeIds = new LinkedHashSet<>();
+        for (NodeConfig n : nodes) {
+            if (!nodeIds.add(n.id())) {
+                throw new IllegalArgumentException(
+                        "CANopen bridge: duplicate node id 0x" + Integer.toHexString(n.id()));
+            }
+        }
+
+        // Binding ids must be globally unique across reads / events / writes.
+        Set<String> seen = new LinkedHashSet<>();
+        for (ReadBindingConfig r : reads) {
+            if (!seen.add(r.bindingId())) {
+                throw new IllegalArgumentException("Duplicate bindingId: " + r.bindingId());
+            }
+            if (!nodeIds.isEmpty() && !nodeIds.contains(r.nodeId())) {
+                throw new IllegalArgumentException(
+                        "Read binding '" + r.bindingId() + "' references unknown nodeId 0x"
+                                + Integer.toHexString(r.nodeId()));
+            }
+        }
+        for (EventBindingConfig ev : events) {
+            if (!seen.add(ev.bindingId())) {
+                throw new IllegalArgumentException("Duplicate bindingId: " + ev.bindingId());
+            }
+            if (!nodeIds.isEmpty() && !nodeIds.contains(ev.nodeId())) {
+                throw new IllegalArgumentException(
+                        "Event binding '" + ev.bindingId() + "' references unknown nodeId 0x"
+                                + Integer.toHexString(ev.nodeId()));
+            }
+        }
+        for (WriteBindingConfig w : writes) {
+            if (!seen.add(w.bindingId())) {
+                throw new IllegalArgumentException("Duplicate bindingId: " + w.bindingId());
+            }
+            if (!nodeIds.isEmpty() && !nodeIds.contains(w.nodeId())) {
+                throw new IllegalArgumentException(
+                        "Write binding '" + w.bindingId() + "' references unknown nodeId 0x"
+                                + Integer.toHexString(w.nodeId()));
+            }
+            // §3, §6, §10 R3 — every write must clear two structural gates:
+            // 1. The hard-coded forbidden-index list rejects controlword unconditionally.
+            // 2. The per-node allow list must include the index.
+            if (FORBIDDEN_WRITE_OD_INDICES.contains(w.odIndex())) {
+                throw new IllegalArgumentException(
+                        "CANopen bridge: write binding '" + w.bindingId()
+                                + "' targets forbidden OD index 0x"
+                                + Integer.toHexString(w.odIndex())
+                                + " (13-CANOPEN.md §3, §5 egress table)");
+            }
+            List<Integer> allowed = writeIndexAllowList.get(w.nodeId());
+            if (allowed == null || !allowed.contains(w.odIndex())) {
+                throw new IllegalArgumentException(
+                        "CANopen bridge: write binding '" + w.bindingId()
+                                + "' targets (nodeId=0x" + Integer.toHexString(w.nodeId())
+                                + ", odIndex=0x" + Integer.toHexString(w.odIndex())
+                                + ") which is not on writeIndexAllowList (13-CANOPEN.md §6)");
+            }
+        }
+
+        perTagSafetyMode = perTagSafetyMode == null
+                ? Map.of()
+                : Map.copyOf(perTagSafetyMode);
+    }
+
+    @JsonCreator
+    public static CanopenBridgeConfig create(
+            @JsonProperty("canBus") CanBusConfig canBus,
+            @JsonProperty("nodes") List<NodeConfig> nodes,
+            @JsonProperty("reads") List<ReadBindingConfig> reads,
+            @JsonProperty("events") List<EventBindingConfig> events,
+            @JsonProperty("writes") List<WriteBindingConfig> writes,
+            @JsonProperty("writeIndexAllowList") Map<Integer, List<Integer>> writeIndexAllowList,
+            @JsonProperty("audit") AuditConfig audit,
+            @JsonProperty("perTagSafetyMode") Map<String, BridgeSafetyMode> perTagSafetyMode,
+            @JsonProperty("tickInterval") Duration tickInterval) {
+        return new CanopenBridgeConfig(
+                canBus, nodes, reads, events, writes,
+                writeIndexAllowList, audit, perTagSafetyMode, tickInterval);
+    }
+
+    /** Transports supported in §6 — the JNA-SocketCAN escape hatch and the cross-platform USB-CAN dongle path. */
+    public enum BusType { SOCKETCAN, USB_CAN }
+
+    /** What signal class a {@link ReadBindingConfig} produces (§5). */
+    public enum ReadSignalKind {
+        /** Joint state / encoder position / velocity from a CiA-402 drive. */
+        PROPRIOCEPTIVE,
+        /** Generic measurement — CiA-401 I/O, sensor PDO. */
+        MEASUREMENT,
+        /** Battery / pack metric — CiA-418 BMS. */
+        EFFICIENCY,
+        /** Drive state-machine snapshot — statusword decoded into BatchStateSignal. */
+        BATCH_STATE,
+        /** Bridge-level liveness or fault alarm. */
+        ALARM
+    }
+
+    /** Source COB-ID class an OD index is mapped through (§5). */
+    public enum PdoSource {
+        TPDO1, TPDO2, TPDO3, TPDO4,
+        /** SDO read (acyclic). Not used for cyclic mapping. */
+        SDO
+    }
+
+    /** OD value type used by the decoder/encoder (CiA-301 §7.4). */
+    public enum OdType {
+        UINT8, UINT16, UINT32,
+        INT8, INT16, INT32,
+        REAL32
+    }
+
+    /** §6 {@code canBus:} block. */
+    public record CanBusConfig(
+            BusType type,
+            String device,
+            int bitrate,
+            Double samplePoint
+    ) {
+        public CanBusConfig {
+            Objects.requireNonNull(type, "type");
+            Objects.requireNonNull(device, "device");
+            if (bitrate <= 0) {
+                throw new IllegalArgumentException("bitrate must be positive");
+            }
+        }
+
+        @JsonCreator
+        public static CanBusConfig of(
+                @JsonProperty("type") BusType type,
+                @JsonProperty("device") String device,
+                @JsonProperty("bitrate") Integer bitrate,
+                @JsonProperty("samplePoint") Double samplePoint) {
+            return new CanBusConfig(type, device,
+                    bitrate == null ? 500_000 : bitrate, samplePoint);
+        }
+    }
+
+    /** §6 {@code nodes:} entry. */
+    public record NodeConfig(
+            int id,
+            String type,
+            String profileEdsFile
+    ) {
+        public NodeConfig {
+            if (id < 1 || id > 127) {
+                throw new IllegalArgumentException(
+                        "CANopen node id must be in 1..127, got 0x" + Integer.toHexString(id));
+            }
+        }
+
+        @JsonCreator
+        public static NodeConfig of(
+                @JsonProperty("id") Integer id,
+                @JsonProperty("type") String type,
+                @JsonProperty("profileEdsFile") String profileEdsFile) {
+            Objects.requireNonNull(id, "node id");
+            return new NodeConfig(id, type, profileEdsFile);
+        }
+    }
+
+    /** §6 {@code reads:} entry — one PDO/SDO read binding. */
+    public record ReadBindingConfig(
+            String bindingId,
+            int nodeId,
+            int odIndex,
+            int subIndex,
+            PdoSource pdoSource,
+            OdType odType,
+            ReadSignalKind targetSignal,
+            String signalTag,
+            double scale,
+            double offset,
+            int decimateBy
+    ) {
+        public ReadBindingConfig {
+            Objects.requireNonNull(bindingId, "bindingId");
+            if (nodeId < 1 || nodeId > 127) {
+                throw new IllegalArgumentException(
+                        "Read binding '" + bindingId + "' nodeId must be 1..127");
+            }
+            if (pdoSource == null) pdoSource = PdoSource.TPDO1;
+            if (odType == null) odType = OdType.UINT16;
+            if (targetSignal == null) targetSignal = ReadSignalKind.MEASUREMENT;
+            if (decimateBy <= 0) decimateBy = 1;
+        }
+
+        @JsonCreator
+        public static ReadBindingConfig of(
+                @JsonProperty("bindingId") String bindingId,
+                @JsonProperty("nodeId") Integer nodeId,
+                @JsonProperty("odIndex") Integer odIndex,
+                @JsonProperty("subIndex") Integer subIndex,
+                @JsonProperty("pdoSource") PdoSource pdoSource,
+                @JsonProperty("odType") OdType odType,
+                @JsonProperty("targetSignal") ReadSignalKind targetSignal,
+                @JsonProperty("signalTag") String signalTag,
+                @JsonProperty("scale") Double scale,
+                @JsonProperty("offset") Double offset,
+                @JsonProperty("decimateBy") Integer decimateBy) {
+            return new ReadBindingConfig(
+                    bindingId,
+                    nodeId == null ? 1 : nodeId,
+                    odIndex == null ? 0 : odIndex,
+                    subIndex == null ? 0 : subIndex,
+                    pdoSource, odType, targetSignal, signalTag,
+                    scale == null ? 1.0 : scale,
+                    offset == null ? 0.0 : offset,
+                    decimateBy == null ? 1 : decimateBy);
+        }
+    }
+
+    /** §6 {@code events:} entry — EMCY / heartbeat-loss subscription. */
+    public record EventBindingConfig(
+            String bindingId,
+            int nodeId,
+            EventSource source,
+            ReadSignalKind targetSignal,
+            String signalTagPrefix
+    ) {
+        public EventBindingConfig {
+            Objects.requireNonNull(bindingId, "bindingId");
+            if (source == null) source = EventSource.EMCY;
+            if (targetSignal == null) targetSignal = ReadSignalKind.ALARM;
+        }
+
+        @JsonCreator
+        public static EventBindingConfig of(
+                @JsonProperty("bindingId") String bindingId,
+                @JsonProperty("nodeId") Integer nodeId,
+                @JsonProperty("source") EventSource source,
+                @JsonProperty("targetSignal") ReadSignalKind targetSignal,
+                @JsonProperty("signalTagPrefix") String signalTagPrefix) {
+            Objects.requireNonNull(nodeId, "nodeId");
+            return new EventBindingConfig(bindingId, nodeId, source, targetSignal, signalTagPrefix);
+        }
+    }
+
+    /** Event-class taxonomy. */
+    public enum EventSource {
+        /** CiA-301 emergency frame (COB-ID = 0x080 + node). */
+        EMCY,
+        /** Heartbeat-timeout watchdog (synthesised by the bridge). */
+        HEARTBEAT_LOSS
+    }
+
+    /** §6 {@code writes:} entry — one advisory egress binding. */
+    public record WriteBindingConfig(
+            String bindingId,
+            int nodeId,
+            int odIndex,
+            int subIndex,
+            OdType odType,
+            WriteVia via,
+            String signalTag,
+            Double minClampValue,
+            Double maxClampValue,
+            Double rampRateMaxPerSec,
+            Double failSafeValue
+    ) {
+        public WriteBindingConfig {
+            Objects.requireNonNull(bindingId, "bindingId");
+            Objects.requireNonNull(signalTag, "signalTag");
+            if (nodeId < 1 || nodeId > 127) {
+                throw new IllegalArgumentException(
+                        "Write binding '" + bindingId + "' nodeId must be 1..127");
+            }
+            if (odType == null) odType = OdType.UINT32;
+            if (via == null) via = WriteVia.SDO;
+        }
+
+        @JsonCreator
+        public static WriteBindingConfig of(
+                @JsonProperty("bindingId") String bindingId,
+                @JsonProperty("nodeId") Integer nodeId,
+                @JsonProperty("odIndex") Integer odIndex,
+                @JsonProperty("subIndex") Integer subIndex,
+                @JsonProperty("odType") OdType odType,
+                @JsonProperty("via") WriteVia via,
+                @JsonProperty("signalTag") String signalTag,
+                @JsonProperty("minClampValue") Double minClampValue,
+                @JsonProperty("maxClampValue") Double maxClampValue,
+                @JsonProperty("rampRateMaxPerSec") Double rampRateMaxPerSec,
+                @JsonProperty("failSafeValue") Double failSafeValue) {
+            Objects.requireNonNull(nodeId, "nodeId");
+            Objects.requireNonNull(odIndex, "odIndex");
+            return new WriteBindingConfig(
+                    bindingId, nodeId, odIndex,
+                    subIndex == null ? 0 : subIndex,
+                    odType, via, signalTag,
+                    minClampValue, maxClampValue,
+                    rampRateMaxPerSec, failSafeValue);
+        }
+    }
+
+    /** Egress channel — SDO is acyclic and audited per write; RPDO is cyclic and per-tick. */
+    public enum WriteVia { SDO, RPDO }
+
+    /** Audit channel (00-FRAMEWORK §3, §4; 13-CANOPEN.md §6). */
+    public record AuditConfig(String localAuditFile) {
+        public AuditConfig {
+            Objects.requireNonNull(localAuditFile, "localAuditFile");
+        }
+
+        @JsonCreator
+        public static AuditConfig of(@JsonProperty("localAuditFile") String localAuditFile) {
+            return new AuditConfig(localAuditFile);
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenBridgeConfigLoader.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenBridgeConfigLoader.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+/**
+ * Loads {@link CanopenBridgeConfig} from YAML (13-CANOPEN.md §6).
+ *
+ * <p>{@code FAIL_ON_UNKNOWN_PROPERTIES = true} per 00-FRAMEWORK §3 — typos
+ * in a config that addresses motors, brakes, and BMS packs must be caught
+ * at load.
+ */
+public final class CanopenBridgeConfigLoader {
+
+    private CanopenBridgeConfigLoader() {}
+
+    public static CanopenBridgeConfig load(Path yaml) throws IOException {
+        return mapper().readValue(yaml.toFile(), CanopenBridgeConfig.class);
+    }
+
+    public static CanopenBridgeConfig load(InputStream in) throws IOException {
+        return mapper().readValue(in, CanopenBridgeConfig.class);
+    }
+
+    public static CanopenBridgeConfig load(String yamlContent) throws IOException {
+        return mapper().readValue(yamlContent, CanopenBridgeConfig.class);
+    }
+
+    private static ObjectMapper mapper() {
+        return new ObjectMapper(new YAMLFactory())
+                .registerModule(new JavaTimeModule())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenClientService.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenClientService.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+
+import java.util.List;
+
+/**
+ * Orchestrator surface used by {@link CanopenMeasurementInput},
+ * {@link CanopenStateInput}, {@link CanopenEventInput} and
+ * {@link CanopenAdvisoryOutputAggregator}. Per 13-CANOPEN.md §6 the
+ * "platform module is selected at startup" — the same surface is exposed
+ * by:
+ *
+ * <ul>
+ *   <li>{@link SocketCanClientService}  — Linux JNA / SocketCAN backend
+ *       (lowest latency).</li>
+ *   <li>{@link UsbCanClientService}     — cross-platform Lawicel-style
+ *       USB-CAN dongle backend (CANable / Korlan / PCAN).</li>
+ *   <li>{@link AbstractCanopenClientService} — concrete shared
+ *       orchestration that the two platform classes extend; tests use it
+ *       directly via a trivial in-memory subclass.</li>
+ * </ul>
+ *
+ * <p>The interface is intentionally narrow — bindings, decoded signals,
+ * heartbeat watchdog, and audit are owned by the implementation; consumers
+ * just pump the queue (read-side) or push a tag/value (write-side).
+ */
+public interface CanopenClientService extends AutoCloseable {
+
+    /** Bridge name carried in every audit record (00-FRAMEWORK §4). */
+    String BRIDGE_NAME = "canopen";
+
+    /** Reconnect / cache-cleared advisory event (00-FRAMEWORK §2.3). */
+    String BRIDGE_RECONNECTED = "BRIDGE_RECONNECTED";
+
+    /** §5 heartbeat-loss threshold. */
+    long HEARTBEAT_TIMEOUT_MS = 2_000L;
+
+    /** Open the underlying CAN interface (or no-op for a stub). Idempotent. */
+    void start();
+
+    /** Drain (and clear) all decoded signals for one read or write binding. */
+    List<IInputSignal> drain(String bindingId);
+
+    /** Drain (and clear) all advisory alarm/event signals (EMCY, heartbeat-loss, reconnect). */
+    List<IInputSignal> drainEvents();
+
+    /**
+     * Issue a write through the configured channel (SDO or RPDO). The
+     * aggregator has already audited the verdict; this method enforces the
+     * runtime backstop for forbidden indices and the per-node allow-list,
+     * and returns {@code true} only on a transport-level success.
+     */
+    boolean send(String bindingId, double value, long ts, long run);
+
+    /**
+     * Heartbeat watchdog (§5, §10 S9). Call once per tick. For every node
+     * we have ever heard a heartbeat from, if more than
+     * {@link #HEARTBEAT_TIMEOUT_MS} has elapsed since the last one, emit a
+     * {@code NODE_OFFLINE} alarm (once per offline transition) and mark
+     * subsequent reads from that node {@code Quality.UNCERTAIN}.
+     */
+    void checkHeartbeats(long nowMs);
+
+    /** Hand a frame received from the wire to the orchestrator's decoder. */
+    void onCanFrame(CanFrame frame);
+
+    /**
+     * Drop the latest-value cache and emit a {@code BRIDGE_RECONNECTED}
+     * advisory alarm. Called by the host after the underlying transport
+     * reports a reconnect.
+     */
+    void onReconnected();
+
+    CanopenBridgeConfig config();
+
+    CanopenNodeBinding writeBindingForTag(String tag);
+
+    CanopenNodeBinding readBinding(String bindingId);
+
+    CanopenNodeBinding writeBinding(String bindingId);
+
+    List<String> readBindingIds();
+
+    @Override
+    void close();
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenEventInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenEventInput.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IInitInput} that drains advisory event signals ({@code AlarmSignal}
+ * for EMCY, drive faults, heartbeat-loss, and {@code BRIDGE_RECONNECTED})
+ * from {@link CanopenClientService} (13-CANOPEN.md §5).
+ *
+ * <p>This input drains the global event channel rather than per-binding
+ * queues, so a single instance covers the whole bridge.
+ */
+public final class CanopenEventInput implements IInitInput {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private final String name;
+    private final CanopenClientService svc;
+
+    public CanopenEventInput(String name, CanopenClientService svc) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.svc = Objects.requireNonNull(svc, "svc");
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        return new ArrayList<>(svc.drainEvents());
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() { return new HashMap<>(); }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() { return PROCESSING_FREQUENCY; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenMeasurementInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenMeasurementInput.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IInitInput} that drains decoded scalar PDO signals
+ * ({@code MeasurementSignal} / {@code EfficiencySignal}) from
+ * {@link CanopenClientService} (13-CANOPEN.md §5).
+ *
+ * <p>One instance binds to one or more {@link CanopenBridgeConfig.ReadSignalKind#MEASUREMENT}
+ * or {@link CanopenBridgeConfig.ReadSignalKind#EFFICIENCY} read bindings.
+ * {@code readSignals()} is a snapshot; the platform service maintains the
+ * cache asynchronously and never blocks on the bus.
+ */
+public final class CanopenMeasurementInput implements IInitInput {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private final String name;
+    private final CanopenClientService svc;
+    private final List<String> bindingIds;
+
+    public CanopenMeasurementInput(String name, CanopenClientService svc, List<String> bindingIds) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.bindingIds = List.copyOf(Objects.requireNonNull(bindingIds, "bindingIds"));
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        List<IInputSignal> out = new ArrayList<>();
+        for (String b : bindingIds) out.addAll(svc.drain(b));
+        return out;
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() { return new HashMap<>(); }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() { return PROCESSING_FREQUENCY; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenNodeBinding.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenNodeBinding.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeBinding;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeBindingDirection;
+
+/**
+ * One CANopen (nodeId, odIndex, subIndex) ↔ signal-tag binding
+ * (13-CANOPEN.md §5, §6, §7).
+ *
+ * <p>Implements {@link BridgeBinding} so the universal audit record
+ * (00-FRAMEWORK §4) can identify the binding by tag and loop. For
+ * {@code READ} and event bindings only the routing fields are meaningful;
+ * clamp / rate / fail-safe fields are {@code null}.
+ */
+public record CanopenNodeBinding(
+        String bindingId,
+        int nodeId,
+        int odIndex,
+        int subIndex,
+        BridgeBindingDirection direction,
+        CanopenBridgeConfig.PdoSource pdoSource,
+        CanopenBridgeConfig.OdType odType,
+        CanopenBridgeConfig.WriteVia writeVia,
+        CanopenBridgeConfig.ReadSignalKind targetSignal,
+        CanopenBridgeConfig.EventSource eventSource,
+        String signalTag,
+        String signalTagPrefix,
+        double scale,
+        double offset,
+        int decimateBy,
+        Double minClampValue,
+        Double maxClampValue,
+        Double rampRateMaxPerSec,
+        Double failSafeValue
+) implements BridgeBinding {
+
+    public static CanopenNodeBinding fromRead(CanopenBridgeConfig.ReadBindingConfig r) {
+        return new CanopenNodeBinding(
+                r.bindingId(), r.nodeId(), r.odIndex(), r.subIndex(),
+                BridgeBindingDirection.READ,
+                r.pdoSource(), r.odType(), null,
+                r.targetSignal(), null,
+                r.signalTag(), null,
+                r.scale(), r.offset(), r.decimateBy(),
+                null, null, null, null);
+    }
+
+    public static CanopenNodeBinding fromEvent(CanopenBridgeConfig.EventBindingConfig e) {
+        return new CanopenNodeBinding(
+                e.bindingId(), e.nodeId(), 0, 0,
+                BridgeBindingDirection.READ,
+                null, CanopenBridgeConfig.OdType.UINT16, null,
+                e.targetSignal(), e.source(),
+                null, e.signalTagPrefix(),
+                1.0, 0.0, 1,
+                null, null, null, null);
+    }
+
+    public static CanopenNodeBinding fromWrite(CanopenBridgeConfig.WriteBindingConfig w) {
+        return new CanopenNodeBinding(
+                w.bindingId(), w.nodeId(), w.odIndex(), w.subIndex(),
+                BridgeBindingDirection.WRITE,
+                null, w.odType(), w.via(),
+                null, null,
+                w.signalTag(), null,
+                1.0, 0.0, 1,
+                w.minClampValue(), w.maxClampValue(),
+                w.rampRateMaxPerSec(), w.failSafeValue());
+    }
+
+    @Override public String loopId() { return bindingId; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenSignalMapper.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenSignalMapper.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmPriority;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.BatchPhase;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.Quality;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.ProprioceptiveSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.BatchStateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.EfficiencySignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Pure functions: CANopen PDO / EMCY / heartbeat ↔ Jneopallium typed
+ * signal (13-CANOPEN.md §5).
+ *
+ * <p>The mapper does not own state — it takes a binding plus already-decoded
+ * frame fields and returns a typed signal. Routing (COB-ID → binding) and
+ * the per-node liveness tracker live in {@link CanopenClientService}.
+ */
+public final class CanopenSignalMapper {
+
+    /** CiA-301 §7.2.1 EMCY error-code → severity. The full CANopen table is huge;
+     *  we collapse it onto five buckets matching the 13-CANOPEN.md §10 S10 brief. */
+    public static AlarmPriority emcySeverity(int errorCode) {
+        // 0x0000 — no error / reset notification.
+        if (errorCode == 0x0000) return AlarmPriority.JOURNAL;
+        // CANopen groups error codes by the upper nibble of the upper byte
+        // (CiA-301 §7.2.1.2 EMCY, table 17). 0x2xxx = current (overcurrent /
+        // short circuit) — kinetic-energy hazard, escalate to URGENT.
+        return switch ((errorCode >>> 12) & 0xf) {
+            case 0x1 -> AlarmPriority.LOW;       // generic
+            case 0x2 -> AlarmPriority.URGENT;    // current
+            case 0x3, 0x4, 0x5, 0x6, 0x8 -> AlarmPriority.HIGH; // voltage/temp/hw/sw/comm
+            case 0xf -> AlarmPriority.HIGH;      // vendor-specific — don't silently swallow
+            default -> AlarmPriority.LOW;
+        };
+    }
+
+    /** Standard CANopen EMCY error-code → human label (subset; §10 S10). */
+    public static String emcyLabel(int errorCode) {
+        return switch (errorCode) {
+            case 0x0000 -> "ERROR_RESET_OR_NO_ERROR";
+            case 0x1000 -> "GENERIC_ERROR";
+            case 0x2310 -> "CONTINUOUS_OVER_CURRENT";
+            case 0x2320 -> "SHORT_CIRCUIT_INTERNAL";
+            case 0x3110 -> "MAINS_OVER_VOLTAGE";
+            case 0x3120 -> "MAINS_UNDER_VOLTAGE";
+            case 0x3210 -> "DC_LINK_OVER_VOLTAGE";
+            case 0x3220 -> "DC_LINK_UNDER_VOLTAGE";
+            case 0x4210 -> "EXCESS_TEMPERATURE_DEVICE";
+            case 0x5530 -> "EEPROM_FAULT";
+            case 0x6010 -> "SOFTWARE_RESET_WATCHDOG";
+            case 0x8110 -> "CAN_OVERRUN";
+            case 0x8130 -> "LIFEGUARD_HEARTBEAT_ERROR";
+            case 0x8140 -> "RECOVERED_FROM_BUS_OFF";
+            case 0x8210 -> "PDO_NOT_PROCESSED";
+            default -> "EMCY_0x" + Integer.toHexString(errorCode).toUpperCase();
+        };
+    }
+
+    /** Decode a scalar from a PDO payload according to the binding's OD type, scale, offset. */
+    public double decodeScalar(CanopenNodeBinding b, byte[] payload) {
+        long raw = readRaw(b.odType(), payload, 0);
+        double v = b.odType() == CanopenBridgeConfig.OdType.REAL32
+                ? Float.intBitsToFloat((int) raw)
+                : (double) raw;
+        return v * b.scale() + b.offset();
+    }
+
+    /** Encode a scalar back to bytes for an SDO/RPDO write. */
+    public byte[] encodeScalar(CanopenBridgeConfig.OdType type, double value) {
+        return switch (type) {
+            case UINT8 -> new byte[]{(byte) ((int) value & 0xff)};
+            case INT8 -> new byte[]{(byte) ((int) value & 0xff)};
+            case UINT16, INT16 -> {
+                ByteBuffer bb = ByteBuffer.allocate(2).order(ByteOrder.LITTLE_ENDIAN);
+                bb.putShort((short) ((int) value & 0xffff));
+                yield bb.array();
+            }
+            case UINT32, INT32 -> {
+                ByteBuffer bb = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+                bb.putInt((int) value);
+                yield bb.array();
+            }
+            case REAL32 -> {
+                ByteBuffer bb = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+                bb.putFloat((float) value);
+                yield bb.array();
+            }
+        };
+    }
+
+    /** Read the raw integer (or REAL32 bit pattern) from a payload at offset. */
+    public static long readRaw(CanopenBridgeConfig.OdType type, byte[] payload, int offset) {
+        if (payload == null || offset >= payload.length) return 0L;
+        ByteBuffer bb = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN);
+        bb.position(offset);
+        return switch (type) {
+            case UINT8 -> bb.get() & 0xffL;
+            case INT8 -> (long) bb.get();
+            case UINT16 -> bb.getShort() & 0xffffL;
+            case INT16 -> (long) bb.getShort();
+            case UINT32 -> bb.getInt() & 0xffffffffL;
+            case INT32 -> (long) bb.getInt();
+            case REAL32 -> ((long) bb.getInt()) & 0xffffffffL;
+        };
+    }
+
+    /** PDO scalar → ProprioceptiveSignal (own joint state). */
+    public IInputSignal toProprioceptive(CanopenNodeBinding b, double value, long ts) {
+        ProprioceptiveSignal s = new ProprioceptiveSignal(
+                b.nodeId(), new double[]{value}, ts);
+        s.setName(b.signalTag() == null ? b.bindingId() : b.signalTag());
+        return s;
+    }
+
+    /** PDO scalar → MeasurementSignal (CiA-401 I/O, sensor PDO). */
+    public IInputSignal toMeasurement(CanopenNodeBinding b, double value, Quality q, long ts) {
+        MeasurementSignal s = new MeasurementSignal(
+                b.signalTag() == null ? b.bindingId() : b.signalTag(),
+                value, q, ts);
+        return s;
+    }
+
+    /** PDO scalar → EfficiencySignal (BMS). The mapper assumes 0..100 % SoC inputs. */
+    public IInputSignal toEfficiency(CanopenNodeBinding b, double value) {
+        String unit = b.signalTag() == null ? b.bindingId() : b.signalTag();
+        double pct = value > 1.0 ? value / 100.0 : value;
+        return new EfficiencySignal(unit, pct, 1.0);
+    }
+
+    /** Statusword (CiA-402 0x6041) → BatchStateSignal + optional fault AlarmSignal. */
+    public BatchStateSignal toDriveState(CanopenNodeBinding b, int statusword, long ts) {
+        BatchPhase phase = decodeStatuswordPhase(statusword);
+        Map<String, Double> metrics = new LinkedHashMap<>();
+        metrics.put("statusword", (double) (statusword & 0xffff));
+        metrics.put("ts", (double) ts);
+        BatchStateSignal s = new BatchStateSignal(
+                "DRIVE." + b.nodeId(), phase, metrics);
+        s.setName(b.signalTag() == null ? b.bindingId() : b.signalTag());
+        return s;
+    }
+
+    /** Bit 3 of statusword is FAULT — flip it into an AlarmSignal so the safety chain sees it. */
+    public AlarmSignal statuswordFault(CanopenNodeBinding b, int statusword, long ts) {
+        if ((statusword & 0x0008) == 0) return null;
+        String tag = (b.signalTag() == null ? b.bindingId() : b.signalTag()) + ".FAULT";
+        return new AlarmSignal(AlarmPriority.HIGH, tag,
+                "DRIVE_FAULT:0x" + Integer.toHexString(statusword & 0xffff), ts);
+    }
+
+    /** EMCY frame (8 bytes) → AlarmSignal. */
+    public AlarmSignal toEmcyAlarm(CanopenNodeBinding b, byte[] payload, long ts) {
+        if (payload == null || payload.length < 3) return null;
+        ByteBuffer bb = ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN);
+        int errorCode = bb.getShort() & 0xffff;
+        int errorReg = bb.get() & 0xff;
+        AlarmPriority pri = emcySeverity(errorCode);
+        String label = emcyLabel(errorCode);
+        String prefix = b.signalTagPrefix() != null ? b.signalTagPrefix() : "DRIVE.FAULT";
+        String tag = prefix + "." + b.nodeId();
+        return new AlarmSignal(pri, tag,
+                label + ":errorReg=0x" + Integer.toHexString(errorReg), ts);
+    }
+
+    /** Heartbeat-loss (synthesised by the bridge watchdog, §5, §10 S9). */
+    public AlarmSignal nodeOffline(int nodeId, long ts) {
+        return new AlarmSignal(AlarmPriority.HIGH,
+                "NODE." + nodeId, "NODE_OFFLINE", ts);
+    }
+
+    /**
+     * Heartbeat-loss measurement quality flag (§5: "subsequent reads marked
+     * Quality.UNCERTAIN" — propagated through the latest-value cache).
+     */
+    public static Quality offlineQuality() { return Quality.UNCERTAIN; }
+
+    /** CiA-402 statusword → CiA-88 batch phase (compact mapping for the bridge audit). */
+    static BatchPhase decodeStatuswordPhase(int sw) {
+        // Bits 0..6 carry the state-machine masked subset. CiA-402 §6.3.
+        int masked = sw & 0x6f;
+        // Fault.
+        if ((sw & 0x0008) != 0) return BatchPhase.ABORTED;
+        // Operation enabled = 0x27.
+        if ((masked & 0x27) == 0x27) return BatchPhase.RUNNING;
+        // Switched on = 0x23.
+        if ((masked & 0x23) == 0x23) return BatchPhase.HELD;
+        // Ready to switch on = 0x21.
+        if ((masked & 0x21) == 0x21) return BatchPhase.IDLE;
+        // Quick stop active = 0x07.
+        if ((masked & 0x07) == 0x07) return BatchPhase.STOPPED;
+        return BatchPhase.IDLE;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenStateInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenStateInput.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IInitInput} that drains decoded joint-state and drive-state
+ * signals ({@code ProprioceptiveSignal} and {@code BatchStateSignal})
+ * from {@link CanopenClientService} (13-CANOPEN.md §5).
+ *
+ * <p>One instance binds to one or more
+ * {@link CanopenBridgeConfig.ReadSignalKind#PROPRIOCEPTIVE} or
+ * {@link CanopenBridgeConfig.ReadSignalKind#BATCH_STATE} read bindings.
+ */
+public final class CanopenStateInput implements IInitInput {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private final String name;
+    private final CanopenClientService svc;
+    private final List<String> bindingIds;
+
+    public CanopenStateInput(String name, CanopenClientService svc, List<String> bindingIds) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.bindingIds = List.copyOf(Objects.requireNonNull(bindingIds, "bindingIds"));
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        List<IInputSignal> out = new ArrayList<>();
+        for (String b : bindingIds) out.addAll(svc.drain(b));
+        return out;
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() { return new HashMap<>(); }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() { return PROCESSING_FREQUENCY; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/EdsParser.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/EdsParser.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Permissive Electronic Data Sheet parser (13-CANOPEN.md §6, §10 R2).
+ *
+ * <p>EDS / DCF files are INI-style (CiA-306). This parser reads the
+ * subset that the bridge actually needs for OD-aware PDO decoding:
+ * sections matching {@code [hhhh]} (object) or {@code [hhhhsubXX]}
+ * (sub-object) and the {@code DataType} / {@code AccessType} /
+ * {@code ParameterName} / {@code DefaultValue} keys. It is permissive by
+ * design (§10 R2): unknown sections / keys are logged as warnings rather
+ * than rejected, so the parser tolerates EDS dialect drift between
+ * vendors.
+ *
+ * <p>The result is a flat {@code Map<Integer key, ObjectDictionaryEntry>}
+ * keyed by {@code (index << 8) | subIndex}.
+ */
+public final class EdsParser {
+
+    private static final Logger log = LoggerFactory.getLogger(EdsParser.class);
+
+    /** Section header: {@code [6041]} or {@code [6041sub1]} (case-insensitive). */
+    private static final Pattern SECTION_RE = Pattern.compile(
+            "^\\[\\s*([0-9A-Fa-f]{1,4})(?:\\s*sub\\s*([0-9A-Fa-f]{1,2}))?\\s*\\]\\s*$");
+
+    private static final Pattern KV_RE = Pattern.compile(
+            "^\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*=\\s*(.*?)\\s*$");
+
+    private EdsParser() {}
+
+    public static Map<Integer, ObjectDictionaryEntry> parse(Path file) throws IOException {
+        try (BufferedReader r = Files.newBufferedReader(file, StandardCharsets.UTF_8)) {
+            return parse(r);
+        }
+    }
+
+    public static Map<Integer, ObjectDictionaryEntry> parse(String content) throws IOException {
+        try (BufferedReader r = new BufferedReader(new StringReader(content))) {
+            return parse(r);
+        }
+    }
+
+    public static Map<Integer, ObjectDictionaryEntry> parse(Reader reader) throws IOException {
+        BufferedReader br = (reader instanceof BufferedReader b) ? b : new BufferedReader(reader);
+        Map<Integer, ObjectDictionaryEntry> out = new LinkedHashMap<>();
+        Map<String, String> sectionKv = new LinkedHashMap<>();
+        Integer currentIndex = null;
+        Integer currentSub = null;
+
+        String line;
+        while ((line = br.readLine()) != null) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith(";") || trimmed.startsWith("#")) {
+                continue;
+            }
+            Matcher sec = SECTION_RE.matcher(trimmed);
+            if (sec.matches()) {
+                flush(out, currentIndex, currentSub, sectionKv);
+                sectionKv = new LinkedHashMap<>();
+                currentIndex = Integer.parseInt(sec.group(1), 16);
+                currentSub = sec.group(2) == null ? 0 : Integer.parseInt(sec.group(2), 16);
+                continue;
+            }
+            if (line.startsWith("[")) {
+                // A non-OD section (e.g. [FileInfo], [DeviceInfo]) — skip until next.
+                flush(out, currentIndex, currentSub, sectionKv);
+                sectionKv = new LinkedHashMap<>();
+                currentIndex = null;
+                currentSub = null;
+                continue;
+            }
+            Matcher kv = KV_RE.matcher(line);
+            if (kv.matches() && currentIndex != null) {
+                sectionKv.put(kv.group(1), kv.group(2));
+            }
+        }
+        flush(out, currentIndex, currentSub, sectionKv);
+        return out;
+    }
+
+    private static void flush(Map<Integer, ObjectDictionaryEntry> out,
+                              Integer index, Integer sub, Map<String, String> kv) {
+        if (index == null || kv.isEmpty()) return;
+        String dataTypeStr = kv.get("DataType");
+        if (dataTypeStr == null) {
+            // No DataType — likely a structure header (ParameterName + ObjectType only); skip.
+            return;
+        }
+        CanopenBridgeConfig.OdType type = mapDataType(dataTypeStr);
+        if (type == null) {
+            log.debug("EDS: unsupported DataType {} at index 0x{}sub{} — skipping",
+                    dataTypeStr, Integer.toHexString(index), sub);
+            return;
+        }
+        ObjectDictionaryEntry.OdAccess access = mapAccess(kv.get("AccessType"));
+        String name = kv.getOrDefault("ParameterName", "");
+        String def = kv.get("DefaultValue");
+
+        int key = (index << 8) | (sub & 0xff);
+        out.put(key, new ObjectDictionaryEntry(index, sub, name, type, access, def));
+    }
+
+    /**
+     * CiA-301 §7.4.7 data-type IDs. Permissive: anything we don't model
+     * is silently skipped (the bridge falls back to the binding's
+     * configured {@code odType}).
+     */
+    static CanopenBridgeConfig.OdType mapDataType(String raw) {
+        if (raw == null) return null;
+        String s = raw.trim();
+        int v;
+        try {
+            if (s.startsWith("0x") || s.startsWith("0X")) v = Integer.parseInt(s.substring(2), 16);
+            else v = Integer.parseInt(s, 16);
+        } catch (NumberFormatException nfe) {
+            return null;
+        }
+        return switch (v) {
+            case 0x0002 -> CanopenBridgeConfig.OdType.INT8;
+            case 0x0003 -> CanopenBridgeConfig.OdType.INT16;
+            case 0x0004 -> CanopenBridgeConfig.OdType.INT32;
+            case 0x0005 -> CanopenBridgeConfig.OdType.UINT8;
+            case 0x0006 -> CanopenBridgeConfig.OdType.UINT16;
+            case 0x0007 -> CanopenBridgeConfig.OdType.UINT32;
+            case 0x0008 -> CanopenBridgeConfig.OdType.REAL32;
+            default -> null;
+        };
+    }
+
+    static ObjectDictionaryEntry.OdAccess mapAccess(String raw) {
+        if (raw == null) return ObjectDictionaryEntry.OdAccess.RW;
+        return switch (raw.trim().toLowerCase()) {
+            case "ro" -> ObjectDictionaryEntry.OdAccess.RO;
+            case "wo" -> ObjectDictionaryEntry.OdAccess.WO;
+            case "rwr" -> ObjectDictionaryEntry.OdAccess.RWR;
+            case "rww" -> ObjectDictionaryEntry.OdAccess.RWW;
+            case "const" -> ObjectDictionaryEntry.OdAccess.CONST;
+            default -> ObjectDictionaryEntry.OdAccess.RW;
+        };
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/ObjectDictionaryEntry.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/ObjectDictionaryEntry.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import java.util.Objects;
+
+/**
+ * One CANopen Object Dictionary entry parsed from an EDS / DCF
+ * (13-CANOPEN.md §1, §6, §10 S8). The (index, subIndex) pair is the
+ * key the bridge uses to look up the type and access flags when decoding
+ * a PDO byte payload.
+ *
+ * <p>The entry is intentionally minimal: only the fields the decoder /
+ * encoder need ({@link OdAccess}, {@link CanopenBridgeConfig.OdType},
+ * default value, parameter name) are kept. Unknown / vendor-specific keys
+ * are dropped by {@link EdsParser} with a warning.
+ */
+public record ObjectDictionaryEntry(
+        int index,
+        int subIndex,
+        String parameterName,
+        CanopenBridgeConfig.OdType odType,
+        OdAccess access,
+        String defaultValue
+) {
+    public ObjectDictionaryEntry {
+        Objects.requireNonNull(odType, "odType");
+        if (access == null) access = OdAccess.RW;
+    }
+
+    /** CiA-301 §7.4.5 access flags. */
+    public enum OdAccess { RO, WO, RW, RWR, RWW, CONST }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/SocketCanClientService.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/SocketCanClientService.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Linux SocketCAN backend (13-CANOPEN.md §2, §6). The integration with the
+ * native interface (PF_CAN socket via JNA, or a {@code candump}-style
+ * subprocess as a fallback) is the responsibility of a separate platform
+ * module that injects an {@link CanFrameSink} via
+ * {@link #attach(CanFrameSink)} — keeping the worker module free of
+ * native-only dependencies (§4 R4: native SocketCAN is not portable to
+ * macOS / Windows; the USB-CAN dongle path is the cross-platform escape
+ * hatch).
+ *
+ * <p>This class is a thin {@link AbstractCanopenClientService} subclass
+ * that captures outbound frames in {@link #lastSent}, exposes them to
+ * the platform module via the {@link CanFrameSink} interface, and routes
+ * inbound frames through {@link #onCanFrame(CanFrame)}. When the platform
+ * module is absent (the typical worker-only test setup) the class still
+ * functions as a faithful in-memory orchestrator — every test that exercises
+ * §10 S7 / S9 / S10 / S11 / S12 in this repo runs against this class
+ * without ever touching the kernel.
+ */
+public class SocketCanClientService extends AbstractCanopenClientService {
+
+    private static final Logger log = LoggerFactory.getLogger(SocketCanClientService.class);
+
+    private volatile CanFrameSink sink;
+    private volatile CanFrame lastSent;
+
+    public SocketCanClientService(CanopenBridgeConfig config, AbstractBridgeAuditOutput audit) {
+        super(config, audit);
+        if (config.canBus().type() != CanopenBridgeConfig.BusType.SOCKETCAN) {
+            log.warn("SocketCanClientService instantiated with bus type {}; expected SOCKETCAN",
+                    config.canBus().type());
+        }
+    }
+
+    /** Attach (or replace) the platform-specific sink that owns the kernel socket. */
+    public void attach(CanFrameSink sink) { this.sink = sink; }
+
+    /** Most-recent frame submitted to {@link #sendRawFrame(CanFrame)}. */
+    public CanFrame lastSent() { return lastSent; }
+
+    @Override
+    protected boolean sendRawFrame(CanFrame frame) {
+        this.lastSent = frame;
+        CanFrameSink s = this.sink;
+        if (s == null) return true;
+        try {
+            return s.send(frame);
+        } catch (RuntimeException ex) {
+            log.warn("SocketCAN sink threw: {}", ex.getMessage());
+            return false;
+        }
+    }
+
+    /** Sink injected by a platform module. Implementations write to {@code AF_CAN}. */
+    @FunctionalInterface
+    public interface CanFrameSink { boolean send(CanFrame frame); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/UsbCanClientService.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/UsbCanClientService.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Cross-platform USB-CAN backend (13-CANOPEN.md §2, §6, §11 R4). Targets
+ * Lawicel-style ASCII over a serial line — CANable, Korlan, PCAN-USB
+ * adapters in Lawicel-compatibility mode are the typical dev hardware.
+ *
+ * <p>As with {@link SocketCanClientService}, the actual serial I/O lives
+ * in a platform module that injects a {@link UsbCanFrameSink}. This class
+ * provides the orchestration; the platform module is responsible for
+ * reading/writing Lawicel ASCII frames over jSerialComm or an equivalent
+ * cross-platform serial library.
+ */
+public class UsbCanClientService extends AbstractCanopenClientService {
+
+    private static final Logger log = LoggerFactory.getLogger(UsbCanClientService.class);
+
+    private volatile UsbCanFrameSink sink;
+    private volatile CanFrame lastSent;
+
+    public UsbCanClientService(CanopenBridgeConfig config, AbstractBridgeAuditOutput audit) {
+        super(config, audit);
+        if (config.canBus().type() != CanopenBridgeConfig.BusType.USB_CAN) {
+            log.warn("UsbCanClientService instantiated with bus type {}; expected USB_CAN",
+                    config.canBus().type());
+        }
+    }
+
+    public void attach(UsbCanFrameSink sink) { this.sink = sink; }
+
+    public CanFrame lastSent() { return lastSent; }
+
+    @Override
+    protected boolean sendRawFrame(CanFrame frame) {
+        this.lastSent = frame;
+        UsbCanFrameSink s = this.sink;
+        if (s == null) return true;
+        try {
+            return s.send(frame);
+        } catch (RuntimeException ex) {
+            log.warn("USB-CAN sink threw: {}", ex.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Sink injected by a platform module. Implementations encode each frame
+     * as a Lawicel ASCII line ({@code tIIILDDD...\r}) and push it to the
+     * dongle's serial port.
+     */
+    @FunctionalInterface
+    public interface UsbCanFrameSink { boolean send(CanFrame frame); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * CANopen bridge (13-CANOPEN.md). Read-and-advisory adapter between a
+ * CANopen network (CiA-301 / CiA-401 / CiA-402 / CiA-418 device profiles)
+ * and the Jneopallium signal pipeline.
+ *
+ * <p>Structural ceiling per 13-CANOPEN.md §3 is <b>ADVISORY</b>. Writes
+ * to the CiA-402 {@code controlword} (0x6040) are rejected at config load
+ * unconditionally; every other write must clear a per-(nodeId, odIndex)
+ * allow-list at config load and a runtime backstop at send-time. PDO
+ * writes go through the universal §2.2 algorithm; SDO writes are slow
+ * enough to log every one.
+ *
+ * <p>Platform support is interface-first
+ * ({@link com.rakovpublic.jneuropallium.worker.bridge.canopen.CanopenClientService}):
+ * the Linux SocketCAN backend
+ * ({@link com.rakovpublic.jneuropallium.worker.bridge.canopen.SocketCanClientService})
+ * is the production target; the Lawicel-style USB-CAN backend
+ * ({@link com.rakovpublic.jneuropallium.worker.bridge.canopen.UsbCanClientService})
+ * is the cross-platform escape hatch.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenBridgeConfigLoaderTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenBridgeConfigLoaderTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link CanopenBridgeConfigLoader} (13-CANOPEN.md §6, §10 S11).
+ */
+class CanopenBridgeConfigLoaderTest {
+
+    @Test
+    void loadsMinimalConfig() throws Exception {
+        String yaml = """
+                canBus:
+                  type: SOCKETCAN
+                  device: vcan0
+                  bitrate: 500000
+                nodes:
+                  - id: 1
+                    type: CiA-402
+                writeIndexAllowList:
+                  1:
+                    - 24705   # 0x6081
+                writes:
+                  - bindingId: DRIVE-1-PROFILE-VEL
+                    nodeId: 1
+                    odIndex: 24705
+                    subIndex: 0
+                    odType: UINT32
+                    via: SDO
+                    signalTag: DRIVE.1.PROFILE_VEL
+                    minClampValue: 0
+                    maxClampValue: 5000
+                audit:
+                  localAuditFile: /tmp/canopen-audit.jsonl
+                """;
+        CanopenBridgeConfig cfg = CanopenBridgeConfigLoader.load(yaml);
+        assertEquals(CanopenBridgeConfig.BusType.SOCKETCAN, cfg.canBus().type());
+        assertEquals(1, cfg.writes().size());
+        assertEquals("DRIVE-1-PROFILE-VEL", cfg.writes().get(0).bindingId());
+    }
+
+    /** §10 S11 — controlword (0x6040) is on the FORBIDDEN list and rejected at load. */
+    @Test
+    void rejectsControlwordWriteBinding() {
+        String yaml = """
+                canBus:
+                  type: SOCKETCAN
+                  device: vcan0
+                  bitrate: 500000
+                nodes:
+                  - id: 1
+                writeIndexAllowList:
+                  1:
+                    - 24640   # 0x6040 — controlword, intentionally allow-listed to prove the FORBIDDEN backstop
+                writes:
+                  - bindingId: BAD
+                    nodeId: 1
+                    odIndex: 24640
+                    odType: UINT16
+                    via: SDO
+                    signalTag: BAD.CTRLWORD
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        Exception ex = assertThrows(Exception.class, () -> CanopenBridgeConfigLoader.load(yaml));
+        assertTrue(ex.getMessage().contains("forbidden") || rootMessage(ex).contains("forbidden"),
+                "expected forbidden-OD-index message, got: " + rootMessage(ex));
+    }
+
+    /** §10 S11 — write bindings whose (nodeId, odIndex) is not on writeIndexAllowList are rejected. */
+    @Test
+    void rejectsWriteBindingNotInAllowList() {
+        String yaml = """
+                canBus:
+                  type: SOCKETCAN
+                  device: vcan0
+                  bitrate: 500000
+                nodes:
+                  - id: 1
+                writeIndexAllowList:
+                  1:
+                    - 24705
+                writes:
+                  - bindingId: NOT-LISTED
+                    nodeId: 1
+                    odIndex: 24706
+                    odType: UINT32
+                    via: SDO
+                    signalTag: NOT.LISTED
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        Exception ex = assertThrows(Exception.class, () -> CanopenBridgeConfigLoader.load(yaml));
+        assertTrue(rootMessage(ex).contains("writeIndexAllowList"),
+                "expected allow-list message, got: " + rootMessage(ex));
+    }
+
+    /** 00-FRAMEWORK §3 — unknown YAML keys must be rejected at load. */
+    @Test
+    void rejectsUnknownYamlKey() {
+        String yaml = """
+                canBus:
+                  type: SOCKETCAN
+                  device: vcan0
+                  bitrate: 500000
+                gravityWell: 9.8
+                audit:
+                  localAuditFile: /tmp/x
+                """;
+        assertThrows(Exception.class, () -> CanopenBridgeConfigLoader.load(yaml));
+    }
+
+    private static String rootMessage(Throwable t) {
+        Throwable cur = t;
+        while (cur.getCause() != null && cur.getCause() != cur) cur = cur.getCause();
+        return cur.getMessage() == null ? t.toString() : cur.getMessage();
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenBridgeIntegrationTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/CanopenBridgeIntegrationTest.java
@@ -1,0 +1,599 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import com.rakovpublic.jneuropallium.worker.net.layers.IResult;
+import com.rakovpublic.jneuropallium.worker.net.layers.impl.SimpleResultWrapper;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmPriority;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.BatchPhase;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.Quality;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.embodiment.ProprioceptiveSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.ActuatorCommandSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.BatchStateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.EfficiencySignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for the CANopen bridge (13-CANOPEN.md §10). Covers the
+ * universal 00-FRAMEWORK §5 scenarios that apply (S1, S2, S3, S4, S5, S6)
+ * plus the bridge-specific scenarios S7–S12. Runs against
+ * {@link InMemoryCanopenClientService} — no SocketCAN / USB-CAN dongle
+ * required.
+ */
+class CanopenBridgeIntegrationTest {
+
+    private static final int NODE_DRIVE = 0x01;
+    private static final int NODE_BMS   = 0x02;
+
+    private static final int OD_POSITION_ACTUAL = 0x6064;
+    private static final int OD_STATUSWORD      = 0x6041;
+    private static final int OD_PROFILE_VEL     = 0x6081;
+    private static final int OD_BMS_SOC         = 0x2001;
+
+    @TempDir Path tempDir;
+
+    private CanopenAuditOutput audit;
+    private InMemoryCanopenClientService svc;
+
+    @BeforeEach
+    void setUp() {
+        audit = new CanopenAuditOutput(tempDir.resolve("canopen-audit.jsonl"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (svc != null) svc.close();
+        if (audit != null) audit.close();
+    }
+
+    /* ===== §5 universal framework scenarios ============================= */
+
+    /**
+     * S1 — pure read: a TPDO1 frame from a CiA-402 drive lands as a
+     * {@link ProprioceptiveSignal}.
+     */
+    @Test
+    void s1_pureReadEmitsProprioceptiveSignal() {
+        bring(baseConfig(
+                List.of(readBinding("DRIVE-1-POS", NODE_DRIVE,
+                        OD_POSITION_ACTUAL, CanopenBridgeConfig.PdoSource.TPDO1,
+                        CanopenBridgeConfig.OdType.INT32,
+                        CanopenBridgeConfig.ReadSignalKind.PROPRIOCEPTIVE,
+                        "DRIVE.1.POS_ACTUAL", 1.0, 0.0, 1)),
+                List.of(),
+                List.of(),
+                Map.of(),
+                Map.of()));
+        // 12345 ticks of position, INT32 little-endian over TPDO1 (cob 0x181).
+        svc.onCanFrame(tpdoFrame(NODE_DRIVE, 1,
+                int32ToBytes(12345)));
+
+        List<IInputSignal> sigs = svc.drain("DRIVE-1-POS");
+        assertEquals(1, sigs.size());
+        ProprioceptiveSignal sig = (ProprioceptiveSignal) sigs.get(0);
+        assertEquals(12345.0, sig.getJointStates()[0], 1e-9);
+        assertEquals(NODE_DRIVE, sig.getEffectorId());
+    }
+
+    /**
+     * S2 — quality propagates: when a node has gone past the heartbeat
+     * timeout, subsequent {@link MeasurementSignal} reads from it carry
+     * {@code Quality.UNCERTAIN}.
+     */
+    @Test
+    void s2_qualityPropagatesAfterHeartbeatLoss() {
+        bring(baseConfig(
+                List.of(readBinding("BMS-SOC", NODE_BMS,
+                        OD_BMS_SOC, CanopenBridgeConfig.PdoSource.TPDO1,
+                        CanopenBridgeConfig.OdType.UINT16,
+                        CanopenBridgeConfig.ReadSignalKind.MEASUREMENT,
+                        "BMS.PACK_A.SOC", 1.0, 0.0, 1)),
+                List.of(), List.of(), Map.of(), Map.of()));
+
+        // Establish liveness for node 2.
+        svc.onCanFrame(heartbeatFrame(NODE_BMS, 0x05 /* operational */));
+        long now = System.currentTimeMillis();
+        svc.checkHeartbeats(now);
+        assertFalse(svc.isOffline(NODE_BMS));
+
+        // 5 s later — past the 2 s timeout.
+        svc.checkHeartbeats(now + 5_000L);
+        assertTrue(svc.isOffline(NODE_BMS));
+
+        svc.onCanFrame(tpdoFrame(NODE_BMS, 1, uint16ToBytes(42)));
+        MeasurementSignal m = (MeasurementSignal) svc.drain("BMS-SOC").get(0);
+        assertEquals(Quality.UNCERTAIN, m.getQuality(),
+                "reads from an offline node must be marked UNCERTAIN (00-FRAMEWORK §0.5, §5 S2)");
+    }
+
+    /** S3 — SHADOW-mode rejects writes; nothing reaches the wire. */
+    @Test
+    void s3_shadowModeRejectsWrite() throws IOException {
+        bring(baseConfig(
+                List.of(),
+                List.of(),
+                List.of(writeBinding("DRIVE-1-PROFILE-VEL", NODE_DRIVE,
+                        OD_PROFILE_VEL, CanopenBridgeConfig.OdType.UINT32,
+                        CanopenBridgeConfig.WriteVia.SDO,
+                        "DRIVE.1.PROFILE_VEL", 0.0, 5000.0, null)),
+                Map.of("DRIVE-1-PROFILE-VEL", BridgeSafetyMode.SHADOW),
+                Map.of(NODE_DRIVE, List.of(OD_PROFILE_VEL))));
+
+        var agg = new CanopenAdvisoryOutputAggregator(svc, audit);
+        agg.save(List.of(result(setpoint("DRIVE.1.PROFILE_VEL", 1500.0))),
+                System.currentTimeMillis(), 1L, null);
+
+        assertEquals(0, svc.sendCount(), "SHADOW must not emit a frame");
+        String log = Files.readString(tempDir.resolve("canopen-audit.jsonl"));
+        assertTrue(log.contains("SHADOW_MODE"), "expected SHADOW_MODE audit, got: " + log);
+    }
+
+    /** S4 — reconnect drops cache and emits {@code BRIDGE_RECONNECTED}. */
+    @Test
+    void s4_reconnectClearsCacheAndEmitsAdvisoryEvent() {
+        bring(baseConfig(
+                List.of(readBinding("DRIVE-1-POS", NODE_DRIVE,
+                        OD_POSITION_ACTUAL, CanopenBridgeConfig.PdoSource.TPDO1,
+                        CanopenBridgeConfig.OdType.INT32,
+                        CanopenBridgeConfig.ReadSignalKind.PROPRIOCEPTIVE,
+                        "DRIVE.1.POS_ACTUAL", 1.0, 0.0, 1)),
+                List.of(), List.of(), Map.of(), Map.of()));
+
+        svc.onCanFrame(tpdoFrame(NODE_DRIVE, 1, int32ToBytes(7)));
+        svc.onReconnected();
+        assertTrue(svc.drain("DRIVE-1-POS").isEmpty(),
+                "cache must be dropped on reconnect (00-FRAMEWORK §2.3)");
+        List<IInputSignal> events = svc.drainEvents();
+        assertTrue(events.stream().anyMatch(e ->
+                        e instanceof AlarmSignal a && CanopenClientService.BRIDGE_RECONNECTED.equals(a.getConditionCode())),
+                "expected BRIDGE_RECONNECTED advisory");
+    }
+
+    /** S5 — audit failure isolation: an unwritable file degrades the audit channel but doesn't block traffic. */
+    @Test
+    void s5_auditFailureIsolation() throws IOException {
+        Path blocker = tempDir.resolve("blocker");
+        Files.createFile(blocker);
+        Path bogus = blocker.resolve("audit.jsonl");
+        audit.close();
+        audit = new CanopenAuditOutput(bogus);
+        svc = new InMemoryCanopenClientService(baseConfig(
+                List.of(readBinding("DRIVE-1-POS", NODE_DRIVE,
+                        OD_POSITION_ACTUAL, CanopenBridgeConfig.PdoSource.TPDO1,
+                        CanopenBridgeConfig.OdType.INT32,
+                        CanopenBridgeConfig.ReadSignalKind.PROPRIOCEPTIVE,
+                        "DRIVE.1.POS_ACTUAL", 1.0, 0.0, 1)),
+                List.of(), List.of(), Map.of(), Map.of()), audit);
+        svc.start();
+
+        svc.onCanFrame(tpdoFrame(NODE_DRIVE, 1, int32ToBytes(1)));
+        assertEquals(1, svc.drain("DRIVE-1-POS").size(),
+                "bridge must keep emitting signals even with a degraded audit channel");
+        assertTrue(audit.isDegraded(), "audit channel should be degraded");
+    }
+
+    /** S6 — unknown tag rejected. */
+    @Test
+    void s6_unknownTagRejected() throws IOException {
+        bring(baseConfig(
+                List.of(), List.of(),
+                List.of(writeBinding("DRIVE-1-PROFILE-VEL", NODE_DRIVE,
+                        OD_PROFILE_VEL, CanopenBridgeConfig.OdType.UINT32,
+                        CanopenBridgeConfig.WriteVia.SDO,
+                        "DRIVE.1.PROFILE_VEL", null, null, null)),
+                Map.of("DRIVE-1-PROFILE-VEL", BridgeSafetyMode.ADVISORY),
+                Map.of(NODE_DRIVE, List.of(OD_PROFILE_VEL))));
+
+        var agg = new CanopenAdvisoryOutputAggregator(svc, audit);
+        agg.save(List.of(result(setpoint("UNKNOWN.TAG", 1.0))),
+                System.currentTimeMillis(), 1L, null);
+
+        assertEquals(0, svc.sendCount());
+        String log = Files.readString(tempDir.resolve("canopen-audit.jsonl"));
+        assertTrue(log.contains("UNKNOWN_TAG"));
+    }
+
+    /* ===== §10 bridge-specific scenarios ================================= */
+
+    /** S7 — vcan0-style PDO read produces the configured signal. */
+    @Test
+    void s7_vcanRead() {
+        bring(baseConfig(
+                List.of(readBinding("DRIVE-1-POS", NODE_DRIVE,
+                        OD_POSITION_ACTUAL, CanopenBridgeConfig.PdoSource.TPDO1,
+                        CanopenBridgeConfig.OdType.INT32,
+                        CanopenBridgeConfig.ReadSignalKind.PROPRIOCEPTIVE,
+                        "DRIVE.1.POS_ACTUAL", 1.0, 0.0, 1)),
+                List.of(), List.of(), Map.of(), Map.of()));
+
+        for (int v : new int[]{1, 2, 3, 4, 5}) {
+            svc.onCanFrame(tpdoFrame(NODE_DRIVE, 1, int32ToBytes(v * 100)));
+        }
+        List<IInputSignal> sigs = svc.drain("DRIVE-1-POS");
+        assertEquals(5, sigs.size());
+        for (int i = 0; i < 5; i++) {
+            assertEquals((double) ((i + 1) * 100),
+                    ((ProprioceptiveSignal) sigs.get(i)).getJointStates()[0], 1e-9);
+        }
+    }
+
+    /** S8 — EDS parsing wired: a parsed EDS exposes the OD entry. */
+    @Test
+    void s8_edsParse() throws Exception {
+        String eds = """
+                [6064]
+                ParameterName=Position actual value
+                DataType=0x0004
+                AccessType=ro
+                """;
+        Map<Integer, ObjectDictionaryEntry> od = EdsParser.parse(eds);
+        ObjectDictionaryEntry e = od.get(0x6064 << 8);
+        assertNotNull(e);
+        assertEquals(CanopenBridgeConfig.OdType.INT32, e.odType());
+    }
+
+    /** S9 — heartbeat loss → NODE_OFFLINE alarm + sticky offline flag. */
+    @Test
+    void s9_heartbeatLossEmitsAlarm() {
+        bring(baseConfig(
+                List.of(),
+                List.of(eventBinding("DRIVE-1-OFFLINE", NODE_DRIVE,
+                        CanopenBridgeConfig.EventSource.HEARTBEAT_LOSS, "DRIVE.OFFLINE")),
+                List.of(), Map.of(), Map.of()));
+
+        svc.onCanFrame(heartbeatFrame(NODE_DRIVE, 0x05));
+        long now = System.currentTimeMillis();
+        svc.checkHeartbeats(now);
+        assertTrue(svc.drainEvents().stream().noneMatch(
+                e -> e instanceof AlarmSignal a && "NODE_OFFLINE".equals(a.getConditionCode())));
+
+        svc.checkHeartbeats(now + 5_000L);
+        List<IInputSignal> events = svc.drainEvents();
+        assertTrue(events.stream().anyMatch(e ->
+                        e instanceof AlarmSignal a
+                                && "NODE_OFFLINE".equals(a.getConditionCode())
+                                && a.getPriority() == AlarmPriority.HIGH),
+                "expected NODE_OFFLINE alarm after heartbeat timeout");
+        // The HEARTBEAT_LOSS event-binding's queue also gets the alarm.
+        List<IInputSignal> q = svc.drain("DRIVE-1-OFFLINE");
+        assertTrue(q.stream().anyMatch(e -> e instanceof AlarmSignal a
+                && a.getTag() != null && a.getTag().startsWith("DRIVE.OFFLINE")));
+    }
+
+    /** S10 — EMCY frame decoded into AlarmSignal with the standard description. */
+    @Test
+    void s10_emcyDecode() {
+        bring(baseConfig(
+                List.of(),
+                List.of(eventBinding("DRIVE-1-FAULT", NODE_DRIVE,
+                        CanopenBridgeConfig.EventSource.EMCY, "DRIVE.FAULT")),
+                List.of(), Map.of(), Map.of()));
+
+        // EMCY frame: code=0x2310 (CONTINUOUS_OVER_CURRENT), errorReg=0x02, vendor=0.
+        byte[] payload = new byte[8];
+        ByteBuffer.wrap(payload).order(ByteOrder.LITTLE_ENDIAN)
+                .putShort((short) 0x2310).put((byte) 0x02);
+        svc.onCanFrame(new CanFrame(0x080 + NODE_DRIVE, payload));
+
+        List<IInputSignal> q = svc.drain("DRIVE-1-FAULT");
+        assertEquals(1, q.size());
+        AlarmSignal a = (AlarmSignal) q.get(0);
+        assertEquals(AlarmPriority.URGENT, a.getPriority(),
+                "0x23xx (current) maps to URGENT in CanopenSignalMapper");
+        assertTrue(a.getConditionCode().contains("CONTINUOUS_OVER_CURRENT"),
+                "expected the standard description, got: " + a.getConditionCode());
+        // The EMCY also fans out to the global event channel.
+        assertTrue(svc.drainEvents().stream().anyMatch(
+                e -> e instanceof AlarmSignal x && x.getConditionCode().contains("CONTINUOUS_OVER_CURRENT")));
+    }
+
+    /**
+     * S11 — disallowed index rejected at config load. Constructed
+     * directly because 13-CANOPEN.md §6 rejects them at load, not
+     * runtime.
+     */
+    @Test
+    void s11_disallowedIndexRejectedAtLoad() {
+        IllegalArgumentException ex = org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalArgumentException.class, () -> baseConfig(
+                        List.of(), List.of(),
+                        List.of(writeBinding("BAD-CTRLWORD", NODE_DRIVE,
+                                0x6040,  // controlword
+                                CanopenBridgeConfig.OdType.UINT16,
+                                CanopenBridgeConfig.WriteVia.SDO,
+                                "BAD.CTRLWORD", null, null, null)),
+                        Map.of(),
+                        Map.of(NODE_DRIVE, List.of(0x6040))));
+        assertTrue(ex.getMessage().contains("forbidden"),
+                "expected forbidden-OD-index message, got: " + ex.getMessage());
+    }
+
+    /** S12 — SDO write to an allowed index emits an SDO download frame. */
+    @Test
+    void s12_sdoWriteToAllowedIndex() throws IOException {
+        bring(baseConfig(
+                List.of(), List.of(),
+                List.of(writeBinding("DRIVE-1-PROFILE-VEL", NODE_DRIVE,
+                        OD_PROFILE_VEL, CanopenBridgeConfig.OdType.UINT32,
+                        CanopenBridgeConfig.WriteVia.SDO,
+                        "DRIVE.1.PROFILE_VEL", 0.0, 5000.0, null)),
+                Map.of("DRIVE-1-PROFILE-VEL", BridgeSafetyMode.ADVISORY),
+                Map.of(NODE_DRIVE, List.of(OD_PROFILE_VEL))));
+
+        var agg = new CanopenAdvisoryOutputAggregator(svc, audit);
+        agg.save(List.of(result(actuator("DRIVE.1.PROFILE_VEL", 1500.0, true))),
+                System.currentTimeMillis(), 1L, null);
+
+        assertEquals(1, svc.sendCount());
+        CanFrame f = svc.sentFrames().get(0);
+        assertEquals(0x600 + NODE_DRIVE, f.cobId(), "SDO request COB-ID = 0x600 + nodeId");
+        byte[] data = f.data();
+        // Expedited download command-specifier with size indicated, n=0 (4 data bytes).
+        assertEquals((byte) 0x23, data[0]);
+        assertEquals((byte) (OD_PROFILE_VEL & 0xff), data[1]);
+        assertEquals((byte) ((OD_PROFILE_VEL >>> 8) & 0xff), data[2]);
+        assertEquals((byte) 0x00, data[3]);
+        // 1500 LE u32 = 0xDC, 0x05, 0x00, 0x00.
+        assertEquals((byte) 0xDC, data[4]);
+        assertEquals((byte) 0x05, data[5]);
+
+        String log = Files.readString(tempDir.resolve("canopen-audit.jsonl"));
+        assertTrue(log.contains("APPLIED"));
+    }
+
+    /* ===== additional defensive scenarios ================================ */
+
+    /** Statusword PDO emits a fault alarm when bit 3 is set, plus the carrier MeasurementSignal. */
+    @Test
+    void statuswordPdoFiresMeasurementAndFaultAlarm() {
+        bring(baseConfig(
+                List.of(readBinding("DRIVE-1-STATE", NODE_DRIVE,
+                        OD_STATUSWORD, CanopenBridgeConfig.PdoSource.TPDO2,
+                        CanopenBridgeConfig.OdType.UINT16,
+                        CanopenBridgeConfig.ReadSignalKind.BATCH_STATE,
+                        "DRIVE.1.STATE", 1.0, 0.0, 1)),
+                List.of(), List.of(), Map.of(), Map.of()));
+
+        // Bit 3 = FAULT, bits 0..2 = "ready to switch on disabled" combination.
+        int statusword = 0x000F;
+        svc.onCanFrame(tpdoFrame(NODE_DRIVE, 2, uint16ToBytes(statusword)));
+
+        List<IInputSignal> q = svc.drain("DRIVE-1-STATE");
+        assertEquals(1, q.size());
+        MeasurementSignal carrier = (MeasurementSignal) q.get(0);
+        assertEquals(statusword, (int) carrier.getMeasurement());
+
+        BatchStateSignal state = svc.lastDriveState("DRIVE-1-STATE");
+        assertNotNull(state);
+        assertEquals(BatchPhase.ABORTED, state.getPhase());
+
+        AlarmSignal fault = (AlarmSignal) svc.drainEvents().stream()
+                .filter(e -> e instanceof AlarmSignal)
+                .findFirst().orElseThrow();
+        assertEquals(AlarmPriority.HIGH, fault.getPriority());
+        assertTrue(fault.getConditionCode().startsWith("DRIVE_FAULT"));
+    }
+
+    /** BMS scalar PDO → EfficiencySignal with the SoC normalised to 0..1. */
+    @Test
+    void bmsPdoEmitsEfficiencySignal() {
+        bring(baseConfig(
+                List.of(readBinding("BMS-SOC", NODE_BMS,
+                        OD_BMS_SOC, CanopenBridgeConfig.PdoSource.TPDO1,
+                        CanopenBridgeConfig.OdType.UINT16,
+                        CanopenBridgeConfig.ReadSignalKind.EFFICIENCY,
+                        "BMS.PACK_A.SOC", 1.0, 0.0, 1)),
+                List.of(), List.of(), Map.of(), Map.of()));
+
+        svc.onCanFrame(tpdoFrame(NODE_BMS, 1, uint16ToBytes(85)));
+        EfficiencySignal eff = (EfficiencySignal) svc.drain("BMS-SOC").get(0);
+        assertEquals(0.85, eff.getEfficiency(), 1e-9);
+    }
+
+    /** Runtime backstop: a forbidden index reaching {@code send()} is rejected with a NOT_ON_ALLOW_LIST audit. */
+    @Test
+    void runtimeBackstopRejectsDisallowedSendDirectly() throws IOException {
+        // Build a config that has an allow-listed write binding, then attempt
+        // a direct send to a binding id that doesn't exist (proxying the
+        // "loader bypassed" path the runtime backstop is the last line of
+        // defence against).
+        bring(baseConfig(
+                List.of(), List.of(),
+                List.of(writeBinding("DRIVE-1-PROFILE-VEL", NODE_DRIVE,
+                        OD_PROFILE_VEL, CanopenBridgeConfig.OdType.UINT32,
+                        CanopenBridgeConfig.WriteVia.SDO,
+                        "DRIVE.1.PROFILE_VEL", null, null, null)),
+                Map.of("DRIVE-1-PROFILE-VEL", BridgeSafetyMode.ADVISORY),
+                Map.of(NODE_DRIVE, List.of(OD_PROFILE_VEL))));
+
+        boolean ok = svc.send("UNKNOWN-BINDING", 1.0,
+                System.currentTimeMillis(), 1L);
+        assertFalse(ok);
+        String log = Files.readString(tempDir.resolve("canopen-audit.jsonl"));
+        assertTrue(log.contains("UNKNOWN_BINDING"),
+                "expected UNKNOWN_BINDING audit, got: " + log);
+    }
+
+    /** Decimation: every Nth frame is delivered, the rest dropped. */
+    @Test
+    void decimationDropsAllButEveryNth() {
+        bring(baseConfig(
+                List.of(readBinding("DRIVE-1-POS", NODE_DRIVE,
+                        OD_POSITION_ACTUAL, CanopenBridgeConfig.PdoSource.TPDO1,
+                        CanopenBridgeConfig.OdType.INT32,
+                        CanopenBridgeConfig.ReadSignalKind.PROPRIOCEPTIVE,
+                        "DRIVE.1.POS_ACTUAL", 1.0, 0.0, 3)),
+                List.of(), List.of(), Map.of(), Map.of()));
+
+        for (int i = 0; i < 9; i++) {
+            svc.onCanFrame(tpdoFrame(NODE_DRIVE, 1, int32ToBytes(i)));
+        }
+        // decimateBy=3 with the counter incremented before the modulo means
+        // i=2,5,8 (the 3rd, 6th, 9th frames) pass.
+        assertEquals(3, svc.drain("DRIVE-1-POS").size());
+    }
+
+    /** The audit shape conforms to 00-FRAMEWORK §4. */
+    @Test
+    void auditShapeMatchesFramework() throws IOException {
+        bring(baseConfig(
+                List.of(), List.of(),
+                List.of(writeBinding("DRIVE-1-PROFILE-VEL", NODE_DRIVE,
+                        OD_PROFILE_VEL, CanopenBridgeConfig.OdType.UINT32,
+                        CanopenBridgeConfig.WriteVia.SDO,
+                        "DRIVE.1.PROFILE_VEL", 0.0, 5000.0, null)),
+                Map.of("DRIVE-1-PROFILE-VEL", BridgeSafetyMode.ADVISORY),
+                Map.of(NODE_DRIVE, List.of(OD_PROFILE_VEL))));
+
+        var agg = new CanopenAdvisoryOutputAggregator(svc, audit);
+        agg.save(List.of(result(actuator("DRIVE.1.PROFILE_VEL", 2500.0, true))),
+                1700_000_000_000L, 42L, null);
+
+        audit.close();
+        audit = null;
+        String log = Files.readString(tempDir.resolve("canopen-audit.jsonl"));
+        assertTrue(log.contains("\"bridge\":\"canopen\""), "missing bridge key: " + log);
+        assertTrue(log.contains("\"verdict\":\"APPLIED\""), "missing APPLIED verdict: " + log);
+        assertTrue(log.contains("\"tag\":\"DRIVE.1.PROFILE_VEL\""), "missing tag: " + log);
+    }
+
+    /**
+     * Clamping and rate-limiting are applied per the universal §2.2
+     * algorithm; the audit's {@code reason} captures the modification.
+     */
+    @Test
+    void clampApplied() throws IOException {
+        bring(baseConfig(
+                List.of(), List.of(),
+                List.of(writeBinding("DRIVE-1-PROFILE-VEL", NODE_DRIVE,
+                        OD_PROFILE_VEL, CanopenBridgeConfig.OdType.UINT32,
+                        CanopenBridgeConfig.WriteVia.SDO,
+                        "DRIVE.1.PROFILE_VEL", 0.0, 5000.0, null)),
+                Map.of("DRIVE-1-PROFILE-VEL", BridgeSafetyMode.ADVISORY),
+                Map.of(NODE_DRIVE, List.of(OD_PROFILE_VEL))));
+
+        var agg = new CanopenAdvisoryOutputAggregator(svc, audit);
+        agg.save(List.of(result(actuator("DRIVE.1.PROFILE_VEL", 99_999.0, true))),
+                System.currentTimeMillis(), 1L, null);
+
+        assertEquals(1, svc.sendCount());
+        CanFrame f = svc.sentFrames().get(0);
+        // 5000 LE = 0x88, 0x13, 0x00, 0x00.
+        assertEquals((byte) 0x88, f.data()[4]);
+        assertEquals((byte) 0x13, f.data()[5]);
+        String log = Files.readString(tempDir.resolve("canopen-audit.jsonl"));
+        assertTrue(log.contains("CLAMPED_HIGH"), "expected CLAMPED_HIGH, got: " + log);
+    }
+
+    /* ===== helpers ====================================================== */
+
+    private void bring(CanopenBridgeConfig cfg) {
+        svc = new InMemoryCanopenClientService(cfg, audit);
+        svc.start();
+    }
+
+    private static CanopenBridgeConfig baseConfig(
+            List<CanopenBridgeConfig.ReadBindingConfig> reads,
+            List<CanopenBridgeConfig.EventBindingConfig> events,
+            List<CanopenBridgeConfig.WriteBindingConfig> writes,
+            Map<String, BridgeSafetyMode> safetyModes,
+            Map<Integer, List<Integer>> allowList) {
+        return new CanopenBridgeConfig(
+                new CanopenBridgeConfig.CanBusConfig(
+                        CanopenBridgeConfig.BusType.SOCKETCAN, "vcan0", 500_000, 0.875),
+                List.of(
+                        new CanopenBridgeConfig.NodeConfig(NODE_DRIVE, "CiA-402", null),
+                        new CanopenBridgeConfig.NodeConfig(NODE_BMS, "CiA-418", null)),
+                reads, events, writes, allowList,
+                new CanopenBridgeConfig.AuditConfig(
+                        Path.of(System.getProperty("java.io.tmpdir"), "canopen-audit.jsonl").toString()),
+                safetyModes, null);
+    }
+
+    private static CanopenBridgeConfig.ReadBindingConfig readBinding(
+            String id, int nodeId, int odIndex,
+            CanopenBridgeConfig.PdoSource src,
+            CanopenBridgeConfig.OdType type,
+            CanopenBridgeConfig.ReadSignalKind kind,
+            String tag, double scale, double offset, int decimateBy) {
+        return new CanopenBridgeConfig.ReadBindingConfig(
+                id, nodeId, odIndex, 0, src, type, kind, tag, scale, offset, decimateBy);
+    }
+
+    private static CanopenBridgeConfig.EventBindingConfig eventBinding(
+            String id, int nodeId,
+            CanopenBridgeConfig.EventSource source, String prefix) {
+        return new CanopenBridgeConfig.EventBindingConfig(
+                id, nodeId, source, CanopenBridgeConfig.ReadSignalKind.ALARM, prefix);
+    }
+
+    private static CanopenBridgeConfig.WriteBindingConfig writeBinding(
+            String id, int nodeId, int odIndex,
+            CanopenBridgeConfig.OdType type,
+            CanopenBridgeConfig.WriteVia via, String tag,
+            Double minClamp, Double maxClamp, Double rampRate) {
+        return new CanopenBridgeConfig.WriteBindingConfig(
+                id, nodeId, odIndex, 0, type, via, tag,
+                minClamp, maxClamp, rampRate, null);
+    }
+
+    private static CanFrame tpdoFrame(int nodeId, int pdoIndex /*1..4*/, byte[] payload) {
+        int cob = switch (pdoIndex) {
+            case 1 -> 0x180 + nodeId;
+            case 2 -> 0x280 + nodeId;
+            case 3 -> 0x380 + nodeId;
+            case 4 -> 0x480 + nodeId;
+            default -> throw new IllegalArgumentException("pdoIndex 1..4");
+        };
+        return new CanFrame(cob, payload);
+    }
+
+    private static CanFrame heartbeatFrame(int nodeId, int nmtState) {
+        return new CanFrame(0x700 + nodeId, new byte[]{(byte) (nmtState & 0xff)});
+    }
+
+    private static byte[] int32ToBytes(int v) {
+        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(v).array();
+    }
+
+    private static byte[] uint16ToBytes(int v) {
+        return ByteBuffer.allocate(2).order(ByteOrder.LITTLE_ENDIAN)
+                .putShort((short) (v & 0xffff)).array();
+    }
+
+    private static SetpointSignal setpoint(String tag, double v) {
+        return new SetpointSignal(tag, v, 0.0, "test");
+    }
+
+    private static ActuatorCommandSignal actuator(String tag, double v, boolean execute) {
+        return new ActuatorCommandSignal(tag, v, 0.0, execute);
+    }
+
+    private static <K extends com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal>
+            IResult<K> result(K s) {
+        return new SimpleResultWrapper<>(s, 1L);
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/EdsParserTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/EdsParserTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link EdsParser} (13-CANOPEN.md §10 S8).
+ */
+class EdsParserTest {
+
+    /** §10 S8 — a real EDS-style fragment is parsed; OD type info is attached. */
+    @Test
+    void parsesStatuswordAndPositionActual() throws Exception {
+        // Trimmed Maxon EPOS4-style EDS fragment. CiA-301 §7.4.7 data-type IDs:
+        // 0x0006 = UINT16, 0x0004 = INT32.
+        String eds = """
+                [FileInfo]
+                FileName=test.eds
+
+                [DeviceInfo]
+                VendorName=Test
+
+                [6041]
+                ParameterName=Statusword
+                DataType=0x0006
+                AccessType=ro
+
+                [6064]
+                ParameterName=Position actual value
+                DataType=0x0004
+                AccessType=ro
+
+                [6081]
+                ParameterName=Profile velocity
+                DataType=0x0007
+                AccessType=rw
+                DefaultValue=1000
+
+                [Comments]
+                Lines=0
+                """;
+        Map<Integer, ObjectDictionaryEntry> od = EdsParser.parse(eds);
+
+        ObjectDictionaryEntry sw = od.get(0x6041 << 8);
+        assertNotNull(sw, "statusword entry must be discovered");
+        assertEquals(CanopenBridgeConfig.OdType.UINT16, sw.odType());
+        assertEquals(ObjectDictionaryEntry.OdAccess.RO, sw.access());
+
+        ObjectDictionaryEntry pos = od.get(0x6064 << 8);
+        assertNotNull(pos);
+        assertEquals(CanopenBridgeConfig.OdType.INT32, pos.odType());
+
+        ObjectDictionaryEntry pv = od.get(0x6081 << 8);
+        assertNotNull(pv);
+        assertEquals(CanopenBridgeConfig.OdType.UINT32, pv.odType());
+        assertEquals(ObjectDictionaryEntry.OdAccess.RW, pv.access());
+        assertEquals("1000", pv.defaultValue());
+    }
+
+    @Test
+    void parsesSubObjects() throws Exception {
+        String eds = """
+                [1018sub1]
+                ParameterName=VendorID
+                DataType=0x0007
+                AccessType=ro
+                """;
+        Map<Integer, ObjectDictionaryEntry> od = EdsParser.parse(eds);
+        ObjectDictionaryEntry e = od.get((0x1018 << 8) | 1);
+        assertNotNull(e);
+        assertEquals(1, e.subIndex());
+        assertEquals(CanopenBridgeConfig.OdType.UINT32, e.odType());
+    }
+
+    /** §10 R2 — unknown / vendor data types are dropped (rather than rejecting the whole file). */
+    @Test
+    void skipsUnknownDataTypes() throws Exception {
+        String eds = """
+                [2001]
+                ParameterName=VendorBlob
+                DataType=0x000F
+                AccessType=ro
+                """;
+        Map<Integer, ObjectDictionaryEntry> od = EdsParser.parse(eds);
+        assertNull(od.get(0x2001 << 8));
+        assertTrue(od.isEmpty());
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/InMemoryCanopenClientService.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/canopen/InMemoryCanopenClientService.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.canopen;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Test seam for the §10 acceptance scenarios: subclass of
+ * {@link AbstractCanopenClientService} that captures every outbound frame
+ * in {@link #sentFrames()} and lets tests inject inbound frames via the
+ * inherited {@link #onCanFrame(CanFrame)} entrypoint.
+ */
+final class InMemoryCanopenClientService extends AbstractCanopenClientService {
+
+    private final List<CanFrame> sentFrames = Collections.synchronizedList(new ArrayList<>());
+    private boolean failNextSend;
+
+    InMemoryCanopenClientService(CanopenBridgeConfig config, AbstractBridgeAuditOutput audit) {
+        super(config, audit);
+    }
+
+    @Override
+    protected boolean sendRawFrame(CanFrame frame) {
+        if (failNextSend) {
+            failNextSend = false;
+            return false;
+        }
+        sentFrames.add(frame);
+        return true;
+    }
+
+    void simulateNextSendFailure() { this.failNextSend = true; }
+
+    List<CanFrame> sentFrames() { return List.copyOf(sentFrames); }
+
+    int sendCount() { return sentFrames.size(); }
+}


### PR DESCRIPTION
Adds a read-and-advisory adapter between a CANopen network (CiA-301 / CiA-401 / CiA-402 / CiA-418 device profiles) and the Jneopallium signal pipeline. Structural ceiling is ADVISORY (§3, §11.13): the CiA-402 controlword (0x6040) is on a hard-coded forbidden list and every other write must clear a per-(nodeId, odIndex) allow-list at config load and again at runtime.

Components under worker/src/main/java/.../bridge/canopen/:

- CanopenBridgeConfig + CanopenBridgeConfigLoader — Jackson YAML records with FAIL_ON_UNKNOWN_PROPERTIES, two structural defences for writes.
- EdsParser + ObjectDictionaryEntry — permissive CiA-306 EDS parser covering CiA-301 §7.4.7 data-type IDs (UINT8..REAL32); unknown vendor types are skipped per §10 R2.
- CanopenSignalMapper — pure decoders for TPDO scalar, statusword (CiA-402 0x6041), EMCY (CiA-301 §7.2.1), and the standard error-code table (0x2310 = CONTINUOUS_OVER_CURRENT, etc.).
- CanopenClientService (interface) + AbstractCanopenClientService (orchestration) + SocketCanClientService / UsbCanClientService (platform backends with sink injection points).
- CanopenMeasurementInput / CanopenStateInput / CanopenEventInput, CanopenAuditOutput, CanopenAdvisoryOutputAggregator implementing the §2.2 algorithm.

Tests cover the universal §5 scenarios (S1, S2 quality propagation, S3 shadow, S4 reconnect, S5 audit isolation, S6 unknown tag) plus the bridge-specific §10 scenarios (S7 vcan read, S8 EDS parse, S9 heartbeat-loss alarm, S10 EMCY 0x2310 decode, S11 disallowed index rejected at load, S12 SDO write to allowed index). 25 new tests, full worker suite (694 tests) green.

https://claude.ai/code/session_01NxRJ5Zqx5EKn4vuLzXpa7z