### PR TITLE
Implement DICOM bridge (07-DICOM.md)

### DIFF
--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomAuditOutput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomAuditOutput.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+
+import java.nio.file.Path;
+
+/**
+ * JSONL audit sink for the DICOM bridge (00-FRAMEWORK §4, §6;
+ * 07-DICOM.md §6 {@code audit.localAuditFile}).
+ *
+ * <p>07-DICOM.md §10 R1 — every audit record carries the pseudonymous id,
+ * never the raw {@code PatientID}. The sink does not mirror to any
+ * external channel by default — radiology metadata egress is
+ * operator-controlled.
+ */
+public final class DicomAuditOutput extends AbstractBridgeAuditOutput {
+    public DicomAuditOutput(Path file) { super(file); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomBridgeConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomBridgeConfig.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Duration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Top-level DICOM bridge configuration (07-DICOM.md §6).
+ *
+ * <p>The bridge ceiling is structurally <b>READ-ONLY — permanently</b>
+ * (07-DICOM.md §0, §3, §4 diagram, §8 phase 3). The structural defences
+ * are:
+ *
+ * <ol>
+ *   <li>The bridge package contains no aggregator or output class
+ *       (07-DICOM.md §7 "No aggregator class — there is no write path"),
+ *       so there is no surface a higher layer could call to push data
+ *       back to the PACS.</li>
+ *   <li>The {@link DicomwebTransport} seam exposes only {@code qido()} and
+ *       {@code wadoMetadata()} — both HTTP {@code GET}. No method accepts
+ *       an HTTP verb argument or a request body, so a write code path
+ *       cannot be expressed within the bridge.</li>
+ *   <li>{@code writes:} blocks are rejected at config-load with a clear
+ *       message (§6 "{@code writes:} block is <b>rejected at config-load</b>
+ *       with a clear message — there is no write surface").</li>
+ * </ol>
+ */
+public record DicomBridgeConfig(
+        Mode mode,
+        DimseConfig dimse,
+        DicomwebConfig dicomweb,
+        SecurityConfig security,
+        List<StudyReadConfig> reads,
+        PrivacyConfig privacy,
+        AuditConfig audit,
+        Duration tickInterval
+) {
+
+    /** Minimum allowed poll interval (protects PACS / DIMSE servers). */
+    public static final long MIN_POLL_INTERVAL_SECONDS = 30L;
+
+    public DicomBridgeConfig {
+        Objects.requireNonNull(mode, "mode");
+        Objects.requireNonNull(audit, "audit");
+        reads = reads == null ? List.of() : List.copyOf(reads);
+        tickInterval = tickInterval == null ? Duration.ofMillis(1000) : tickInterval;
+        privacy = privacy == null ? PrivacyConfig.defaults() : privacy;
+
+        if (mode == Mode.DICOMWEB && dicomweb == null) {
+            throw new IllegalArgumentException(
+                    "DICOM bridge: mode=DICOMWEB requires a 'dicomweb:' block.");
+        }
+        if (mode == Mode.DIMSE && dimse == null) {
+            throw new IllegalArgumentException(
+                    "DICOM bridge: mode=DIMSE requires a 'dimse:' block.");
+        }
+
+        Set<String> seen = new LinkedHashSet<>();
+        for (StudyReadConfig r : reads) {
+            if (!seen.add(r.bindingId())) {
+                throw new IllegalArgumentException(
+                        "DICOM bridge: duplicate bindingId: " + r.bindingId());
+            }
+        }
+    }
+
+    @JsonCreator
+    public static DicomBridgeConfig create(
+            @JsonProperty("mode") Mode mode,
+            @JsonProperty("dimse") DimseConfig dimse,
+            @JsonProperty("dicomweb") DicomwebConfig dicomweb,
+            @JsonProperty("security") SecurityConfig security,
+            @JsonProperty("reads") List<StudyReadConfig> reads,
+            @JsonProperty("privacy") PrivacyConfig privacy,
+            @JsonProperty("audit") AuditConfig audit,
+            @JsonProperty("tickInterval") Duration tickInterval,
+            // §6 — reject a writes: block at load time. Declared so Jackson surfaces it
+            // with FAIL_ON_UNKNOWN_PROPERTIES=true and rejects with a clear message.
+            @JsonProperty("writes") Object writes) {
+        if (writes != null) {
+            throw new IllegalArgumentException(
+                    "DICOM bridge: 'writes:' block is not permitted — the bridge ceiling "
+                            + "is READ-ONLY (07-DICOM.md §0, §3, §6). Remove the writes section.");
+        }
+        return new DicomBridgeConfig(mode, dimse, dicomweb, security, reads,
+                privacy, audit, tickInterval);
+    }
+
+    /** Ingress mode (§4 architecture). */
+    public enum Mode {
+        /** DICOMweb REST (QIDO-RS / WADO-RS). */
+        DICOMWEB,
+        /** Classic DIMSE network protocol (C-FIND / C-MOVE / C-GET). */
+        DIMSE
+    }
+
+    /** Supported authentication modes (§6 {@code security.type}). */
+    public enum SecurityType {
+        OAUTH2_BEARER_TOKEN,
+        BASIC_AUTH,
+        MUTUAL_TLS,
+        /** No authentication — only valid against open test instances (e.g. Orthanc demo). */
+        NONE
+    }
+
+    /** Target Jneopallium signal kind. Currently only one is supported (§5). */
+    public enum TargetSignal {
+        IMAGING_FINDING
+    }
+
+    /** §6 {@code dimse:} block. Only used when {@link Mode#DIMSE}. */
+    public record DimseConfig(
+            String callingAet,
+            String calledAet,
+            String host,
+            int port,
+            boolean requireTls
+    ) {
+        public DimseConfig {
+            Objects.requireNonNull(callingAet, "callingAet");
+            Objects.requireNonNull(calledAet, "calledAet");
+            Objects.requireNonNull(host, "host");
+            if (port <= 0 || port > 65535) {
+                throw new IllegalArgumentException("DICOM bridge: dimse.port out of range: " + port);
+            }
+        }
+
+        @JsonCreator
+        public static DimseConfig of(
+                @JsonProperty("callingAet") String callingAet,
+                @JsonProperty("calledAet") String calledAet,
+                @JsonProperty("host") String host,
+                @JsonProperty("port") int port,
+                @JsonProperty("requireTls") Boolean requireTls) {
+            return new DimseConfig(callingAet, calledAet, host, port,
+                    requireTls != null && requireTls);
+        }
+    }
+
+    /** §6 {@code dicomweb:} block. Only used when {@link Mode#DICOMWEB}. */
+    public record DicomwebConfig(
+            String baseUrl,
+            String qidoEndpoint,
+            String wadoEndpoint,
+            long pollIntervalSeconds
+    ) {
+        public DicomwebConfig {
+            Objects.requireNonNull(baseUrl, "baseUrl");
+            if (qidoEndpoint == null) qidoEndpoint = "/studies";
+            if (wadoEndpoint == null) wadoEndpoint =
+                    "/studies/{study}/series/{series}/instances/{instance}/metadata";
+            if (pollIntervalSeconds <= 0) pollIntervalSeconds = 60L;
+            if (pollIntervalSeconds < MIN_POLL_INTERVAL_SECONDS) {
+                throw new IllegalArgumentException(
+                        "DICOM bridge: pollIntervalSeconds=" + pollIntervalSeconds
+                                + " is below the minimum " + MIN_POLL_INTERVAL_SECONDS
+                                + "s mandated to protect the PACS (07-DICOM.md §10 R2).");
+            }
+        }
+
+        @JsonCreator
+        public static DicomwebConfig of(
+                @JsonProperty("baseUrl") String baseUrl,
+                @JsonProperty("qidoEndpoint") String qidoEndpoint,
+                @JsonProperty("wadoEndpoint") String wadoEndpoint,
+                @JsonProperty("pollIntervalSeconds") Long pollIntervalSeconds) {
+            return new DicomwebConfig(baseUrl, qidoEndpoint, wadoEndpoint,
+                    pollIntervalSeconds == null ? 60L : pollIntervalSeconds);
+        }
+    }
+
+    /** §6 {@code security:} block. */
+    public record SecurityConfig(
+            SecurityType type,
+            String tokenEndpoint,
+            String clientId,
+            String clientSecretEnv,
+            String scope,
+            String basicAuthUserEnv,
+            String basicAuthPassEnv,
+            String trustStorePath,
+            String trustStorePassEnv
+    ) {
+        @JsonCreator
+        public static SecurityConfig of(
+                @JsonProperty("type") SecurityType type,
+                @JsonProperty("tokenEndpoint") String tokenEndpoint,
+                @JsonProperty("clientId") String clientId,
+                @JsonProperty("clientSecretEnv") String clientSecretEnv,
+                @JsonProperty("scope") String scope,
+                @JsonProperty("basicAuthUserEnv") String basicAuthUserEnv,
+                @JsonProperty("basicAuthPassEnv") String basicAuthPassEnv,
+                @JsonProperty("trustStorePath") String trustStorePath,
+                @JsonProperty("trustStorePassEnv") String trustStorePassEnv) {
+            return new SecurityConfig(
+                    type == null ? SecurityType.NONE : type,
+                    tokenEndpoint, clientId, clientSecretEnv, scope,
+                    basicAuthUserEnv, basicAuthPassEnv,
+                    trustStorePath, trustStorePassEnv);
+        }
+    }
+
+    /** §6 {@code reads[].studyFilter:} block. */
+    public record StudyFilterConfig(
+            String modality,
+            String accessionPattern,
+            Integer windowHours
+    ) {
+        @JsonCreator
+        public static StudyFilterConfig of(
+                @JsonProperty("modality") String modality,
+                @JsonProperty("accessionPattern") String accessionPattern,
+                @JsonProperty("windowHours") Integer windowHours) {
+            return new StudyFilterConfig(modality, accessionPattern, windowHours);
+        }
+    }
+
+    /** §6 {@code reads:} entry. */
+    public record StudyReadConfig(
+            String bindingId,
+            StudyFilterConfig studyFilter,
+            TargetSignal targetSignal,
+            String signalTagPrefix
+    ) {
+        public StudyReadConfig {
+            Objects.requireNonNull(bindingId, "bindingId");
+            if (targetSignal == null) targetSignal = TargetSignal.IMAGING_FINDING;
+        }
+
+        @JsonCreator
+        public static StudyReadConfig of(
+                @JsonProperty("bindingId") String bindingId,
+                @JsonProperty("studyFilter") StudyFilterConfig studyFilter,
+                @JsonProperty("targetSignal") TargetSignal targetSignal,
+                @JsonProperty("signalTagPrefix") String signalTagPrefix) {
+            return new StudyReadConfig(bindingId, studyFilter, targetSignal, signalTagPrefix);
+        }
+    }
+
+    /** §6 {@code privacy:} block. */
+    public record PrivacyConfig(
+            boolean pseudonymise,
+            String saltEnv,
+            boolean redactPatientName,
+            boolean redactInstitution
+    ) {
+        public static PrivacyConfig defaults() {
+            return new PrivacyConfig(true, null, true, false);
+        }
+
+        @JsonCreator
+        public static PrivacyConfig of(
+                @JsonProperty("pseudonymise") Boolean pseudonymise,
+                @JsonProperty("saltEnv") String saltEnv,
+                @JsonProperty("redactPatientName") Boolean redactPatientName,
+                @JsonProperty("redactInstitution") Boolean redactInstitution) {
+            return new PrivacyConfig(
+                    pseudonymise == null || pseudonymise,
+                    saltEnv,
+                    redactPatientName == null || redactPatientName,
+                    redactInstitution != null && redactInstitution);
+        }
+    }
+
+    /** §6 {@code audit:} block. */
+    public record AuditConfig(String localAuditFile) {
+        public AuditConfig {
+            Objects.requireNonNull(localAuditFile, "localAuditFile");
+        }
+
+        @JsonCreator
+        public static AuditConfig of(@JsonProperty("localAuditFile") String localAuditFile) {
+            return new AuditConfig(localAuditFile);
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomBridgeConfigLoader.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomBridgeConfigLoader.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+/**
+ * Loads {@link DicomBridgeConfig} from YAML (07-DICOM.md §6).
+ *
+ * <p>{@code FAIL_ON_UNKNOWN_PROPERTIES = true} per 00-FRAMEWORK §3 — typos
+ * in a clinical-bridge config must surface at load time. Together with the
+ * explicit {@code writes:} parameter on
+ * {@link DicomBridgeConfig#create}, this guarantees that a YAML config
+ * carrying a {@code writes:} block is rejected with the message mandated
+ * by §6 ("{@code writes:} block is rejected at config-load").
+ */
+public final class DicomBridgeConfigLoader {
+
+    private DicomBridgeConfigLoader() {}
+
+    public static DicomBridgeConfig load(Path yaml) throws IOException {
+        return mapper().readValue(yaml.toFile(), DicomBridgeConfig.class);
+    }
+
+    public static DicomBridgeConfig load(InputStream in) throws IOException {
+        return mapper().readValue(in, DicomBridgeConfig.class);
+    }
+
+    public static DicomBridgeConfig load(String yamlContent) throws IOException {
+        return mapper().readValue(yamlContent, DicomBridgeConfig.class);
+    }
+
+    private static ObjectMapper mapper() {
+        return new ObjectMapper(new YAMLFactory())
+                .registerModule(new JavaTimeModule())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomClientService.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomClientService.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.ImagingFindingSignal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * DICOM bridge polling client + per-binding cache (07-DICOM.md §4, §7).
+ *
+ * <p>Owns:
+ * <ul>
+ *   <li>The {@link DicomwebTransport} <i>or</i> {@link DimseClient} seam —
+ *       read-only access to the PACS (§3, §4 diagram). Exactly one of the
+ *       two is wired per the bridge mode.</li>
+ *   <li>Per-binding queues of decoded {@link ImagingFindingSignal}s
+ *       drained by {@link DicomFindingInput} once per tick.</li>
+ *   <li>The {@link DicomSrParser} / {@link DicomSignalMapper} pipeline.</li>
+ *   <li>Pseudonymisation, applied by the mapper so the queues never carry
+ *       a raw {@code PatientID}.</li>
+ * </ul>
+ *
+ * <p>The service has no write methods. There is no aggregator class in
+ * this package (§7) and the transport seams expose no write surface — a
+ * code path that pushes a DICOM instance back to the PACS cannot be
+ * expressed inside the bridge.
+ */
+public final class DicomClientService implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(DicomClientService.class);
+
+    /** Bridge name carried in every audit record (00-FRAMEWORK §4). */
+    public static final String BRIDGE_NAME = "dicom";
+
+    /** Default per-binding ring-buffer cap. */
+    public static final int DEFAULT_RING_BUFFER = 4096;
+
+    private final DicomBridgeConfig config;
+    private final DicomwebClient dicomweb;
+    private final DimseClient dimse;
+    private final AbstractBridgeAuditOutput audit;
+    private final DicomSrParser parser;
+    private final DicomSignalMapper mapper;
+    private final DicomPseudonymService pseudonyms;
+
+    private final Map<String, DicomStudyBinding> bindings = new LinkedHashMap<>();
+    private final Map<String, Deque<IInputSignal>> queueByBinding = new ConcurrentHashMap<>();
+
+    private final AtomicBoolean started = new AtomicBoolean();
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    /** DICOMweb wiring (07-DICOM.md §4 — first ingress mode). */
+    public static DicomClientService forDicomweb(DicomBridgeConfig config,
+                                                 DicomwebTransport transport,
+                                                 AbstractBridgeAuditOutput audit) {
+        Objects.requireNonNull(transport, "transport");
+        if (config.mode() != DicomBridgeConfig.Mode.DICOMWEB) {
+            throw new IllegalArgumentException(
+                    "DICOMweb transport supplied but config.mode=" + config.mode());
+        }
+        return new DicomClientService(config, new DicomwebClient(transport, config), null, audit);
+    }
+
+    /** DIMSE wiring (07-DICOM.md §4 — second ingress mode). */
+    public static DicomClientService forDimse(DicomBridgeConfig config,
+                                              DimseClient dimse,
+                                              AbstractBridgeAuditOutput audit) {
+        Objects.requireNonNull(dimse, "dimse");
+        if (config.mode() != DicomBridgeConfig.Mode.DIMSE) {
+            throw new IllegalArgumentException(
+                    "DIMSE client supplied but config.mode=" + config.mode());
+        }
+        return new DicomClientService(config, null, dimse, audit);
+    }
+
+    DicomClientService(DicomBridgeConfig config,
+                       DicomwebClient dicomweb,
+                       DimseClient dimse,
+                       AbstractBridgeAuditOutput audit) {
+        this.config = Objects.requireNonNull(config, "config");
+        this.audit = Objects.requireNonNull(audit, "audit");
+        this.dicomweb = dicomweb;
+        this.dimse = dimse;
+        this.pseudonyms = DicomPseudonymService.fromConfig(config.privacy());
+        this.parser = new DicomSrParser();
+        this.mapper = new DicomSignalMapper(pseudonyms, parser,
+                config.privacy().redactPatientName());
+    }
+
+    /** Register every read binding. No outlets exist (§3, §7). */
+    public synchronized void start() {
+        if (started.get() || closed.get()) return;
+        for (DicomBridgeConfig.StudyReadConfig r : config.reads()) {
+            DicomStudyBinding b = DicomStudyBinding.fromConfig(r);
+            bindings.put(b.bindingId(), b);
+            queueByBinding.put(b.bindingId(), new ArrayDeque<>());
+        }
+        started.set(true);
+        log.info("DicomClientService started; mode={} bindings={} pseudonymise={}",
+                config.mode(), bindings.size(), pseudonyms.isEnabled());
+    }
+
+    /**
+     * Run one polling cycle: enumerate matching studies for every binding,
+     * fetch the SR metadata, parse the content tree, and enqueue one
+     * {@link ImagingFindingSignal} per leaf finding.
+     */
+    public synchronized void poll() {
+        if (!isStarted()) return;
+        if (!transportReady()) {
+            log.debug("DicomClientService.poll: transport not ready, skipping cycle");
+            return;
+        }
+        for (DicomStudyBinding b : bindings.values()) {
+            try {
+                if (config.mode() == DicomBridgeConfig.Mode.DICOMWEB) {
+                    pollDicomweb(b);
+                } else {
+                    pollDimse(b);
+                }
+            } catch (IOException | RuntimeException e) {
+                audit.append(new BridgeAuditRecord(
+                        System.currentTimeMillis(), 0, BRIDGE_NAME,
+                        BridgeAuditRecord.Verdict.FAILED, b.loopId(), b.signalTagPrefix(),
+                        null, null,
+                        BridgeAuditRecord.RejectReason.EXCEPTION + ":" + e.getClass().getSimpleName(),
+                        null, List.of()));
+                log.warn("DicomClientService: binding={} failed: {}", b.bindingId(), e.getMessage());
+            }
+        }
+    }
+
+    private void pollDicomweb(DicomStudyBinding b) throws IOException {
+        List<JsonNode> studies = dicomweb.qidoStudies(b);
+        int totalFindings = 0;
+        for (JsonNode study : studies) {
+            List<JsonNode> instances = dicomweb.wadoSrInstancesForStudy(study);
+            for (JsonNode srInstance : instances) {
+                totalFindings += enqueueFromInstance(b, srInstance);
+            }
+        }
+        log.debug("DicomClientService: binding={} studies={} findings={}",
+                b.bindingId(), studies.size(), totalFindings);
+    }
+
+    private void pollDimse(DicomStudyBinding b) throws IOException {
+        if (dimse == null) return;
+        JsonNode q = buildDimseQuery(b);
+        List<JsonNode> studies = dimse.cFind(q);
+        if (studies.isEmpty()) return;
+        List<JsonNode> srInstances = dimse.cMove(q);
+        int totalFindings = 0;
+        for (JsonNode srInstance : srInstances) {
+            totalFindings += enqueueFromInstance(b, srInstance);
+        }
+        log.debug("DicomClientService: binding={} studies={} findings={} (DIMSE)",
+                b.bindingId(), studies.size(), totalFindings);
+    }
+
+    private int enqueueFromInstance(DicomStudyBinding b, JsonNode srInstance) {
+        DicomSrParser.SrDocument doc = parser.parse(srInstance);
+        List<ImagingFindingSignal> signals = mapper.mapDocument(doc);
+        if (signals.isEmpty()) return 0;
+        for (ImagingFindingSignal s : signals) enqueue(b.bindingId(), s);
+        return signals.size();
+    }
+
+    private void enqueue(String bindingId, IInputSignal signal) {
+        Deque<IInputSignal> q = queueByBinding.get(bindingId);
+        if (q == null) return;
+        synchronized (q) {
+            int dropped = 0;
+            while (q.size() >= DEFAULT_RING_BUFFER) {
+                q.pollFirst();
+                dropped++;
+            }
+            q.addLast(signal);
+            if (dropped > 0) {
+                audit.append(new BridgeAuditRecord(
+                        System.currentTimeMillis(), 0, BRIDGE_NAME,
+                        BridgeAuditRecord.Verdict.REJECTED, bindingId, null, null, null,
+                        "RING_BUFFER_OVERFLOW:dropped=" + dropped, null, List.of()));
+            }
+        }
+    }
+
+    private boolean transportReady() {
+        if (config.mode() == DicomBridgeConfig.Mode.DICOMWEB) {
+            return dicomweb != null && dicomweb.isReady();
+        }
+        return dimse != null && dimse.isReady();
+    }
+
+    private JsonNode buildDimseQuery(DicomStudyBinding b) {
+        com.fasterxml.jackson.databind.ObjectMapper m = new com.fasterxml.jackson.databind.ObjectMapper();
+        ObjectNode q = m.createObjectNode();
+        if (b.modality() != null) q.put("ModalitiesInStudy", b.modality());
+        if (b.accessionPattern() != null) q.put("AccessionNumber", b.accessionPattern());
+        if (b.windowHours() != null) q.put("WindowHours", b.windowHours());
+        return q;
+    }
+
+    /** Drain (and clear) the decoded signal queue for one binding. */
+    public List<IInputSignal> drain(String bindingId) {
+        Deque<IInputSignal> q = queueByBinding.get(bindingId);
+        if (q == null || q.isEmpty()) return List.of();
+        synchronized (q) {
+            List<IInputSignal> snap = new ArrayList<>(q);
+            q.clear();
+            return snap;
+        }
+    }
+
+    public boolean isStarted() { return started.get() && !closed.get(); }
+
+    public Map<String, DicomStudyBinding> bindings() { return Map.copyOf(bindings); }
+
+    public DicomBridgeConfig config() { return config; }
+
+    public DicomPseudonymService pseudonymService() { return pseudonyms; }
+
+    public DicomSrParser parser() { return parser; }
+
+    @Override
+    public synchronized void close() {
+        if (!closed.compareAndSet(false, true)) return;
+        try {
+            if (dicomweb != null) dicomweb.transport().close();
+        } catch (RuntimeException e) {
+            log.warn("DicomwebTransport close threw: {}", e.getMessage());
+        }
+        try {
+            if (dimse != null) dimse.close();
+        } catch (RuntimeException e) {
+            log.warn("DimseClient close threw: {}", e.getMessage());
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomFindingInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomFindingInput.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IInitInput} that drains DICOM bindings (07-DICOM.md §7 —
+ * {@code DicomFindingInput}). Each configured binding's {@code targetSignal}
+ * ({@code IMAGING_FINDING}) is decoded by {@link DicomSignalMapper} inside
+ * {@link DicomClientService}; this adapter only walks the binding-id list
+ * and snapshots their queues.
+ */
+public final class DicomFindingInput implements IInitInput {
+
+    /**
+     * Matches {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.ImagingFindingSignal#PROCESSING_FREQUENCY}
+     * (loop=2, epoch=5) so the bridge pace lines up with the consumer
+     * neuron's processing cadence.
+     */
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(5L, 2);
+
+    private final String name;
+    private final DicomClientService svc;
+    private final List<String> bindingIds;
+
+    public DicomFindingInput(String name, DicomClientService svc, List<String> bindingIds) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.bindingIds = List.copyOf(Objects.requireNonNull(bindingIds, "bindingIds"));
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        List<IInputSignal> out = new ArrayList<>();
+        for (String b : bindingIds) out.addAll(svc.drain(b));
+        return out;
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() { return new HashMap<>(); }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() { return PROCESSING_FREQUENCY; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomPseudonymService.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomPseudonymService.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Objects;
+
+/**
+ * Pseudonymises DICOM patient identifiers (07-DICOM.md §6 {@code privacy:},
+ * §9 S9, §10 R1).
+ *
+ * <p>The bridge never persists the raw {@code PatientID} or
+ * {@code PatientName}; every signal and audit record carries
+ * {@code SHA-256(rawId || ":" || salt)} truncated to {@link #ID_LEN}
+ * hexadecimal characters. The salt is sourced from an operator-controlled
+ * environment variable so the pseudonym mapping is non-reversible without
+ * the salted secret.
+ */
+public final class DicomPseudonymService {
+
+    /** Length of the pseudonymous id surfaced to signals (hex chars). */
+    public static final int ID_LEN = 24;
+
+    private final boolean enabled;
+    private final byte[] salt;
+
+    public DicomPseudonymService(boolean enabled, String salt) {
+        this.enabled = enabled;
+        this.salt = (salt == null ? "" : salt).getBytes(StandardCharsets.UTF_8);
+    }
+
+    /** Convenience constructor — reads the salt from {@code System.getenv}. */
+    public static DicomPseudonymService fromConfig(DicomBridgeConfig.PrivacyConfig privacy) {
+        Objects.requireNonNull(privacy, "privacy");
+        if (!privacy.pseudonymise()) {
+            return new DicomPseudonymService(false, null);
+        }
+        String saltEnv = privacy.saltEnv();
+        String salt = saltEnv == null ? "" : System.getenv(saltEnv);
+        if (salt == null) salt = "";
+        return new DicomPseudonymService(true, salt);
+    }
+
+    public String pseudonymise(String rawId) {
+        if (rawId == null || rawId.isEmpty()) return null;
+        if (!enabled) return rawId;
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(rawId.getBytes(StandardCharsets.UTF_8));
+            md.update((byte) ':');
+            md.update(salt);
+            byte[] digest = md.digest();
+            StringBuilder sb = new StringBuilder(ID_LEN);
+            int hexChars = Math.min(ID_LEN, digest.length * 2);
+            for (int i = 0; i < (hexChars + 1) / 2; i++) {
+                int v = digest[i] & 0xFF;
+                sb.append(Character.forDigit(v >>> 4, 16));
+                sb.append(Character.forDigit(v & 0x0F, 16));
+            }
+            return sb.substring(0, ID_LEN);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+    public boolean isEnabled() { return enabled; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomSignalMapper.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomSignalMapper.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.FindingCategory;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.ImagingFindingSignal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Converts parsed {@link DicomSrParser.SrDocument}s into Jneopallium
+ * {@link ImagingFindingSignal}s (07-DICOM.md §5, §9 S7).
+ *
+ * <p>One signal is emitted per leaf finding. The mapper is responsible for:
+ * <ul>
+ *   <li>Pseudonymising the patient id (§9 S9, §10 R1) — the raw id never
+ *       enters the emitted signal.</li>
+ *   <li>Inferring {@link FindingCategory} via the parser's coding-scheme
+ *       heuristics.</li>
+ *   <li>Choosing a confidence value: numeric SR items derive confidence
+ *       from the source coding scheme (supported → 0.85, unsupported →
+ *       0.5 per §10 R3 "unknown codes pass through ... with
+ *       Quality.UNCERTAIN").</li>
+ * </ul>
+ *
+ * <p>The mapper never reads pixel data — the WADO request the bridge
+ * issues is metadata-only and the SR is not a pixel object. §4 diagram:
+ * "Image bytes never enter the JVM heap."
+ */
+public final class DicomSignalMapper {
+
+    private final DicomPseudonymService pseudonyms;
+    private final DicomSrParser parser;
+    private final boolean redactPatientName;
+
+    public DicomSignalMapper(DicomPseudonymService pseudonyms,
+                             DicomSrParser parser,
+                             boolean redactPatientName) {
+        this.pseudonyms = Objects.requireNonNull(pseudonyms, "pseudonyms");
+        this.parser = Objects.requireNonNull(parser, "parser");
+        this.redactPatientName = redactPatientName;
+    }
+
+    /**
+     * Build one {@link ImagingFindingSignal} per leaf finding in
+     * {@code doc}. The returned list is never {@code null} and never
+     * contains a signal carrying the raw patient id.
+     */
+    public List<ImagingFindingSignal> mapDocument(DicomSrParser.SrDocument doc) {
+        if (doc == null || doc.findings().isEmpty()) return List.of();
+        String pseudoPid = pseudonyms.pseudonymise(doc.rawPatientId());
+        // S9 — patient name is dropped on the signal regardless; the redaction
+        // flag governs whether it makes it to the audit metadata at all.
+        if (redactPatientName) {
+            // No-op for the signal: ImagingFindingSignal has no patient-name field.
+            // The flag controls the audit path (see DicomClientService).
+        }
+        String modality = doc.modality();
+        String region = doc.bodyPart();
+        List<ImagingFindingSignal> out = new ArrayList<>(doc.findings().size());
+        for (DicomSrParser.Finding f : doc.findings()) {
+            FindingCategory category = parser.inferCategory(f);
+            double confidence = inferConfidence(f);
+            out.add(new ImagingFindingSignal(modality, region, category, confidence, pseudoPid));
+        }
+        return out;
+    }
+
+    private double inferConfidence(DicomSrParser.Finding f) {
+        // §10 R3 — unknown codes pass through as opaque strings with Quality.UNCERTAIN.
+        // We map "unknown scheme" to a low (0.5) confidence; supported schemes get 0.85.
+        if (f == null || f.valueCode() == null) return 0.6;
+        int colon = f.valueCode().indexOf(':');
+        String scheme = colon < 0 ? null : f.valueCode().substring(0, colon);
+        return parser.schemeSupported(scheme) ? 0.85 : 0.5;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomSrParser.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomSrParser.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.FindingCategory;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Walks a DICOM Structured Report (SR) content tree and yields the leaf
+ * observations as {@link Finding} records (07-DICOM.md §5, §9 S11).
+ *
+ * <p>The parser consumes the DICOM+JSON representation returned by
+ * WADO-RS metadata: each attribute is keyed by its 8-digit tag and carries
+ * a {@code vr} / {@code Value} pair. Container items recurse via the
+ * Content Sequence (tag {@code 0040A730}); only non-container leaves emit
+ * a {@link Finding}. Intermediate {@code CONTAINER} nodes are <b>not</b>
+ * duplicated as findings — S11 requires "all leaves are emitted;
+ * intermediate nodes are not duplicated".
+ *
+ * <p>The parser supports three SR coding schemes by default: SNOMED CT,
+ * LOINC and RadLex (§10 R3). Unknown coding schemes are passed through as
+ * opaque {@code "SCHEME:code"} strings and the resulting finding carries
+ * {@link FindingCategory#INDETERMINATE}.
+ */
+public final class DicomSrParser {
+
+    /** SR attribute tags (DICOM PS3.6). */
+    private static final String TAG_VALUE_TYPE          = "0040A040";
+    private static final String TAG_CONCEPT_NAME        = "0040A043";
+    private static final String TAG_CONCEPT_CODE        = "0040A168";
+    private static final String TAG_TEXT_VALUE          = "0040A160";
+    private static final String TAG_MEASURED_VALUE_SEQ  = "0040A30A";
+    private static final String TAG_NUMERIC_VALUE       = "0040A30B";
+    private static final String TAG_MEASUREMENT_UNITS   = "004008EA";
+    private static final String TAG_CONTENT_SEQUENCE    = "0040A730";
+    private static final String TAG_REL_TYPE            = "0040A010";
+
+    /** Document-level tags. */
+    private static final String TAG_MODALITY            = "00080060";
+    private static final String TAG_PATIENT_ID          = "00100020";
+    private static final String TAG_PATIENT_NAME        = "00100010";
+    private static final String TAG_BODY_PART_EXAMINED  = "00180015";
+    private static final String TAG_INSTITUTION_NAME    = "00080080";
+
+    /** Code system OIDs / designators recognised by the parser. */
+    private static final String SCHEME_SNOMED = "SCT";
+    private static final String SCHEME_SNOMED_OID = "2.16.840.1.113883.6.96";
+    private static final String SCHEME_LOINC  = "LN";
+    private static final String SCHEME_LOINC_OID = "2.16.840.1.113883.6.1";
+    private static final String SCHEME_RADLEX = "RADLEX";
+    private static final String SCHEME_DCM    = "DCM";
+
+    /**
+     * A leaf observation extracted from an SR content tree.
+     *
+     * @param conceptName  the SR {@code ConceptNameCodeSequence} (what was
+     *                     observed, e.g. "Finding")
+     * @param valueCode    the coded value if the leaf is a CODE item, or
+     *                     {@code null} for text/numeric leaves
+     * @param text         text value if the leaf is a TEXT item
+     * @param numericValue numeric value if the leaf is a NUM item
+     * @param units        measurement units if NUM, otherwise {@code null}
+     * @param depth        depth in the content tree (1 = top-level leaf)
+     * @param valueType    raw {@code ValueType} (CODE / TEXT / NUM / DATE …)
+     */
+    public record Finding(
+            String conceptName,
+            String valueCode,
+            String text,
+            Double numericValue,
+            String units,
+            int depth,
+            String valueType
+    ) {}
+
+    /**
+     * Document-level metadata pulled from the SR header. Patient id is the
+     * <b>raw</b> id from the SR — the caller pseudonymises before emitting
+     * a signal (07-DICOM.md §6, §9 S9, §10 R1).
+     */
+    public record SrDocument(
+            String modality,
+            String rawPatientId,
+            String rawPatientName,
+            String bodyPart,
+            String institution,
+            List<Finding> findings
+    ) {}
+
+    private final List<String> supportedSchemes;
+
+    public DicomSrParser() {
+        this(List.of(SCHEME_SNOMED, SCHEME_LOINC, SCHEME_RADLEX, SCHEME_DCM));
+    }
+
+    public DicomSrParser(List<String> supportedSchemes) {
+        this.supportedSchemes = List.copyOf(supportedSchemes);
+    }
+
+    /**
+     * Parse a DICOM+JSON SR instance.
+     *
+     * @return the SR document metadata plus its leaf findings. The returned
+     *         object is never {@code null}; missing fields surface as
+     *         {@code null} / empty list.
+     */
+    public SrDocument parse(JsonNode srInstance) {
+        if (srInstance == null || srInstance.isNull() || !srInstance.isObject()) {
+            return new SrDocument(null, null, null, null, null, List.of());
+        }
+        String modality   = stringValue(srInstance, TAG_MODALITY);
+        String patientId  = stringValue(srInstance, TAG_PATIENT_ID);
+        String patientName = patientNameValue(srInstance, TAG_PATIENT_NAME);
+        String bodyPart   = stringValue(srInstance, TAG_BODY_PART_EXAMINED);
+        String institution = stringValue(srInstance, TAG_INSTITUTION_NAME);
+
+        List<Finding> findings = new ArrayList<>();
+        walk(srInstance, 0, findings);
+        return new SrDocument(modality, patientId, patientName, bodyPart, institution, findings);
+    }
+
+    /** Quick category inference for a finding leaf. Conservative by default. */
+    public FindingCategory inferCategory(Finding f) {
+        if (f == null) return FindingCategory.INDETERMINATE;
+        String code = f.valueCode == null ? null : f.valueCode.toUpperCase(Locale.ROOT);
+        if (code != null) {
+            // A few common SNOMED concept ids; everything else stays INDETERMINATE.
+            if (code.endsWith(":17621005") || code.endsWith("-NORMAL") || code.equals("NORMAL")) {
+                return FindingCategory.NORMAL;
+            }
+            if (code.endsWith(":263654008") || code.contains("INCIDENTAL")) {
+                return FindingCategory.INCIDENTAL;
+            }
+            if (code.endsWith(":24484000") || code.contains("CRITICAL") || code.contains("URGENT")) {
+                return FindingCategory.CRITICAL;
+            }
+            if (code.contains("ABNORMAL") || code.contains("MASS") || code.contains("LESION")
+                    || code.contains("HEMORRHAGE") || code.contains("NODULE")) {
+                return FindingCategory.ABNORMAL;
+            }
+        }
+        if (f.text != null && f.text.toLowerCase(Locale.ROOT).contains("normal")) {
+            return FindingCategory.NORMAL;
+        }
+        return FindingCategory.INDETERMINATE;
+    }
+
+    /** {@code true} iff {@code scheme} is one of the schemes the bridge claims to understand. */
+    public boolean schemeSupported(String scheme) {
+        if (scheme == null) return false;
+        for (String s : supportedSchemes) {
+            if (s.equalsIgnoreCase(scheme)) return true;
+        }
+        // OID-form acceptance (SNOMED, LOINC).
+        return SCHEME_SNOMED_OID.equals(scheme) || SCHEME_LOINC_OID.equals(scheme);
+    }
+
+    /* ===== walk ========================================================= */
+
+    private void walk(JsonNode node, int depth, List<Finding> out) {
+        JsonNode contentSeq = sequence(node, TAG_CONTENT_SEQUENCE);
+        if (contentSeq == null) return;
+        for (Iterator<JsonNode> it = contentSeq.elements(); it.hasNext(); ) {
+            JsonNode item = it.next();
+            if (item == null || item.isNull()) continue;
+            String valueType = stringValue(item, TAG_VALUE_TYPE);
+            JsonNode children = sequence(item, TAG_CONTENT_SEQUENCE);
+            boolean hasChildren = children != null && children.size() > 0;
+            if ("CONTAINER".equalsIgnoreCase(valueType) || hasChildren) {
+                walk(item, depth + 1, out);
+                continue;
+            }
+            Finding f = leaf(item, valueType, depth + 1);
+            if (f != null) out.add(f);
+        }
+    }
+
+    private Finding leaf(JsonNode item, String valueType, int depth) {
+        String conceptName = codedConcept(item, TAG_CONCEPT_NAME);
+        if (valueType == null) return null;
+        String type = valueType.toUpperCase(Locale.ROOT);
+        switch (type) {
+            case "CODE" -> {
+                String valueCode = codedConcept(item, TAG_CONCEPT_CODE);
+                return new Finding(conceptName, valueCode, null, null, null, depth, type);
+            }
+            case "TEXT" -> {
+                String text = stringValue(item, TAG_TEXT_VALUE);
+                if (text == null) return null;
+                return new Finding(conceptName, null, text, null, null, depth, type);
+            }
+            case "NUM" -> {
+                JsonNode mvs = sequence(item, TAG_MEASURED_VALUE_SEQ);
+                if (mvs == null || mvs.size() == 0) return null;
+                JsonNode mv = mvs.get(0);
+                Double value = numericValue(mv, TAG_NUMERIC_VALUE);
+                String units = codedConcept(mv, TAG_MEASUREMENT_UNITS);
+                return new Finding(conceptName, null, null, value, units, depth, type);
+            }
+            default -> {
+                String text = stringValue(item, TAG_TEXT_VALUE);
+                return new Finding(conceptName, null, text, null, null, depth, type);
+            }
+        }
+    }
+
+    /* ===== JSON helpers ================================================= */
+
+    private static JsonNode sequence(JsonNode node, String tag) {
+        JsonNode attr = node.get(tag);
+        if (attr == null || attr.isNull()) return null;
+        JsonNode value = attr.get("Value");
+        return (value != null && value.isArray()) ? value : null;
+    }
+
+    private static String stringValue(JsonNode node, String tag) {
+        JsonNode attr = node.get(tag);
+        if (attr == null || attr.isNull()) return null;
+        JsonNode value = attr.get("Value");
+        if (value == null || !value.isArray() || value.size() == 0) return null;
+        JsonNode first = value.get(0);
+        return first == null || first.isNull() ? null : first.asText();
+    }
+
+    private static Double numericValue(JsonNode node, String tag) {
+        JsonNode attr = node.get(tag);
+        if (attr == null || attr.isNull()) return null;
+        JsonNode value = attr.get("Value");
+        if (value == null || !value.isArray() || value.size() == 0) return null;
+        JsonNode first = value.get(0);
+        if (first == null || first.isNull()) return null;
+        if (first.isNumber()) return first.asDouble();
+        try {
+            return Double.valueOf(first.asText());
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static String patientNameValue(JsonNode node, String tag) {
+        JsonNode attr = node.get(tag);
+        if (attr == null || attr.isNull()) return null;
+        JsonNode value = attr.get("Value");
+        if (value == null || !value.isArray() || value.size() == 0) return null;
+        JsonNode first = value.get(0);
+        if (first == null || first.isNull()) return null;
+        // DICOM PN VR — either {"Alphabetic":"DOE^JOHN"} or a plain string.
+        if (first.isTextual()) return first.asText();
+        JsonNode alpha = first.get("Alphabetic");
+        return alpha == null ? null : alpha.asText();
+    }
+
+    /**
+     * Render a CodeableConcept-style attribute as {@code "SCHEME:code"}.
+     * Returns {@code null} if the attribute is missing or malformed.
+     */
+    private static String codedConcept(JsonNode node, String tag) {
+        JsonNode attr = node.get(tag);
+        if (attr == null || attr.isNull()) return null;
+        JsonNode value = attr.get("Value");
+        if (value == null || !value.isArray() || value.size() == 0) return null;
+        JsonNode first = value.get(0);
+        if (first == null || first.isNull()) return null;
+        // SR coded entry: 00080100 CodeValue, 00080102 CodingSchemeDesignator,
+        //                 00080104 CodeMeaning.
+        String code = stringValue(first, "00080100");
+        String scheme = stringValue(first, "00080102");
+        String meaning = stringValue(first, "00080104");
+        if (code == null && meaning != null) return meaning;
+        if (code == null) return null;
+        return (scheme == null ? "?" : scheme) + ":" + code;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomStudyBinding.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomStudyBinding.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeBinding;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeBindingDirection;
+
+import java.util.Objects;
+
+/**
+ * Resolved per-binding DICOM study query (07-DICOM.md §6, §7).
+ *
+ * <p>Every binding is {@link BridgeBindingDirection#READ} — the DICOM
+ * bridge has no write direction (§3, §0). The clamp / ramp / loop fields
+ * required by {@link BridgeBinding} are therefore {@code null}; they exist
+ * on the interface so the universal §2.2 audit path treats a DICOM study
+ * query uniformly with industrial bindings, but the DICOM bridge never
+ * invokes them (no write code path exists).
+ */
+public record DicomStudyBinding(
+        String bindingId,
+        DicomBridgeConfig.StudyFilterConfig studyFilter,
+        DicomBridgeConfig.TargetSignal targetSignal,
+        String signalTagPrefix
+) implements BridgeBinding {
+
+    public DicomStudyBinding {
+        Objects.requireNonNull(bindingId, "bindingId");
+        if (targetSignal == null) targetSignal = DicomBridgeConfig.TargetSignal.IMAGING_FINDING;
+    }
+
+    public static DicomStudyBinding fromConfig(DicomBridgeConfig.StudyReadConfig r) {
+        return new DicomStudyBinding(
+                r.bindingId(),
+                r.studyFilter(),
+                r.targetSignal(),
+                r.signalTagPrefix());
+    }
+
+    @Override public BridgeBindingDirection direction() { return BridgeBindingDirection.READ; }
+    @Override public String loopId() { return bindingId; }
+    @Override public String signalTag() { return signalTagPrefix; }
+    @Override public Double failSafeValue() { return null; }
+    @Override public Double rampRateMaxPerSec() { return null; }
+    @Override public Double minClampValue() { return null; }
+    @Override public Double maxClampValue() { return null; }
+
+    /** Modality filter (e.g. {@code "SR"}). Returns {@code null} if not configured. */
+    public String modality() {
+        return studyFilter == null ? null : studyFilter.modality();
+    }
+
+    /** Accession number glob (e.g. {@code "RAD-*"}). Returns {@code null} if not configured. */
+    public String accessionPattern() {
+        return studyFilter == null ? null : studyFilter.accessionPattern();
+    }
+
+    /** Sliding window in hours; {@code null} means no time bound. */
+    public Integer windowHours() {
+        return studyFilter == null ? null : studyFilter.windowHours();
+    }
+
+    /**
+     * Build a QIDO-RS query string (relative to {@code /studies}) representing
+     * this binding's study filter. Used by {@link DicomwebClient} on every
+     * poll cycle.
+     */
+    public String qidoQueryString() {
+        StringBuilder qs = new StringBuilder();
+        if (modality() != null) appendParam(qs, "ModalitiesInStudy", modality());
+        if (accessionPattern() != null) appendParam(qs, "AccessionNumber", accessionPattern());
+        if (windowHours() != null && windowHours() > 0) {
+            appendParam(qs, "StudyDate", windowParam(windowHours()));
+        }
+        return qs.toString();
+    }
+
+    private static void appendParam(StringBuilder qs, String key, String value) {
+        qs.append(qs.length() == 0 ? "?" : "&").append(key).append('=').append(value);
+    }
+
+    private static String windowParam(int hours) {
+        // DICOM StudyDate is a date range; for the QIDO call we approximate
+        // "last N hours" with the day-range starting at today minus the
+        // ceiling-of (N/24) days. PACS servers vary in how strictly they
+        // honour finer windowing — daily granularity is the safe default.
+        int days = Math.max(1, (hours + 23) / 24);
+        java.time.LocalDate today = java.time.LocalDate.now();
+        java.time.LocalDate from = today.minusDays(days);
+        return fmt(from) + "-" + fmt(today);
+    }
+
+    private static String fmt(java.time.LocalDate d) {
+        return String.format("%04d%02d%02d", d.getYear(), d.getMonthValue(), d.getDayOfMonth());
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomwebClient.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomwebClient.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Thin DICOMweb query layer (07-DICOM.md §4, §7).
+ *
+ * <p>Drives the {@link DicomwebTransport} seam — one QIDO call per binding
+ * to enumerate matching studies, then a WADO-RS metadata fetch per
+ * candidate SR instance. Per §10 R1, the WADO call asks for metadata only
+ * (the transport pins the {@code Accept} header at
+ * {@code application/dicom+json}).
+ *
+ * <p>This client returns parsed JSON; the {@link DicomSrParser} consumes
+ * it and the {@link DicomSignalMapper} turns the parsed findings into
+ * signals. Splitting the layers like this lets the bridge run against the
+ * Orthanc demo with one wire transport and against the test fixtures with
+ * a different one — the parser is identical.
+ */
+public final class DicomwebClient {
+
+    private final DicomwebTransport transport;
+    private final DicomBridgeConfig config;
+
+    public DicomwebClient(DicomwebTransport transport, DicomBridgeConfig config) {
+        this.transport = Objects.requireNonNull(transport, "transport");
+        this.config = Objects.requireNonNull(config, "config");
+    }
+
+    /**
+     * Enumerate study summaries matching the binding's filter via QIDO-RS.
+     * Each entry is a DICOM+JSON study attribute object.
+     */
+    public List<JsonNode> qidoStudies(DicomStudyBinding binding) throws IOException {
+        DicomBridgeConfig.DicomwebConfig dw = config.dicomweb();
+        if (dw == null) return List.of();
+        String path = stripTrailingSlash(dw.qidoEndpoint()) + binding.qidoQueryString();
+        JsonNode response = transport.qido(path);
+        return toList(response);
+    }
+
+    /**
+     * Fetch the WADO-RS metadata for an instance identified by its
+     * Study/Series/SOPInstance UIDs (DICOM tags {@code 0020000D},
+     * {@code 0020000E}, {@code 00080018}).
+     */
+    public List<JsonNode> wadoInstanceMetadata(String studyUid, String seriesUid, String instanceUid)
+            throws IOException {
+        DicomBridgeConfig.DicomwebConfig dw = config.dicomweb();
+        if (dw == null) return List.of();
+        String path = dw.wadoEndpoint()
+                .replace("{study}", studyUid)
+                .replace("{series}", seriesUid)
+                .replace("{instance}", instanceUid);
+        JsonNode response = transport.wadoMetadata(path);
+        return toList(response);
+    }
+
+    /** Convenience — given a QIDO study entry, fetch SR instances inside it. */
+    public List<JsonNode> wadoSrInstancesForStudy(JsonNode studyAttrs) throws IOException {
+        if (studyAttrs == null) return List.of();
+        String studyUid = dicomTagFirst(studyAttrs, "0020000D");
+        if (studyUid == null) return List.of();
+        // For brevity the v1 bridge expects the QIDO response to already include
+        // SeriesInstanceUID and SOPInstanceUID (modern PACSes return this when
+        // includefield=all). Where it doesn't, the caller wires the per-series
+        // QIDO + per-instance metadata calls explicitly.
+        String seriesUid = dicomTagFirst(studyAttrs, "0020000E");
+        String instanceUid = dicomTagFirst(studyAttrs, "00080018");
+        if (seriesUid == null || instanceUid == null) return List.of();
+        return wadoInstanceMetadata(studyUid, seriesUid, instanceUid);
+    }
+
+    /** True if the transport reports authenticated + ready. */
+    public boolean isReady() { return transport.isReady(); }
+
+    public DicomwebTransport transport() { return transport; }
+
+    private static List<JsonNode> toList(JsonNode response) {
+        List<JsonNode> out = new ArrayList<>();
+        if (response == null || response.isNull()) return out;
+        if (response.isArray()) {
+            for (Iterator<JsonNode> it = response.elements(); it.hasNext(); ) {
+                JsonNode n = it.next();
+                if (n != null && !n.isNull()) out.add(n);
+            }
+            return out;
+        }
+        // Some servers return a single object — treat it as a list of one.
+        out.add(response);
+        return out;
+    }
+
+    private static String dicomTagFirst(JsonNode node, String tag) {
+        JsonNode attr = node.get(tag);
+        if (attr == null || attr.isNull()) return null;
+        JsonNode value = attr.get("Value");
+        if (value == null || !value.isArray() || value.size() == 0) return null;
+        JsonNode first = value.get(0);
+        return first == null || first.isNull() ? null : first.asText();
+    }
+
+    private static String stripTrailingSlash(String s) {
+        if (s == null) return "/studies";
+        return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomwebTransport.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomwebTransport.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+
+/**
+ * Test seam between {@link DicomwebClient} and a real DICOMweb endpoint
+ * (07-DICOM.md §3, §4, §7).
+ *
+ * <p><b>Structurally read-only.</b> This interface is the entire DICOMweb
+ * surface the bridge can use. There is intentionally no {@code post()},
+ * {@code put()}, {@code stowRs()}, {@code delete()} or any method that
+ * accepts an HTTP verb argument or a request body: a code path that
+ * pushes a DICOM instance back to the PACS cannot exist within the
+ * bridge because the seam to the wire does not provide one
+ * (07-DICOM.md §3, §4 diagram "NO C-STORE outbound. NO STOW-RS.").
+ *
+ * <p>Production wiring constructs a {@code JdkHttpDicomwebTransport}; an
+ * {@link InMemoryDicomwebTransport} backs the acceptance scenarios.
+ */
+public interface DicomwebTransport extends AutoCloseable {
+
+    /**
+     * QIDO-RS search. {@code path} is a relative URL with leading slash
+     * (e.g. {@code "/studies?ModalitiesInStudy=SR"}). Returns the parsed
+     * JSON array of matching study/series/instance attributes, or an
+     * empty array if there are no matches.
+     */
+    JsonNode qido(String path) throws IOException;
+
+    /**
+     * WADO-RS metadata fetch (no pixel data — §10 R1 mandates
+     * {@code accept=application/dicom+json}). {@code path} is a relative
+     * URL identifying an instance metadata endpoint. Returns the JSON
+     * array of instances, or an empty array if not found.
+     */
+    JsonNode wadoMetadata(String path) throws IOException;
+
+    /** Best-effort indication that the underlying transport is alive and authenticated. */
+    default boolean isReady() { return true; }
+
+    @Override
+    default void close() { /* default: no-op */ }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DimseClient.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DimseClient.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Read-only DIMSE client seam (07-DICOM.md §4, §7).
+ *
+ * <p><b>Structurally read-only.</b> The interface exposes only the three
+ * classical query/retrieve DIMSE primitives that the bridge needs —
+ * C-FIND (study/series/instance query), C-MOVE (queued retrieval) and
+ * C-GET (synchronous retrieval). There is intentionally no
+ * {@code cStore()} / {@code cEcho()} write path; a code path that pushes a
+ * DICOM instance to the PACS cannot exist within the bridge because the
+ * seam to the wire does not provide one (07-DICOM.md §3, §4 diagram
+ * "NO write path. NO C-STORE outbound.").
+ *
+ * <p>This project ships the interface but not a wire-level dcm4che
+ * implementation. Deployments that need DIMSE plug in an external
+ * adapter module that mirrors the seam exactly. {@link InMemoryDimseClient}
+ * backs the acceptance scenarios and lets phase-2 wiring be exercised in
+ * unit tests without a live PACS.
+ */
+public interface DimseClient extends AutoCloseable {
+
+    /**
+     * Issue a C-FIND request with the supplied DICOM attribute filter
+     * (e.g. {@code {"ModalitiesInStudy":"SR"}}). Returns a list of matching
+     * studies as DICOM+JSON nodes.
+     */
+    List<JsonNode> cFind(JsonNode queryAttributes) throws IOException;
+
+    /**
+     * Issue a C-MOVE for the matching studies and return the retrieved
+     * SR instances as DICOM+JSON nodes (the implementation runs a
+     * temporary C-STORE SCP, parses received SR objects, and returns the
+     * parsed metadata only — pixel data never leaves the SCP buffer).
+     */
+    List<JsonNode> cMove(JsonNode queryAttributes) throws IOException;
+
+    /**
+     * Issue a C-GET for the matching studies. Same return shape as
+     * {@link #cMove(JsonNode)}; chosen by deployments that cannot run an
+     * inbound C-STORE listener (firewalled environments).
+     */
+    List<JsonNode> cGet(JsonNode queryAttributes) throws IOException;
+
+    /** Best-effort indication that the underlying association is alive. */
+    default boolean isReady() { return true; }
+
+    @Override
+    default void close() { /* default: no-op */ }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/InMemoryDicomwebTransport.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/InMemoryDicomwebTransport.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * In-memory {@link DicomwebTransport} for tests and acceptance scenarios
+ * (07-DICOM.md §9 S7, S9, S11). Holds parsed JSON responses keyed by the
+ * exact relative path issued by {@link DicomwebClient}.
+ *
+ * <p>This transport mirrors the interface exactly — that is the entire
+ * structural defence the bridge relies on. No {@code post()} /
+ * {@code stow()} method exists here either (§3, §4 diagram).
+ */
+public final class InMemoryDicomwebTransport implements DicomwebTransport {
+
+    private final ObjectMapper mapper;
+    private final Map<String, JsonNode> qidoResponses = new LinkedHashMap<>();
+    private final Map<String, JsonNode> wadoResponses = new LinkedHashMap<>();
+    private boolean ready = true;
+
+    public InMemoryDicomwebTransport() {
+        this(new ObjectMapper());
+    }
+
+    public InMemoryDicomwebTransport(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    /** Register a QIDO response. {@code path} starts with {@code "/"}. */
+    public InMemoryDicomwebTransport putQido(String path, JsonNode response) {
+        qidoResponses.put(path, response);
+        return this;
+    }
+
+    /** Convenience — register a QIDO response from raw JSON text. */
+    public InMemoryDicomwebTransport putQido(String path, String json) throws IOException {
+        return putQido(path, mapper.readTree(json));
+    }
+
+    /** Register a WADO metadata response. */
+    public InMemoryDicomwebTransport putWadoMetadata(String path, JsonNode response) {
+        wadoResponses.put(path, response);
+        return this;
+    }
+
+    /** Convenience — register a WADO response from raw JSON text. */
+    public InMemoryDicomwebTransport putWadoMetadata(String path, String json) throws IOException {
+        return putWadoMetadata(path, mapper.readTree(json));
+    }
+
+    /** Force the transport to report unready (e.g. expired token). */
+    public InMemoryDicomwebTransport setReady(boolean ready) {
+        this.ready = ready;
+        return this;
+    }
+
+    @Override
+    public JsonNode qido(String path) {
+        JsonNode r = qidoResponses.get(path);
+        return r == null ? emptyArray() : r;
+    }
+
+    @Override
+    public JsonNode wadoMetadata(String path) {
+        JsonNode r = wadoResponses.get(path);
+        return r == null ? emptyArray() : r;
+    }
+
+    @Override
+    public boolean isReady() { return ready; }
+
+    private ArrayNode emptyArray() {
+        return mapper.createArrayNode();
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/InMemoryDimseClient.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/InMemoryDimseClient.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * In-memory {@link DimseClient} for tests (07-DICOM.md §9 S8). Behaves
+ * like a tiny PACS that answers C-FIND with a preloaded study list and
+ * C-MOVE / C-GET with the preloaded SR instances.
+ *
+ * <p>Mirrors the read-only interface exactly — no {@code cStore()} method
+ * is even possible to call through this transport.
+ */
+public final class InMemoryDimseClient implements DimseClient {
+
+    private final List<JsonNode> findResponse = new ArrayList<>();
+    private final List<JsonNode> moveResponse = new ArrayList<>();
+    private boolean ready = true;
+
+    public InMemoryDimseClient addStudyMatch(JsonNode study) {
+        findResponse.add(study);
+        return this;
+    }
+
+    public InMemoryDimseClient addSrInstance(JsonNode srInstance) {
+        moveResponse.add(srInstance);
+        return this;
+    }
+
+    public InMemoryDimseClient setReady(boolean ready) {
+        this.ready = ready;
+        return this;
+    }
+
+    @Override
+    public List<JsonNode> cFind(JsonNode queryAttributes) {
+        return List.copyOf(findResponse);
+    }
+
+    @Override
+    public List<JsonNode> cMove(JsonNode queryAttributes) {
+        return List.copyOf(moveResponse);
+    }
+
+    @Override
+    public List<JsonNode> cGet(JsonNode queryAttributes) {
+        return List.copyOf(moveResponse);
+    }
+
+    @Override
+    public boolean isReady() { return ready; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/JdkHttpDicomwebTransport.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/JdkHttpDicomwebTransport.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Production {@link DicomwebTransport} backed by {@link HttpClient}
+ * (07-DICOM.md §3, §4, §10 R1).
+ *
+ * <p>This transport issues only HTTP {@code GET} requests; it has no
+ * method that takes an HTTP verb argument and no path that constructs a
+ * request with a body. {@code Accept} is fixed to
+ * {@code application/dicom+json} so pixel data is never returned (§10 R1
+ * "pixel data path is unreachable").
+ *
+ * <p>The class is a thin convenience around the JDK's built-in client to
+ * avoid pulling the full dcm4che dependency tree as a hard requirement.
+ * Deployments that prefer dcm4che's {@code WadoRSClient} may replace this
+ * implementation — they must mirror the read-only seam exactly.
+ */
+public final class JdkHttpDicomwebTransport implements DicomwebTransport {
+
+    private static final Logger log = LoggerFactory.getLogger(JdkHttpDicomwebTransport.class);
+
+    /** Per §10 R1 — pixel data must never enter the JVM heap. */
+    public static final String ACCEPT_HEADER = "application/dicom+json";
+
+    private final HttpClient http;
+    private final ObjectMapper mapper;
+    private final String baseUrl;
+    private final DicomBridgeConfig.SecurityConfig security;
+    private final AtomicReference<String> bearerCache = new AtomicReference<>();
+
+    public JdkHttpDicomwebTransport(DicomBridgeConfig config) {
+        this(config, HttpClient.newBuilder()
+                        .connectTimeout(Duration.ofSeconds(10))
+                        .followRedirects(HttpClient.Redirect.NORMAL)
+                        .build(),
+                new ObjectMapper());
+    }
+
+    public JdkHttpDicomwebTransport(DicomBridgeConfig config, HttpClient http, ObjectMapper mapper) {
+        Objects.requireNonNull(config, "config");
+        if (config.dicomweb() == null) {
+            throw new IllegalArgumentException(
+                    "JdkHttpDicomwebTransport requires a 'dicomweb:' config block.");
+        }
+        this.http = Objects.requireNonNull(http, "http");
+        this.mapper = Objects.requireNonNull(mapper, "mapper");
+        this.baseUrl = stripTrailingSlash(config.dicomweb().baseUrl());
+        this.security = config.security() == null
+                ? new DicomBridgeConfig.SecurityConfig(
+                        DicomBridgeConfig.SecurityType.NONE, null, null, null, null,
+                        null, null, null, null)
+                : config.security();
+    }
+
+    @Override
+    public JsonNode qido(String path) throws IOException {
+        return getJson(absoluteUrl(path));
+    }
+
+    @Override
+    public JsonNode wadoMetadata(String path) throws IOException {
+        return getJson(absoluteUrl(path));
+    }
+
+    @Override
+    public boolean isReady() {
+        if (security.type() != DicomBridgeConfig.SecurityType.OAUTH2_BEARER_TOKEN) {
+            return true;
+        }
+        return bearerCache.get() != null;
+    }
+
+    /** Force the next call to re-authenticate (e.g. after a 401). */
+    public void invalidateToken() {
+        bearerCache.set(null);
+    }
+
+    private JsonNode getJson(String url) throws IOException {
+        HttpRequest.Builder b = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Accept", ACCEPT_HEADER)
+                .GET()
+                .timeout(Duration.ofSeconds(30));
+        applyAuth(b);
+        try {
+            HttpResponse<byte[]> response = http.send(b.build(), HttpResponse.BodyHandlers.ofByteArray());
+            int code = response.statusCode();
+            if (code == 401 || code == 403) {
+                if (security.type() == DicomBridgeConfig.SecurityType.OAUTH2_BEARER_TOKEN) {
+                    invalidateToken();
+                }
+                throw new IOException("DICOMweb GET " + url + " returned " + code);
+            }
+            if (code == 404) {
+                return mapper.createArrayNode();
+            }
+            if (code >= 400) {
+                throw new IOException("DICOMweb GET " + url + " returned " + code);
+            }
+            byte[] body = response.body();
+            if (body == null || body.length == 0) {
+                return mapper.createArrayNode();
+            }
+            return mapper.readTree(body);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while issuing DICOMweb GET " + url, e);
+        }
+    }
+
+    private void applyAuth(HttpRequest.Builder b) throws IOException {
+        switch (security.type()) {
+            case OAUTH2_BEARER_TOKEN -> {
+                String token = bearerCache.get();
+                if (token == null) {
+                    token = acquireBearerToken();
+                    bearerCache.set(token);
+                }
+                if (token != null) b.header("Authorization", "Bearer " + token);
+            }
+            case BASIC_AUTH -> {
+                String user = security.basicAuthUserEnv() == null
+                        ? null : System.getenv(security.basicAuthUserEnv());
+                String pass = security.basicAuthPassEnv() == null
+                        ? null : System.getenv(security.basicAuthPassEnv());
+                if (user != null && pass != null) {
+                    String enc = Base64.getEncoder().encodeToString(
+                            (user + ":" + pass).getBytes(StandardCharsets.UTF_8));
+                    b.header("Authorization", "Basic " + enc);
+                }
+            }
+            case MUTUAL_TLS, NONE -> { /* no header */ }
+        }
+    }
+
+    private String acquireBearerToken() throws IOException {
+        String endpoint = security.tokenEndpoint();
+        String clientId = security.clientId();
+        String secretEnv = security.clientSecretEnv();
+        String secret = secretEnv == null ? null : System.getenv(secretEnv);
+        if (endpoint == null || clientId == null || secret == null) {
+            log.warn("OAuth2 not fully configured (tokenEndpoint/clientId/{}=secret); skipping",
+                    secretEnv);
+            return null;
+        }
+        StringBuilder form = new StringBuilder();
+        form.append("grant_type=client_credentials");
+        form.append("&client_id=").append(urlEncode(clientId));
+        form.append("&client_secret=").append(urlEncode(secret));
+        if (security.scope() != null && !security.scope().isEmpty()) {
+            form.append("&scope=").append(urlEncode(security.scope()));
+        }
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create(endpoint))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .header("Accept", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(form.toString(), StandardCharsets.UTF_8))
+                .timeout(Duration.ofSeconds(15))
+                .build();
+        try {
+            HttpResponse<byte[]> resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+            if (resp.statusCode() != 200) {
+                throw new IOException("Token endpoint returned " + resp.statusCode());
+            }
+            JsonNode node = mapper.readTree(resp.body());
+            JsonNode token = node.get("access_token");
+            return token == null ? null : token.asText();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while acquiring OAuth2 token", e);
+        }
+    }
+
+    private String absoluteUrl(String relative) {
+        if (relative == null || relative.isEmpty()) return baseUrl;
+        if (relative.startsWith("http://") || relative.startsWith("https://")) {
+            return relative;
+        }
+        String rel = relative.startsWith("/") ? relative.substring(1) : relative;
+        return baseUrl + "/" + rel;
+    }
+
+    private static String stripTrailingSlash(String s) {
+        if (s == null) return "";
+        return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
+    }
+
+    private static String urlEncode(String s) {
+        return java.net.URLEncoder.encode(s, StandardCharsets.UTF_8);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * DICOM bridge — Bridge 07 (07-DICOM.md).
+ *
+ * <p>Adapter that converts imaging <i>findings</i> produced by a radiologist
+ * or an upstream model — surfaced through DICOM Structured Reports — into
+ * {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.ImagingFindingSignal}s
+ * that the clinical reasoning module can integrate with vitals, labs and
+ * history.
+ *
+ * <p><b>Bridge ceiling: READ-ONLY — permanently.</b> This package contains
+ * no aggregator / output / write class. The
+ * {@link com.rakovpublic.jneuropallium.worker.bridge.dicom.DicomwebTransport}
+ * and {@link com.rakovpublic.jneuropallium.worker.bridge.dicom.DimseClient}
+ * seams expose only read primitives — no method takes an HTTP verb or a
+ * DICOM message body. The bridge does not read pixel data: WADO requests
+ * are pinned to {@code application/dicom+json}, and image instances are
+ * never fetched (07-DICOM.md §5, §10 R1 — "Image bytes never enter the
+ * JVM heap").
+ *
+ * <p>Production wiring constructs a
+ * {@link com.rakovpublic.jneuropallium.worker.bridge.dicom.JdkHttpDicomwebTransport}
+ * (DICOMweb) or an external dcm4che-backed {@link com.rakovpublic.jneuropallium.worker.bridge.dicom.DimseClient}
+ * (DIMSE — phase 2 of §8). Acceptance tests use the in-memory
+ * implementations.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/clinical/ImagingFindingSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/clinical/ImagingFindingSignal.java
@@ -6,13 +6,18 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical;
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.clinical.FindingCategory;
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
  * A radiologist- or model-reported imaging finding.
  * ProcessingFrequency: loop=2, epoch=5.
+ *
+ * <p>Also implements {@link IInputSignal} so the DICOM bridge
+ * (07-DICOM.md) can drain finding signals through the universal
+ * {@code IInitInput} adapter shared with the FHIR bridge.
  */
-public class ImagingFindingSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class ImagingFindingSignal extends AbstractSignal<Void> implements ISignal<Void>, IInputSignal<Void> {
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(5L, 2);
 

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomBridgeConfigLoaderTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomBridgeConfigLoaderTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 07-DICOM.md §6 — {@code writes:} block is rejected at config-load with a
+ * clear message. Verifies the structural rejection mechanism.
+ */
+class DicomBridgeConfigLoaderTest {
+
+    @Test
+    void writesBlockIsRejectedAtLoad() {
+        String yaml = """
+                mode: DICOMWEB
+                dicomweb:
+                  baseUrl: "https://orthanc.test/dicom-web"
+                  pollIntervalSeconds: 60
+                audit:
+                  localAuditFile: "/tmp/dicom.jsonl"
+                writes:
+                  - bindingId: ANY
+                """;
+        Exception ex = assertThrows(Exception.class, () -> DicomBridgeConfigLoader.load(yaml));
+        Throwable cause = unwrap(ex);
+        assertTrue(cause.getMessage().contains("writes:"),
+                "expected message to mention the writes: block, was: " + cause.getMessage());
+        assertTrue(cause.getMessage().contains("READ-ONLY"),
+                "expected message to reference READ-ONLY ceiling, was: " + cause.getMessage());
+    }
+
+    @Test
+    void minimalDicomwebConfigLoads() throws IOException {
+        String yaml = """
+                mode: DICOMWEB
+                dicomweb:
+                  baseUrl: "https://orthanc.test/dicom-web"
+                  pollIntervalSeconds: 60
+                audit:
+                  localAuditFile: "/tmp/dicom.jsonl"
+                reads:
+                  - bindingId: "RECENT-RADIOLOGY-SR"
+                    studyFilter:
+                      modality: "SR"
+                      accessionPattern: "RAD-*"
+                      windowHours: 24
+                    targetSignal: "IMAGING_FINDING"
+                    signalTagPrefix: "EHR.RADIOLOGY"
+                """;
+        DicomBridgeConfig cfg = DicomBridgeConfigLoader.load(yaml);
+        assertEquals(DicomBridgeConfig.Mode.DICOMWEB, cfg.mode());
+        assertNotNull(cfg.dicomweb());
+        assertEquals(1, cfg.reads().size());
+        assertEquals("RECENT-RADIOLOGY-SR", cfg.reads().get(0).bindingId());
+        assertEquals("SR", cfg.reads().get(0).studyFilter().modality());
+    }
+
+    @Test
+    void pollIntervalBelowMinimumIsRejected() {
+        String yaml = """
+                mode: DICOMWEB
+                dicomweb:
+                  baseUrl: "https://orthanc.test/dicom-web"
+                  pollIntervalSeconds: 5
+                audit:
+                  localAuditFile: "/tmp/dicom.jsonl"
+                """;
+        Exception ex = assertThrows(Exception.class, () -> DicomBridgeConfigLoader.load(yaml));
+        Throwable cause = unwrap(ex);
+        assertTrue(cause.getMessage().contains("pollIntervalSeconds"),
+                "expected poll interval rejection, was: " + cause.getMessage());
+    }
+
+    @Test
+    void dicomwebModeRequiresDicomwebBlock() {
+        String yaml = """
+                mode: DICOMWEB
+                audit:
+                  localAuditFile: "/tmp/dicom.jsonl"
+                """;
+        Exception ex = assertThrows(Exception.class, () -> DicomBridgeConfigLoader.load(yaml));
+        Throwable cause = unwrap(ex);
+        assertTrue(cause.getMessage().contains("dicomweb:"),
+                "expected message to require dicomweb: block, was: " + cause.getMessage());
+    }
+
+    private static Throwable unwrap(Throwable t) {
+        Throwable cur = t;
+        while (cur instanceof JsonMappingException && cur.getCause() != null) {
+            cur = cur.getCause();
+        }
+        return cur;
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomBridgeIntegrationTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomBridgeIntegrationTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.clinical.ImagingFindingSignal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end DICOM bridge tests (07-DICOM.md §9 S7, S8, S9, S11).
+ */
+class DicomBridgeIntegrationTest {
+
+    private final ObjectMapper json = new ObjectMapper();
+
+    private DicomBridgeConfig dicomwebConfig(Path auditFile) {
+        return new DicomBridgeConfig(
+                DicomBridgeConfig.Mode.DICOMWEB,
+                null,
+                new DicomBridgeConfig.DicomwebConfig(
+                        "https://orthanc.test/dicom-web",
+                        "/studies",
+                        "/studies/{study}/series/{series}/instances/{instance}/metadata",
+                        60L),
+                DicomBridgeConfig.SecurityConfig.of(DicomBridgeConfig.SecurityType.NONE,
+                        null, null, null, null, null, null, null, null),
+                List.of(new DicomBridgeConfig.StudyReadConfig(
+                        "RECENT-RADIOLOGY-SR",
+                        new DicomBridgeConfig.StudyFilterConfig("SR", "RAD-*", 24),
+                        DicomBridgeConfig.TargetSignal.IMAGING_FINDING,
+                        "EHR.RADIOLOGY")),
+                new DicomBridgeConfig.PrivacyConfig(true, null, true, false),
+                new DicomBridgeConfig.AuditConfig(auditFile.toString()),
+                null);
+    }
+
+    /** §9 S7 — DICOMweb fetch — bridge produces ImagingFindingSignals, one per leaf. */
+    @Test
+    void s7_dicomwebFetchEmitsImagingFindings(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        DicomBridgeConfig cfg = dicomwebConfig(auditFile);
+
+        String study = """
+                {
+                  "0020000D": { "vr": "UI", "Value": ["1.2.3.4"] },
+                  "0020000E": { "vr": "UI", "Value": ["1.2.3.4.5"] },
+                  "00080018": { "vr": "UI", "Value": ["1.2.3.4.5.6"] }
+                }
+                """;
+        String srInstance = """
+                {
+                  "00080060": { "vr": "CS", "Value": ["SR"] },
+                  "00100020": { "vr": "LO", "Value": ["PT-007"] },
+                  "00100010": { "vr": "PN", "Value": [{"Alphabetic": "DOE^JOHN"}] },
+                  "00180015": { "vr": "CS", "Value": ["CHEST"] },
+                  "0040A730": { "vr": "SQ", "Value": [
+                    {
+                      "0040A040": { "vr": "CS", "Value": ["CODE"] },
+                      "0040A168": { "vr": "SQ", "Value": [{
+                        "00080100": { "vr": "SH", "Value": ["MASS"] },
+                        "00080102": { "vr": "SH", "Value": ["SCT"] },
+                        "00080104": { "vr": "LO", "Value": ["Mass"] }
+                      }]}
+                    }
+                  ]}
+                }
+                """;
+        InMemoryDicomwebTransport transport = new InMemoryDicomwebTransport()
+                .putQido("/studies?ModalitiesInStudy=SR&AccessionNumber=RAD-*"
+                                + "&StudyDate=" + qidoWindow(24),
+                        "[" + study + "]")
+                .putWadoMetadata(
+                        "/studies/1.2.3.4/series/1.2.3.4.5/instances/1.2.3.4.5.6/metadata",
+                        "[" + srInstance + "]");
+        try (DicomAuditOutput audit = new DicomAuditOutput(auditFile);
+             DicomClientService svc = DicomClientService.forDicomweb(cfg, transport, audit)) {
+            svc.start();
+            svc.poll();
+            DicomFindingInput input = new DicomFindingInput(
+                    "dicom-demo", svc, List.of("RECENT-RADIOLOGY-SR"));
+            List<IInputSignal> signals = input.readSignals();
+            assertEquals(1, signals.size(), "expected one ImagingFindingSignal");
+            ImagingFindingSignal s = (ImagingFindingSignal) signals.get(0);
+            assertEquals("SR", s.getModality());
+            assertEquals("CHEST", s.getRegionCode());
+            assertNotNull(s.getPatientId());
+            assertFalse("PT-007".equals(s.getPatientId()),
+                    "S9 — raw PatientID must never appear on the emitted signal");
+        }
+    }
+
+    /** §9 S8 — transport not ready: poll cycle is graceful no-op. */
+    @Test
+    void s8_transportNotReadyIsGraceful(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        DicomBridgeConfig cfg = dicomwebConfig(auditFile);
+        InMemoryDicomwebTransport transport = new InMemoryDicomwebTransport().setReady(false);
+        try (DicomAuditOutput audit = new DicomAuditOutput(auditFile);
+             DicomClientService svc = DicomClientService.forDicomweb(cfg, transport, audit)) {
+            svc.start();
+            svc.poll(); // must not throw
+            DicomFindingInput input = new DicomFindingInput(
+                    "dicom", svc, List.of("RECENT-RADIOLOGY-SR"));
+            assertTrue(input.readSignals().isEmpty(),
+                    "no signals should be emitted while transport is unauthenticated");
+        }
+    }
+
+    /** §9 S9 — raw PatientID/PatientName never appears in the audit JSONL. */
+    @Test
+    void s9_pseudonymisationKeepsPatientIdOutOfAudit(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        DicomBridgeConfig cfg = dicomwebConfig(auditFile);
+        InMemoryDicomwebTransport transport = new InMemoryDicomwebTransport()
+                // No registered QIDO response — the bridge polls, gets an empty list,
+                // and must not write the raw patient id anywhere; the audit must also
+                // not contain it on failure paths.
+                ;
+        try (DicomAuditOutput audit = new DicomAuditOutput(auditFile);
+             DicomClientService svc = DicomClientService.forDicomweb(cfg, transport, audit)) {
+            svc.start();
+            svc.poll();
+        }
+        String content = Files.exists(auditFile) ? Files.readString(auditFile) : "";
+        assertFalse(content.contains("PT-007") || content.contains("DOE^JOHN"),
+                "S9 — raw PatientID / PatientName must never appear in audit, was: " + content);
+    }
+
+    /** §9 S8 (DIMSE) — DIMSE handshake path returns expected findings. */
+    @Test
+    void s8_dimseModeReturnsExpectedFindings(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        DicomBridgeConfig cfg = new DicomBridgeConfig(
+                DicomBridgeConfig.Mode.DIMSE,
+                new DicomBridgeConfig.DimseConfig("JNEO-BRIDGE", "PACS",
+                        "pacs.test", 11112, false),
+                null,
+                DicomBridgeConfig.SecurityConfig.of(DicomBridgeConfig.SecurityType.NONE,
+                        null, null, null, null, null, null, null, null),
+                List.of(new DicomBridgeConfig.StudyReadConfig(
+                        "DIMSE-SR",
+                        new DicomBridgeConfig.StudyFilterConfig("SR", null, null),
+                        DicomBridgeConfig.TargetSignal.IMAGING_FINDING,
+                        "EHR.RADIOLOGY")),
+                new DicomBridgeConfig.PrivacyConfig(true, null, true, false),
+                new DicomBridgeConfig.AuditConfig(auditFile.toString()),
+                null);
+        String srInstance = """
+                {
+                  "00080060": { "vr": "CS", "Value": ["SR"] },
+                  "00100020": { "vr": "LO", "Value": ["PT-DIMSE"] },
+                  "0040A730": { "vr": "SQ", "Value": [
+                    {
+                      "0040A040": { "vr": "CS", "Value": ["TEXT"] },
+                      "0040A160": { "vr": "UT", "Value": ["incidental finding"] }
+                    }
+                  ]}
+                }
+                """;
+        InMemoryDimseClient dimse = new InMemoryDimseClient()
+                .addStudyMatch(json.readTree("{\"0020000D\":{\"vr\":\"UI\",\"Value\":[\"1.2\"]}}"))
+                .addSrInstance(json.readTree(srInstance));
+        try (DicomAuditOutput audit = new DicomAuditOutput(auditFile);
+             DicomClientService svc = DicomClientService.forDimse(cfg, dimse, audit)) {
+            svc.start();
+            svc.poll();
+            DicomFindingInput input = new DicomFindingInput("dicom-dimse",
+                    svc, List.of("DIMSE-SR"));
+            List<IInputSignal> signals = input.readSignals();
+            assertEquals(1, signals.size());
+            ImagingFindingSignal s = (ImagingFindingSignal) signals.get(0);
+            assertEquals("SR", s.getModality());
+            assertNotNull(s.getPatientId());
+            assertFalse("PT-DIMSE".equals(s.getPatientId()));
+        }
+    }
+
+    /** §11 S11 — deeply nested SR via the end-to-end pipeline. */
+    @Test
+    void s11_deeplyNestedSrEmitsAllLeavesOnce(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        DicomBridgeConfig cfg = dicomwebConfig(auditFile);
+        String study = """
+                {
+                  "0020000D": { "vr": "UI", "Value": ["1.2.3"] },
+                  "0020000E": { "vr": "UI", "Value": ["1.2.3.4"] },
+                  "00080018": { "vr": "UI", "Value": ["1.2.3.4.5"] }
+                }
+                """;
+        String srInstance = """
+                {
+                  "00080060": { "vr": "CS", "Value": ["SR"] },
+                  "00100020": { "vr": "LO", "Value": ["PT-N"] },
+                  "0040A730": { "vr": "SQ", "Value": [
+                    { "0040A040": { "vr": "CS", "Value": ["CONTAINER"] },
+                      "0040A730": { "vr": "SQ", "Value": [
+                        { "0040A040": { "vr": "CS", "Value": ["CONTAINER"] },
+                          "0040A730": { "vr": "SQ", "Value": [
+                            { "0040A040": { "vr": "CS", "Value": ["TEXT"] },
+                              "0040A160": { "vr": "UT", "Value": ["leaf-1"] } },
+                            { "0040A040": { "vr": "CS", "Value": ["TEXT"] },
+                              "0040A160": { "vr": "UT", "Value": ["leaf-2"] } }
+                          ]}
+                        },
+                        { "0040A040": { "vr": "CS", "Value": ["TEXT"] },
+                          "0040A160": { "vr": "UT", "Value": ["leaf-3"] } }
+                      ]}
+                    }
+                  ]}
+                }
+                """;
+        InMemoryDicomwebTransport transport = new InMemoryDicomwebTransport()
+                .putQido("/studies?ModalitiesInStudy=SR&AccessionNumber=RAD-*"
+                                + "&StudyDate=" + qidoWindow(24),
+                        "[" + study + "]")
+                .putWadoMetadata("/studies/1.2.3/series/1.2.3.4/instances/1.2.3.4.5/metadata",
+                        "[" + srInstance + "]");
+        try (DicomAuditOutput audit = new DicomAuditOutput(auditFile);
+             DicomClientService svc = DicomClientService.forDicomweb(cfg, transport, audit)) {
+            svc.start();
+            svc.poll();
+            DicomFindingInput input = new DicomFindingInput(
+                    "dicom", svc, List.of("RECENT-RADIOLOGY-SR"));
+            List<IInputSignal> signals = input.readSignals();
+            assertEquals(3, signals.size(),
+                    "S11 — exactly three leaf signals; CONTAINER intermediates must not duplicate");
+        }
+    }
+
+    private static String qidoWindow(int hours) {
+        int days = Math.max(1, (hours + 23) / 24);
+        java.time.LocalDate today = java.time.LocalDate.now();
+        java.time.LocalDate from = today.minusDays(days);
+        return fmt(from) + "-" + fmt(today);
+    }
+
+    private static String fmt(java.time.LocalDate d) {
+        return String.format("%04d%02d%02d", d.getYear(), d.getMonthValue(), d.getDayOfMonth());
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomSrParserTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomSrParserTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Parser-level tests for 07-DICOM.md §5 (SR mapping) and §11 S11 (deeply
+ * nested findings).
+ */
+class DicomSrParserTest {
+
+    private final ObjectMapper json = new ObjectMapper();
+    private final DicomSrParser parser = new DicomSrParser();
+
+    @Test
+    void parsesFlatFindingsAndExtractsPatientId() throws Exception {
+        String srJson = """
+                {
+                  "00080060": { "vr": "CS", "Value": ["SR"] },
+                  "00100020": { "vr": "LO", "Value": ["PT-001"] },
+                  "00100010": { "vr": "PN", "Value": [{"Alphabetic": "DOE^JOHN"}] },
+                  "00180015": { "vr": "CS", "Value": ["CHEST"] },
+                  "0040A730": { "vr": "SQ", "Value": [
+                    {
+                      "0040A040": { "vr": "CS", "Value": ["CODE"] },
+                      "0040A043": { "vr": "SQ", "Value": [{
+                        "00080100": { "vr": "SH", "Value": ["F-01"] },
+                        "00080102": { "vr": "SH", "Value": ["DCM"] },
+                        "00080104": { "vr": "LO", "Value": ["Finding"] }
+                      }]},
+                      "0040A168": { "vr": "SQ", "Value": [{
+                        "00080100": { "vr": "SH", "Value": ["17621005"] },
+                        "00080102": { "vr": "SH", "Value": ["SCT"] },
+                        "00080104": { "vr": "LO", "Value": ["Normal"] }
+                      }]}
+                    }
+                  ]}
+                }
+                """;
+        DicomSrParser.SrDocument doc = parser.parse(json.readTree(srJson));
+        assertEquals("SR", doc.modality());
+        assertEquals("PT-001", doc.rawPatientId());
+        assertEquals("DOE^JOHN", doc.rawPatientName());
+        assertEquals("CHEST", doc.bodyPart());
+        assertEquals(1, doc.findings().size());
+        DicomSrParser.Finding f = doc.findings().get(0);
+        assertEquals("CODE", f.valueType());
+        assertEquals("SCT:17621005", f.valueCode());
+    }
+
+    /** §11 S11 — 3-level nested SR; all leaves emitted, intermediate nodes not duplicated. */
+    @Test
+    void deeplyNestedSrEmitsOnlyLeaves() throws Exception {
+        String srJson = """
+                {
+                  "00080060": { "vr": "CS", "Value": ["SR"] },
+                  "00100020": { "vr": "LO", "Value": ["PT-002"] },
+                  "0040A730": { "vr": "SQ", "Value": [
+                    {
+                      "0040A040": { "vr": "CS", "Value": ["CONTAINER"] },
+                      "0040A730": { "vr": "SQ", "Value": [
+                        {
+                          "0040A040": { "vr": "CS", "Value": ["CONTAINER"] },
+                          "0040A730": { "vr": "SQ", "Value": [
+                            {
+                              "0040A040": { "vr": "CS", "Value": ["CODE"] },
+                              "0040A168": { "vr": "SQ", "Value": [{
+                                "00080100": { "vr": "SH", "Value": ["MASS"] },
+                                "00080102": { "vr": "SH", "Value": ["SCT"] },
+                                "00080104": { "vr": "LO", "Value": ["Mass"] }
+                              }]}
+                            },
+                            {
+                              "0040A040": { "vr": "CS", "Value": ["TEXT"] },
+                              "0040A160": { "vr": "UT", "Value": ["spiculated"] }
+                            }
+                          ]}
+                        },
+                        {
+                          "0040A040": { "vr": "CS", "Value": ["NUM"] },
+                          "0040A30A": { "vr": "SQ", "Value": [{
+                            "0040A30B": { "vr": "DS", "Value": [12.5] }
+                          }]}
+                        }
+                      ]}
+                    }
+                  ]}
+                }
+                """;
+        DicomSrParser.SrDocument doc = parser.parse(json.readTree(srJson));
+        List<DicomSrParser.Finding> leaves = doc.findings();
+        assertEquals(3, leaves.size(),
+                "S11 — three leaf observations expected, intermediate CONTAINERs should not duplicate");
+        assertTrue(leaves.stream().anyMatch(f -> "SCT:MASS".equals(f.valueCode())));
+        assertTrue(leaves.stream().anyMatch(f -> "spiculated".equals(f.text())));
+        assertTrue(leaves.stream().anyMatch(
+                f -> f.numericValue() != null && Math.abs(f.numericValue() - 12.5) < 1e-9));
+    }
+
+    /** §10 R3 — unsupported scheme is preserved as opaque code; finding still emits. */
+    @Test
+    void unknownSchemePassesThroughAsOpaqueCode() throws Exception {
+        String srJson = """
+                {
+                  "00080060": { "vr": "CS", "Value": ["SR"] },
+                  "0040A730": { "vr": "SQ", "Value": [
+                    {
+                      "0040A040": { "vr": "CS", "Value": ["CODE"] },
+                      "0040A168": { "vr": "SQ", "Value": [{
+                        "00080100": { "vr": "SH", "Value": ["XYZ"] },
+                        "00080102": { "vr": "SH", "Value": ["UNKNOWN"] },
+                        "00080104": { "vr": "LO", "Value": ["Unknown"] }
+                      }]}
+                    }
+                  ]}
+                }
+                """;
+        DicomSrParser.SrDocument doc = parser.parse(json.readTree(srJson));
+        assertEquals(1, doc.findings().size());
+        assertEquals("UNKNOWN:XYZ", doc.findings().get(0).valueCode());
+        assertFalse(parser.schemeSupported("UNKNOWN"));
+    }
+
+    @Test
+    void parserHandlesEmptyInputGracefully() {
+        DicomSrParser.SrDocument doc = parser.parse(null);
+        assertNotNull(doc);
+        assertTrue(doc.findings().isEmpty());
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomTransportContractTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/dicom/DicomTransportContractTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.dicom;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Structural test for 07-DICOM.md §3, §4 diagram, §9 S10. Asserts that the
+ * {@link DicomwebTransport} and {@link DimseClient} interfaces — the only
+ * surfaces the bridge can use to reach a PACS — have no method whose name
+ * suggests a non-read operation.
+ *
+ * <p>Also verifies that the bridge package contains no aggregator class:
+ * §9 S10 — "Unit test attempts to construct a {@code DicomCommandOutputAggregator}
+ * (class doesn't exist) → Compile error".
+ */
+class DicomTransportContractTest {
+
+    private static final List<String> FORBIDDEN_NAMES = List.of(
+            "create", "update", "delete", "patch", "put", "post", "save", "submit",
+            "write", "send", "store", "stow", "cstore", "ccancel"
+    );
+
+    @Test
+    void dicomwebTransportSurfaceIsReadOnly() {
+        for (Method m : DicomwebTransport.class.getDeclaredMethods()) {
+            String name = m.getName().toLowerCase(Locale.ROOT);
+            for (String forbidden : FORBIDDEN_NAMES) {
+                assertFalse(name.equals(forbidden) || name.startsWith(forbidden),
+                        "DicomwebTransport has method '" + m.getName()
+                                + "' that suggests a non-read operation. "
+                                + "07-DICOM.md §3, §4 diagram forbid any write surface.");
+            }
+        }
+    }
+
+    @Test
+    void dimseClientSurfaceIsReadOnly() {
+        for (Method m : DimseClient.class.getDeclaredMethods()) {
+            String name = m.getName().toLowerCase(Locale.ROOT);
+            for (String forbidden : FORBIDDEN_NAMES) {
+                assertFalse(name.equals(forbidden) || name.startsWith(forbidden),
+                        "DimseClient has method '" + m.getName()
+                                + "' that suggests a non-read DIMSE operation. "
+                                + "07-DICOM.md §3, §4 diagram forbid C-STORE / STOW-RS.");
+            }
+        }
+    }
+
+    @Test
+    void dicomwebReadAndSearchMethodsExist() {
+        boolean qido = Arrays.stream(DicomwebTransport.class.getDeclaredMethods())
+                .anyMatch(m -> m.getName().equals("qido"));
+        boolean wado = Arrays.stream(DicomwebTransport.class.getDeclaredMethods())
+                .anyMatch(m -> m.getName().equals("wadoMetadata"));
+        assertTrue(qido, "DicomwebTransport.qido() is required");
+        assertTrue(wado, "DicomwebTransport.wadoMetadata() is required");
+    }
+
+    /** §9 S10 — no aggregator class exists in the bridge package. */
+    @Test
+    void noOutputAggregatorClassExistsInDicomBridge() {
+        String pkg = DicomwebTransport.class.getPackageName();
+        for (String forbidden : List.of(
+                pkg + ".DicomCommandOutputAggregator",
+                pkg + ".DicomOutputAggregator",
+                pkg + ".DicomAdvisoryOutputAggregator")) {
+            assertFalse(classExists(forbidden),
+                    "Class " + forbidden + " must not exist — DICOM bridge ceiling is READ-ONLY "
+                            + "(07-DICOM.md §3, §7).");
+        }
+    }
+
+    /** §10 R1 — WADO metadata Accept header is structurally pinned. */
+    @Test
+    void wadoAcceptHeaderIsDicomJson() {
+        assertTrue("application/dicom+json".equals(JdkHttpDicomwebTransport.ACCEPT_HEADER),
+                "JdkHttpDicomwebTransport.ACCEPT_HEADER must be application/dicom+json "
+                        + "to keep the pixel-data path unreachable (07-DICOM.md §10 R1).");
+    }
+
+    private static boolean classExists(String name) {
+        try {
+            Class.forName(name);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Adds the read-only DICOM context bridge: a DICOMweb (QIDO-RS / WADO-RS) HTTP client and a DIMSE client seam, an SR content-tree parser that extracts leaf findings, and a signal mapper that emits one ImagingFindingSignal per finding. Patient identifiers are pseudonymised before any signal or audit record is written; WADO requests are pinned to application/dicom+json so pixel data is structurally unreachable.

The bridge ceiling is structurally READ-ONLY: the package contains no aggregator class, the DicomwebTransport / DimseClient seams expose only read primitives (S10 contract test), and a writes: block in the YAML config is rejected at load time with a clear message.

ImagingFindingSignal now also implements IInputSignal so the DicomFindingInput adapter can hand findings to the clinical pipeline through the same IInitInput surface used by the FHIR bridge.

Covers acceptance scenarios S7 (DICOMweb fetch), S8 (transport not-ready + DIMSE handshake), S9 (PatientID/PatientName never reach the audit), S10 (no write surface) and S11 (deeply nested SR — leaves only, no duplication of containers).