### PR TITLE
Implement IEC 61850 bridge (11-IEC61850.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ every loop.
 | 08 | Apache Kafka | enterprise/cyber | spec | ADVISORY |
 | 09 | OpenTelemetry | observability | spec | EXPORT-ONLY (no writeback) |
 | 10 | Eclipse Ditto | digital twins | shipped | ADVISORY |
-| 11 | IEC 61850 | power grid | spec | READ-ONLY initially |
+| 11 | IEC 61850 | power grid | shipped | READ-ONLY initially |
 | 12 | MAVLink | drones | shipped | SIM-ONLY initially |
 | 13 | CANopen | embedded | shipped | ADVISORY |
 | 14 | LTI / xAPI | adaptive tutoring | spec | ADVISORY |
@@ -321,6 +321,30 @@ Lawicel-style USB-CAN backend (`UsbCanClientService`) is the
 cross-platform escape hatch (CANable / Korlan / PCAN). See
 [`docs/canopen-bridge.md`](docs/canopen-bridge.md) and
 [`13-CANOPEN.md`](13-CANOPEN.md).
+
+### IEC 61850 bridge
+
+For electrical substations and power-utility automation the IEC 61850
+bridge reads measurements (`MMXU` voltages / currents / power), status
+(`XCBR` / `XSWI` breaker and isolator positions) and protection events
+(`PIOC` / `PTOC` / `PTUV` operate signals from buffered or unbuffered
+Report Control Blocks) and emits typed `MeasurementSignal` /
+`AlarmSignal` instances per binding. Quality from the IEC 61850 `q`
+attribute propagates unmodified into `Quality.GOOD/BAD/UNCERTAIN`;
+source-system timestamps from the `t` attribute always win over the
+JVM clock.
+
+The ceiling is structurally **READ-ONLY**. The bridge package contains
+no aggregator or output class, the `Iec61850MmsClient` transport seam
+exposes no method that writes a Data Attribute or issues a
+select-before-operate, and a `writes:` block in YAML is rejected at
+config-load with a message pointing to the separate
+`iec61850-control` bridge that would need its own SIL certification.
+SCL (`.icd` / `.cid` / `.scd`) is the ground-truth data model: the
+bridge fails fast at startup if any IED's SCL file is missing or
+malformed. Sampled Values (PTP / IRIG-B) are deferred to v2. See
+[`docs/iec61850-bridge.md`](docs/iec61850-bridge.md) and
+[`11-IEC61850.md`](11-IEC61850.md).
 
 ### Lab Streaming Layer (LSL) bridge
 

--- a/docs/iec61850-bridge.md
+++ b/docs/iec61850-bridge.md
@@ -1,0 +1,135 @@
+# IEC 61850 bridge
+
+> Companion to [`11-IEC61850.md`](../11-IEC61850.md) (the spec) and
+> [`00-FRAMEWORK.md`](../00-FRAMEWORK.md) (the universal contract). This
+> file documents the IEC 61850 bridge's domain context, YAML schema,
+> manual demo procedure, and regulatory posture — the §10
+> Definition-of-Done items that don't belong in the spec itself.
+
+## Domain context
+
+[IEC 61850](https://webstore.iec.ch/publication/6028) is the
+interoperability standard for electrical substations and power utility
+automation. It defines a five-level data model
+(`LDevice / LN / DO / DA / data-attribute-leaf`), three information
+services (MMS client/server for reads, GOOSE multicast for fast event
+exchange, Sampled Values for synchrophasor-rate streams), and the
+Substation Configuration Language (SCL) — the XML engineering exchange
+format that describes the entire substation configuration.
+
+Substations expose **measurements** (currents, voltages, frequencies,
+power factors), **status** (breaker open/closed, isolator position),
+**events** (protection trips, alarms) and **control** (operate,
+select-before-operate, cancel). For Jneopallium the bridge reads the
+first three. **Control is permanently out of scope.**
+
+## Why READ-ONLY
+
+* IEC 61850 control writes use select-before-operate (SBO) with operator
+  confirmation; wrapping that in a JVM-resident bridge undermines the
+  protocol's safety model.
+* Substation control is a SIL-classified function (SIL 2/3) that lives on
+  certified RTUs and protection relays. A Java bridge writing to a
+  Logical Node's `Oper` attribute would act outside its certification
+  scope.
+* Reads are sufficient to add value: state-estimation cross-checks,
+  anomaly detection, equipment-degradation modelling, demand-response
+  advisory.
+
+A bridge that opens a write surface here is a *different* bridge — name
+it `iec61850-control` and certify it separately. Do not extend this one.
+This package contains no aggregator or output class (11-IEC61850.md §7),
+and its `Iec61850MmsClient` seam exposes no method that writes a Data
+Attribute. The `writes:` block in YAML is rejected at config-load.
+
+## Components
+
+```
+worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/
+├── Iec61850BridgeConfig.java          ← YAML record (writes: rejected at load)
+├── Iec61850BridgeConfigLoader.java    ← Jackson YAML loader, FAIL_ON_UNKNOWN
+├── Iec61850DaBinding.java             ← BridgeBinding for one Data Attribute read
+├── SclParser.java                     ← Stax SCL parser (.icd/.cid/.scd)
+├── Iec61850SignalMapper.java          ← MMS read / report → MeasurementSignal/AlarmSignal
+├── Iec61850MmsClient.java             ← read-only transport seam (no write methods)
+├── InMemoryIec61850MmsClient.java     ← in-memory simulator used by tests
+├── Iec61850ClientService.java         ← orchestrator: SCL load, polling, RCB subs
+├── Iec61850MeasurementInput.java      ← IInitInput → MeasurementSignal
+├── Iec61850EventInput.java            ← IInitInput → AlarmSignal (RCB reports)
+├── Iec61850AuditOutput.java           ← local JSONL audit
+└── package-info.java
+```
+
+No aggregator class. No output class. There is no write code path.
+
+## YAML schema
+
+The canonical example lives in 11-IEC61850.md §6. Key points:
+
+* `ied[].sclFile` is required per IED. The bridge **fails fast** at
+  startup if the file is missing or malformed — SCL is the ground-truth
+  data model and unresolved DA paths are unsafe to silently approximate.
+* `reads[]` is a flat list of Data Attribute reads. `targetSignal` is
+  optional: paths matching `XCBR*` / `XSWI*` auto-classify as `STATUS`,
+  everything else as `MEASUREMENT`.
+* `events[]` subscribes to Report Control Blocks. `severityMap` keys are
+  IEC 61850 Logical Node classes (`PIOC`, `PTOC`, `PTUV`, …) and values
+  are taken from the `CRITICAL / HIGH / LOW / JOURNAL` vocabulary; the
+  bridge maps `CRITICAL` → ISA-18.2 `URGENT` (the closest in-tree priority).
+* GOOSE listener is **not wired in v1** (11-IEC61850.md §8 phase 3). The
+  per-binding-id queues are already in place; adding GOOSE is a matter
+  of slotting a new transport seam that calls
+  `Iec61850ClientService.onReport` — the rest of the pipeline is
+  protocol-agnostic.
+* `audit.localAuditFile` is the JSONL audit destination conforming to
+  00-FRAMEWORK §4. Audit failures are isolated per framework S5 — the
+  bridge continues running in degraded mode.
+
+## Manual demo
+
+Phase 1 acceptance is exercised against the simulator that ships with
+`libiec61850` (`server_example_basic_io`). Manual procedure:
+
+1. Build and run the libiec61850 example server on `localhost:102` —
+   it advertises an `LD0` Logical Device with `MMXU1`, `MMXU2`, `XCBR1`
+   and an `LLN0` reporting facility.
+2. Drop a minimal SCL describing those nodes into
+   `/etc/jneopallium/scl/SUB1.icd`. (For phase-1 smoke testing the SCL
+   shipped in `Iec61850BridgeIntegrationTest` is sufficient.)
+3. Wire the bridge with `Iec61850BridgeConfigLoader.load(yamlPath)`,
+   instantiate the production MMS client (a `iec61850bean`-backed
+   implementation of `Iec61850MmsClient`) and tick `svc.poll()`.
+4. Watch the per-binding queues drain through
+   `Iec61850MeasurementInput.readSignals()` — each binding should produce
+   one `MeasurementSignal` per cycle, carrying the source-system
+   timestamp.
+5. Force a protection trip on the simulator and confirm
+   `Iec61850EventInput.readSignals()` returns an `AlarmSignal` of priority
+   `URGENT` (per the `severityMap`).
+
+Acceptance tests (`mvn -pl worker -Dtest='Iec61850*,Scl*' test`) cover
+the no-simulator path with `InMemoryIec61850MmsClient`. Production
+sites need a real MMS adapter, which slots in unchanged behind the
+`Iec61850MmsClient` seam.
+
+## Regulatory posture
+
+The IEC 61850 bridge is **READ-ONLY initially** and remains so until a
+separately-certified `iec61850-control` bridge is built. It contributes
+only advisory observations to the Jneopallium pipeline:
+
+* Protection trips become `AlarmSignal(URGENT, "PROTECTION_OPERATE")` —
+  awareness, not commands.
+* Breaker positions become `MeasurementSignal` with value `0.0` (OPEN)
+  or `1.0` (CLOSED) — state observation, not directive. The framework's
+  `InterlockSignal` is reserved for the aggregator's interlock-trip
+  path (00-FRAMEWORK §0 rule 2) and is not produced by this bridge.
+* Measurement quality from the IEC 61850 `q` attribute propagates
+  unmodified into `Quality.GOOD/BAD/UNCERTAIN` — untrustworthy data is
+  never silently promoted to "good" (framework rule 5).
+* Source-system timestamps (the IEC 61850 `t` attribute) always win
+  over `System.currentTimeMillis()` (framework rule 6).
+
+Time sync for sampled-values use cases (PTP / IRIG-B) is **out of scope
+for v1**; sampled-values support is deferred and use-cases requiring it
+are documented as future work (11-IEC61850.md §10 R4).

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850AuditOutput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850AuditOutput.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.iec61850;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+
+import java.nio.file.Path;
+
+/**
+ * JSONL audit sink for the IEC 61850 bridge (00-FRAMEWORK §4, §6;
+ * 11-IEC61850.md §6 {@code audit.localAuditFile}).
+ *
+ * <p>The sink does not mirror to any external channel by default —
+ * substation-side audit egress is operator-controlled. Operators that
+ * want to mirror events to a SCADA historian or the IT side can extend
+ * this class and override {@link AbstractBridgeAuditOutput#mirror}.
+ */
+public final class Iec61850AuditOutput extends AbstractBridgeAuditOutput {
+    public Iec61850AuditOutput(Path file) { super(file); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850BridgeConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850BridgeConfig.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.iec61850;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Top-level IEC 61850 bridge configuration (11-IEC61850.md §6).
+ *
+ * <p>The bridge ceiling is structurally <b>READ-ONLY — initially</b>
+ * (11-IEC61850.md §0 safety ceiling, §3 "Why read-only", §4 diagram,
+ * §7 "No aggregator class"). The structural defences are:
+ *
+ * <ol>
+ *   <li>The bridge package contains no aggregator or output class
+ *       (11-IEC61850.md §7), so there is no surface a higher layer could
+ *       call to push data back to an IED.</li>
+ *   <li>The {@link Iec61850MmsClient} seam exposes only {@code readDa()},
+ *       {@code subscribeReport()} and connection lifecycle — no method
+ *       writes a Data Attribute, issues a select-before-operate, or
+ *       controls a breaker.</li>
+ *   <li>{@code writes:} blocks are rejected at config-load with a clear
+ *       message (11-IEC61850.md §6 "{@code writes:} block is rejected at
+ *       config-load with a clear message").</li>
+ * </ol>
+ */
+public record Iec61850BridgeConfig(
+        List<IedConfig> ied,
+        List<DaReadConfig> reads,
+        List<ReportEventConfig> events,
+        AuditConfig audit,
+        Duration tickInterval
+) {
+
+    public Iec61850BridgeConfig {
+        Objects.requireNonNull(audit, "audit");
+        ied = ied == null ? List.of() : List.copyOf(ied);
+        reads = reads == null ? List.of() : List.copyOf(reads);
+        events = events == null ? List.of() : List.copyOf(events);
+        tickInterval = tickInterval == null ? Duration.ofMillis(1000) : tickInterval;
+
+        Set<String> seenIeds = new LinkedHashSet<>();
+        for (IedConfig i : ied) {
+            if (!seenIeds.add(i.id())) {
+                throw new IllegalArgumentException(
+                        "IEC 61850 bridge: duplicate IED id: " + i.id());
+            }
+        }
+        Set<String> seenBindings = new LinkedHashSet<>();
+        for (DaReadConfig r : reads) {
+            if (!seenBindings.add(r.bindingId())) {
+                throw new IllegalArgumentException(
+                        "IEC 61850 bridge: duplicate bindingId: " + r.bindingId());
+            }
+            if (!seenIeds.contains(r.iedId())) {
+                throw new IllegalArgumentException(
+                        "IEC 61850 bridge: read binding '" + r.bindingId()
+                                + "' references unknown iedId '" + r.iedId() + "'");
+            }
+        }
+        for (ReportEventConfig e : events) {
+            if (!seenBindings.add(e.bindingId())) {
+                throw new IllegalArgumentException(
+                        "IEC 61850 bridge: duplicate bindingId: " + e.bindingId());
+            }
+            if (!seenIeds.contains(e.iedId())) {
+                throw new IllegalArgumentException(
+                        "IEC 61850 bridge: event binding '" + e.bindingId()
+                                + "' references unknown iedId '" + e.iedId() + "'");
+            }
+        }
+    }
+
+    @JsonCreator
+    public static Iec61850BridgeConfig create(
+            @JsonProperty("ied") List<IedConfig> ied,
+            @JsonProperty("reads") List<DaReadConfig> reads,
+            @JsonProperty("events") List<ReportEventConfig> events,
+            @JsonProperty("audit") AuditConfig audit,
+            @JsonProperty("tickInterval") Duration tickInterval,
+            // 11-IEC61850.md §6 — reject a writes: block at load time. Declared so
+            // Jackson surfaces it with FAIL_ON_UNKNOWN_PROPERTIES=true and rejects
+            // with the clear message mandated by the spec.
+            @JsonProperty("writes") Object writes) {
+        if (writes != null) {
+            throw new IllegalArgumentException(
+                    "IEC 61850 bridge: 'writes:' block is not permitted — the bridge "
+                            + "ceiling is READ-ONLY (11-IEC61850.md §0, §3, §6). "
+                            + "Control surface is a separate bridge ('iec61850-control') "
+                            + "that must be certified separately. Remove the writes section.");
+        }
+        return new Iec61850BridgeConfig(ied, reads, events, audit, tickInterval);
+    }
+
+    /** Resolve an IED by id, throwing a clear error if absent. */
+    public IedConfig requireIed(String id) {
+        for (IedConfig i : ied) {
+            if (i.id().equals(id)) return i;
+        }
+        throw new IllegalArgumentException(
+                "IEC 61850 bridge: no IED configured with id '" + id + "'");
+    }
+
+    /** Target Jneopallium signal kind for a read binding (§5 mapping table). */
+    public enum TargetSignal {
+        /** MMXU-style measurement → {@code MeasurementSignal}. */
+        MEASUREMENT,
+        /** XCBR/XSWI status → {@code InterlockSignal} (state-only, never tripped). */
+        STATUS,
+        /** Protection / supervisory event → {@code AlarmSignal}. */
+        ALARM
+    }
+
+    /** §6 {@code ied:} entry. */
+    public record IedConfig(
+            String id,
+            String host,
+            int port,
+            String sclFile,
+            String reportControlBlock
+    ) {
+        public IedConfig {
+            Objects.requireNonNull(id, "id");
+            Objects.requireNonNull(host, "host");
+            Objects.requireNonNull(sclFile, "sclFile");
+            if (port <= 0 || port > 65535) {
+                throw new IllegalArgumentException(
+                        "IEC 61850 bridge: ied.port out of range: " + port);
+            }
+        }
+
+        @JsonCreator
+        public static IedConfig of(
+                @JsonProperty("id") String id,
+                @JsonProperty("host") String host,
+                @JsonProperty("port") Integer port,
+                @JsonProperty("sclFile") String sclFile,
+                @JsonProperty("reportControlBlock") String reportControlBlock) {
+            return new IedConfig(id, host, port == null ? 102 : port,
+                    sclFile, reportControlBlock);
+        }
+    }
+
+    /** §6 {@code reads:} entry — direct DA path read binding. */
+    public record DaReadConfig(
+            String bindingId,
+            String iedId,
+            String daPath,
+            String signalTag,
+            TargetSignal targetSignal
+    ) {
+        public DaReadConfig {
+            Objects.requireNonNull(bindingId, "bindingId");
+            Objects.requireNonNull(iedId, "iedId");
+            Objects.requireNonNull(daPath, "daPath");
+            Objects.requireNonNull(signalTag, "signalTag");
+            if (targetSignal == null) targetSignal = inferTargetFromPath(daPath);
+        }
+
+        @JsonCreator
+        public static DaReadConfig of(
+                @JsonProperty("bindingId") String bindingId,
+                @JsonProperty("iedId") String iedId,
+                @JsonProperty("daPath") String daPath,
+                @JsonProperty("signalTag") String signalTag,
+                @JsonProperty("targetSignal") TargetSignal targetSignal) {
+            return new DaReadConfig(bindingId, iedId, daPath, signalTag, targetSignal);
+        }
+
+        /**
+         * Infer the target signal from the DA path Logical Node prefix (§5).
+         * MMXU/MMTR/MSQI → measurement; XCBR/XSWI → status; others default to
+         * measurement.
+         */
+        private static TargetSignal inferTargetFromPath(String daPath) {
+            String upper = daPath.toUpperCase();
+            if (upper.contains("XCBR") || upper.contains("XSWI")) return TargetSignal.STATUS;
+            return TargetSignal.MEASUREMENT;
+        }
+    }
+
+    /** §6 {@code events:} entry — Report Control Block subscription. */
+    public record ReportEventConfig(
+            String bindingId,
+            String iedId,
+            String reportControlBlock,
+            String targetSignal,
+            Map<String, String> severityMap
+    ) {
+        public ReportEventConfig {
+            Objects.requireNonNull(bindingId, "bindingId");
+            Objects.requireNonNull(iedId, "iedId");
+            Objects.requireNonNull(reportControlBlock, "reportControlBlock");
+            if (targetSignal == null) targetSignal = "ALARM";
+            severityMap = severityMap == null ? Map.of() : Map.copyOf(severityMap);
+        }
+
+        @JsonCreator
+        public static ReportEventConfig of(
+                @JsonProperty("bindingId") String bindingId,
+                @JsonProperty("iedId") String iedId,
+                @JsonProperty("reportControlBlock") String reportControlBlock,
+                @JsonProperty("targetSignal") String targetSignal,
+                @JsonProperty("severityMap") Map<String, String> severityMap) {
+            // Preserve YAML ordering for deterministic auditing.
+            Map<String, String> ordered = severityMap == null
+                    ? Map.of() : new LinkedHashMap<>(severityMap);
+            return new ReportEventConfig(bindingId, iedId, reportControlBlock,
+                    targetSignal, ordered);
+        }
+    }
+
+    /** §6 {@code audit:} block. */
+    public record AuditConfig(String localAuditFile) {
+        public AuditConfig {
+            Objects.requireNonNull(localAuditFile, "localAuditFile");
+        }
+
+        @JsonCreator
+        public static AuditConfig of(@JsonProperty("localAuditFile") String localAuditFile) {
+            return new AuditConfig(localAuditFile);
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850BridgeConfigLoader.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850BridgeConfigLoader.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.iec61850;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+/**
+ * Loads {@link Iec61850BridgeConfig} from YAML (11-IEC61850.md §6).
+ *
+ * <p>{@code FAIL_ON_UNKNOWN_PROPERTIES = true} per 00-FRAMEWORK §3 — typos
+ * in a substation bridge config must surface at load time. Together with
+ * the explicit {@code writes:} parameter on
+ * {@link Iec61850BridgeConfig#create}, this guarantees that a YAML config
+ * carrying a {@code writes:} block is rejected with the message mandated
+ * by §6 ("{@code writes:} block is rejected at config-load").
+ */
+public final class Iec61850BridgeConfigLoader {
+
+    private Iec61850BridgeConfigLoader() {}
+
+    public static Iec61850BridgeConfig load(Path yaml) throws IOException {
+        return mapper().readValue(yaml.toFile(), Iec61850BridgeConfig.class);
+    }
+
+    public static Iec61850BridgeConfig load(InputStream in) throws IOException {
+        return mapper().readValue(in, Iec61850BridgeConfig.class);
+    }
+
+    public static Iec61850BridgeConfig load(String yamlContent) throws IOException {
+        return mapper().readValue(yamlContent, Iec61850BridgeConfig.class);
+    }
+
+    private static ObjectMapper mapper() {
+        return new ObjectMapper(new YAMLFactory())
+                .registerModule(new JavaTimeModule())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850ClientService.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850ClientService.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.iec61850;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * IEC 61850 bridge polling client + per-binding cache
+ * (11-IEC61850.md §4, §7).
+ *
+ * <p>Owns:
+ * <ul>
+ *   <li>The {@link Iec61850MmsClient} seam — read-only access to the IEDs
+ *       (§3, §4 diagram). No write surface exists.</li>
+ *   <li>Per-binding queues of decoded signals (one per read binding,
+ *       drained by {@link Iec61850MeasurementInput}; one per event
+ *       binding, drained by {@link Iec61850EventInput}).</li>
+ *   <li>The parsed {@link SclParser.SclModel} per IED — ground-truth data
+ *       model required by §6 ("bridge fails fast at startup if SCL is
+ *       missing or malformed").</li>
+ *   <li>Active Report Control Block subscriptions for the events bindings.</li>
+ * </ul>
+ *
+ * <p>The service has no write methods. There is no aggregator class in
+ * this package (§7) and the MMS client seam exposes no write surface — a
+ * code path that pushes data back to an IED cannot be expressed inside
+ * the bridge.
+ */
+public final class Iec61850ClientService implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(Iec61850ClientService.class);
+
+    /** Bridge name carried in every audit record (00-FRAMEWORK §4). */
+    public static final String BRIDGE_NAME = "iec61850";
+
+    /** Default per-binding ring-buffer cap. */
+    public static final int DEFAULT_RING_BUFFER = 4096;
+
+    private final Iec61850BridgeConfig config;
+    private final Iec61850MmsClient mms;
+    private final AbstractBridgeAuditOutput audit;
+
+    private final Map<String, SclParser.SclModel> sclByIed = new LinkedHashMap<>();
+    private final Map<String, Iec61850DaBinding> readBindings = new LinkedHashMap<>();
+    private final Map<String, Iec61850BridgeConfig.ReportEventConfig> eventBindings = new LinkedHashMap<>();
+    private final Map<String, Deque<IInputSignal>> queueByBinding = new ConcurrentHashMap<>();
+    private final List<AutoCloseable> subscriptions = new ArrayList<>();
+
+    private final AtomicBoolean started = new AtomicBoolean();
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    public Iec61850ClientService(Iec61850BridgeConfig config,
+                                 Iec61850MmsClient mms,
+                                 AbstractBridgeAuditOutput audit) {
+        this.config = Objects.requireNonNull(config, "config");
+        this.mms = Objects.requireNonNull(mms, "mms");
+        this.audit = Objects.requireNonNull(audit, "audit");
+    }
+
+    /**
+     * Parse every configured IED's SCL file, register read bindings,
+     * subscribe to event bindings, and prepare per-binding queues. Fails
+     * fast at the first missing or malformed SCL — there is no fallback
+     * (§6 last line).
+     */
+    public synchronized void start() throws IOException {
+        if (started.get() || closed.get()) return;
+        for (Iec61850BridgeConfig.IedConfig ied : config.ied()) {
+            SclParser.SclModel model = SclParser.parseFile(Paths.get(ied.sclFile()));
+            sclByIed.put(ied.id(), model);
+        }
+        for (Iec61850BridgeConfig.DaReadConfig r : config.reads()) {
+            Iec61850DaBinding b = Iec61850DaBinding.fromConfig(r);
+            readBindings.put(b.bindingId(), b);
+            queueByBinding.put(b.bindingId(), new ArrayDeque<>());
+        }
+        for (Iec61850BridgeConfig.ReportEventConfig e : config.events()) {
+            eventBindings.put(e.bindingId(), e);
+            queueByBinding.put(e.bindingId(), new ArrayDeque<>());
+            try {
+                AutoCloseable sub = mms.subscribeReport(
+                        e.iedId(), e.reportControlBlock(),
+                        report -> onReport(e, report));
+                subscriptions.add(sub);
+            } catch (IOException io) {
+                audit.append(new BridgeAuditRecord(
+                        System.currentTimeMillis(), 0, BRIDGE_NAME,
+                        BridgeAuditRecord.Verdict.FAILED, e.bindingId(),
+                        e.reportControlBlock(), null, null,
+                        BridgeAuditRecord.RejectReason.EXCEPTION + ":SUBSCRIBE",
+                        null, List.of()));
+                throw io;
+            }
+        }
+        started.set(true);
+        log.info("Iec61850ClientService started; ieds={} reads={} events={}",
+                sclByIed.size(), readBindings.size(), eventBindings.size());
+    }
+
+    /**
+     * Run one polling cycle over the read bindings. Each binding reads
+     * one Data Attribute from its IED and, if a value is present, enqueues
+     * a mapped signal. MMS read errors are isolated per binding — one
+     * binding failing must not stop the cycle for the others.
+     */
+    public synchronized void poll() {
+        if (!isStarted()) return;
+        if (!mms.isReady()) {
+            log.debug("Iec61850ClientService.poll: MMS not ready, skipping cycle");
+            return;
+        }
+        for (Iec61850DaBinding b : readBindings.values()) {
+            try {
+                Iec61850MmsClient.MmsRead read = mms.readDa(b.iedId(), b.daPath());
+                IInputSignal mapped = Iec61850SignalMapper.mapDaRead(b, read);
+                if (mapped != null) enqueue(b.bindingId(), mapped);
+            } catch (IOException | RuntimeException e) {
+                audit.append(new BridgeAuditRecord(
+                        System.currentTimeMillis(), 0, BRIDGE_NAME,
+                        BridgeAuditRecord.Verdict.FAILED, b.loopId(), b.signalTag(),
+                        null, null,
+                        BridgeAuditRecord.RejectReason.EXCEPTION + ":" + e.getClass().getSimpleName(),
+                        null, List.of()));
+                log.warn("Iec61850ClientService: binding={} failed: {}",
+                        b.bindingId(), e.getMessage());
+            }
+        }
+    }
+
+    private void onReport(Iec61850BridgeConfig.ReportEventConfig event,
+                          Iec61850MmsClient.MmsReport report) {
+        try {
+            List<IInputSignal> signals = Iec61850SignalMapper.mapReport(
+                    event, report, event.bindingId());
+            for (IInputSignal s : signals) enqueue(event.bindingId(), s);
+        } catch (RuntimeException ex) {
+            audit.append(new BridgeAuditRecord(
+                    System.currentTimeMillis(), 0, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.FAILED, event.bindingId(),
+                    event.reportControlBlock(), null, null,
+                    BridgeAuditRecord.RejectReason.EXCEPTION + ":REPORT",
+                    null, List.of()));
+            log.warn("Iec61850ClientService: report handler for binding={} threw: {}",
+                    event.bindingId(), ex.getMessage());
+        }
+    }
+
+    private void enqueue(String bindingId, IInputSignal signal) {
+        Deque<IInputSignal> q = queueByBinding.get(bindingId);
+        if (q == null) return;
+        synchronized (q) {
+            int dropped = 0;
+            while (q.size() >= DEFAULT_RING_BUFFER) {
+                q.pollFirst();
+                dropped++;
+            }
+            q.addLast(signal);
+            if (dropped > 0) {
+                audit.append(new BridgeAuditRecord(
+                        System.currentTimeMillis(), 0, BRIDGE_NAME,
+                        BridgeAuditRecord.Verdict.REJECTED, bindingId, null, null, null,
+                        "RING_BUFFER_OVERFLOW:dropped=" + dropped, null, List.of()));
+            }
+        }
+    }
+
+    /** Drain (and clear) the decoded signal queue for one binding. */
+    public List<IInputSignal> drain(String bindingId) {
+        Deque<IInputSignal> q = queueByBinding.get(bindingId);
+        if (q == null || q.isEmpty()) return List.of();
+        synchronized (q) {
+            List<IInputSignal> snap = new ArrayList<>(q);
+            q.clear();
+            return snap;
+        }
+    }
+
+    public boolean isStarted() { return started.get() && !closed.get(); }
+
+    public Map<String, Iec61850DaBinding> readBindings() { return Map.copyOf(readBindings); }
+
+    public Map<String, Iec61850BridgeConfig.ReportEventConfig> eventBindings() {
+        return Map.copyOf(eventBindings);
+    }
+
+    /** Parsed SCL model for an IED, or {@code null} if no such IED is configured. */
+    public SclParser.SclModel scl(String iedId) { return sclByIed.get(iedId); }
+
+    public Iec61850BridgeConfig config() { return config; }
+
+    @Override
+    public synchronized void close() {
+        if (!closed.compareAndSet(false, true)) return;
+        for (AutoCloseable sub : subscriptions) {
+            try { sub.close(); } catch (Exception e) {
+                log.warn("Iec61850ClientService: subscription close threw: {}", e.getMessage());
+            }
+        }
+        subscriptions.clear();
+        try { mms.close(); } catch (RuntimeException e) {
+            log.warn("Iec61850MmsClient close threw: {}", e.getMessage());
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static Path requirePath(String s) { return Paths.get(s); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850DaBinding.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850DaBinding.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.iec61850;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeBinding;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeBindingDirection;
+
+import java.util.Objects;
+
+/**
+ * Resolved per-binding IEC 61850 Data Attribute read (11-IEC61850.md §6, §7).
+ *
+ * <p>Every binding is {@link BridgeBindingDirection#READ} — the IEC 61850
+ * bridge has no write direction (§0, §3). The clamp / ramp / fail-safe
+ * fields required by {@link BridgeBinding} are therefore {@code null};
+ * they exist on the interface so the universal audit path treats an IEC
+ * binding uniformly with industrial bindings, but the bridge never
+ * invokes them (no write code path exists).
+ */
+public record Iec61850DaBinding(
+        String bindingId,
+        String iedId,
+        String daPath,
+        String signalTag,
+        Iec61850BridgeConfig.TargetSignal targetSignal
+) implements BridgeBinding {
+
+    public Iec61850DaBinding {
+        Objects.requireNonNull(bindingId, "bindingId");
+        Objects.requireNonNull(iedId, "iedId");
+        Objects.requireNonNull(daPath, "daPath");
+        Objects.requireNonNull(signalTag, "signalTag");
+        Objects.requireNonNull(targetSignal, "targetSignal");
+    }
+
+    public static Iec61850DaBinding fromConfig(Iec61850BridgeConfig.DaReadConfig r) {
+        return new Iec61850DaBinding(
+                r.bindingId(),
+                r.iedId(),
+                r.daPath(),
+                r.signalTag(),
+                r.targetSignal());
+    }
+
+    @Override public BridgeBindingDirection direction() { return BridgeBindingDirection.READ; }
+    @Override public String loopId() { return bindingId; }
+    @Override public Double failSafeValue() { return null; }
+    @Override public Double rampRateMaxPerSec() { return null; }
+    @Override public Double minClampValue() { return null; }
+    @Override public Double maxClampValue() { return null; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850EventInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850EventInput.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.iec61850;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IInitInput} that drains IEC 61850 event bindings — Report Control
+ * Block reports (and, later, GOOSE multicast) translated to
+ * {@link AlarmSignal}s (11-IEC61850.md §7 — {@code Iec61850EventInput}).
+ *
+ * <p>11-IEC61850.md §8 phase 3 deliberately defers GOOSE listener wiring
+ * (separate thread, raw socket / VLAN config); the bridge phase plan
+ * keeps event ingestion to Report Control Blocks for v1. The
+ * {@link Iec61850ClientService} routes both into the same per-binding
+ * queues — adding a GOOSE listener does not change this adapter.
+ */
+public final class Iec61850EventInput implements IInitInput {
+
+    /** Aligned with {@link AlarmSignal#PROCESSING_FREQUENCY}. */
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = AlarmSignal.PROCESSING_FREQUENCY;
+
+    private final String name;
+    private final Iec61850ClientService svc;
+    private final List<String> bindingIds;
+
+    public Iec61850EventInput(String name, Iec61850ClientService svc, List<String> bindingIds) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.bindingIds = List.copyOf(Objects.requireNonNull(bindingIds, "bindingIds"));
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        List<IInputSignal> out = new ArrayList<>();
+        for (String b : bindingIds) out.addAll(svc.drain(b));
+        return out;
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() { return new HashMap<>(); }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() { return PROCESSING_FREQUENCY; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850MeasurementInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850MeasurementInput.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.iec61850;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IInitInput} that drains IEC 61850 read bindings
+ * (11-IEC61850.md §7 — {@code Iec61850MeasurementInput}).
+ *
+ * <p>The {@link Iec61850ClientService} polls the configured Data Attributes
+ * once per tick and decodes them via {@link Iec61850SignalMapper}; this
+ * adapter only walks the configured binding-id list and snapshots their
+ * queues. {@code getDesiredResults()} is empty — the bridge is read-only
+ * and has no aggregator (§7).
+ */
+public final class Iec61850MeasurementInput implements IInitInput {
+
+    /** Aligned with {@link MeasurementSignal#PROCESSING_FREQUENCY} so the
+     *  bridge pace matches the consumer neuron's cadence. */
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = MeasurementSignal.PROCESSING_FREQUENCY;
+
+    private final String name;
+    private final Iec61850ClientService svc;
+    private final List<String> bindingIds;
+
+    public Iec61850MeasurementInput(String name, Iec61850ClientService svc, List<String> bindingIds) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.bindingIds = List.copyOf(Objects.requireNonNull(bindingIds, "bindingIds"));
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        List<IInputSignal> out = new ArrayList<>();
+        for (String b : bindingIds) out.addAll(svc.drain(b));
+        return out;
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() { return new HashMap<>(); }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() { return PROCESSING_FREQUENCY; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850MmsClient.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850MmsClient.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.iec61850;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Read-only MMS transport seam (11-IEC61850.md §4).
+ *
+ * <p>The bridge talks to IEDs only through this interface. No method
+ * writes a Data Attribute, issues a select-before-operate, or controls a
+ * breaker — substation control writes are a SIL-classified function that
+ * lives on certified RTUs and protection relays (§3). A production
+ * implementation backed by {@code org.openmuc:iec61850bean} or the JNI
+ * bindings of {@code libiec61850} provides only the methods on this
+ * surface; an attempt to add a write method here is a build break.
+ *
+ * <p>Acceptance tests use {@link InMemoryIec61850MmsClient}.
+ */
+public interface Iec61850MmsClient extends AutoCloseable {
+
+    /** {@code true} when the underlying MMS association is ready for reads. */
+    boolean isReady();
+
+    /**
+     * Read one Data Attribute by its IEC 61850 functional-constraint path
+     * (e.g. {@code "LD0/MMXU1.PhV.phsA.cVal.mag.f"}). Implementations
+     * return a snapshot of the latest value, optionally with a
+     * vendor-provided quality and timestamp; if the IED has not reported
+     * a value yet, the result MUST be {@link MmsRead#none()}.
+     *
+     * @throws IOException on association failure — caller decides whether
+     *                     to enter the reconnect loop.
+     */
+    MmsRead readDa(String iedId, String daPath) throws IOException;
+
+    /**
+     * Subscribe to a Report Control Block on an IED. The {@code consumer}
+     * is invoked once per buffered or unbuffered report from the IED.
+     * Implementations MUST decouple the consumer from any network thread
+     * — runtime exceptions thrown by the consumer must be isolated.
+     *
+     * @return an {@link AutoCloseable} that cancels the subscription;
+     *         closing twice is a no-op.
+     */
+    AutoCloseable subscribeReport(String iedId, String reportControlBlock,
+                                  Consumer<MmsReport> consumer) throws IOException;
+
+    @Override
+    void close();
+
+    /**
+     * Quality flag taken from the IEC 61850 {@code q} attribute. The
+     * mapping to {@link com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.Quality}
+     * is documented in 11-IEC61850.md §5: {@code GOOD→GOOD},
+     * {@code INVALID→BAD}, {@code QUESTIONABLE→UNCERTAIN},
+     * {@code SUBSTITUTED→UNCERTAIN}.
+     */
+    enum Iec61850Quality { GOOD, INVALID, QUESTIONABLE, SUBSTITUTED }
+
+    /** Snapshot of a Data Attribute read. Immutable; nulls allowed. */
+    record MmsRead(Double numericValue, Boolean booleanValue,
+                   Iec61850Quality quality, Long sourceTimestampMillis) {
+
+        public static MmsRead none() {
+            return new MmsRead(null, null, null, null);
+        }
+
+        public static MmsRead measurement(double value, Iec61850Quality q, long ts) {
+            return new MmsRead(value, null, q == null ? Iec61850Quality.GOOD : q, ts);
+        }
+
+        public static MmsRead status(boolean closed, Iec61850Quality q, long ts) {
+            return new MmsRead(null, closed, q == null ? Iec61850Quality.GOOD : q, ts);
+        }
+
+        public boolean isAbsent() {
+            return numericValue == null && booleanValue == null;
+        }
+    }
+
+    /**
+     * One report from a Report Control Block (RP/BR). Contains one
+     * {@link Entry} per Data Set member flagged by the report's data-set
+     * reasons. Used for protection-trip awareness and status changes.
+     */
+    record MmsReport(String reportControlBlock,
+                     long sourceTimestampMillis,
+                     List<Entry> entries) {
+
+        public MmsReport {
+            entries = entries == null ? List.of() : List.copyOf(entries);
+        }
+
+        /**
+         * One Data Set member in a report. {@code logicalNodeClass} is the
+         * 4-letter IEC 61850 LN class (e.g. {@code "PIOC"}, {@code "PTOC"})
+         * used to look up the severity in
+         * {@link Iec61850BridgeConfig.ReportEventConfig#severityMap()}.
+         */
+        public record Entry(String daPath,
+                            String logicalNodeClass,
+                            Double numericValue,
+                            Boolean booleanValue,
+                            Iec61850Quality quality,
+                            String reason) {
+            public Entry {
+                // null reason is fine — IEC 61850 reports do not always carry one.
+            }
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850SignalMapper.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850SignalMapper.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.iec61850;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmPriority;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.Quality;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Pure-function mapping from IEC 61850 reads / reports to Jneopallium
+ * signals (11-IEC61850.md §5).
+ *
+ * <p>Mapping table (verbatim from §5):
+ * <ul>
+ *   <li>{@code MMXU} measurements (PhV/PhA/W/Hz, ...) →
+ *       {@link MeasurementSignal} with {@link Quality} from the {@code q}
+ *       attribute.</li>
+ *   <li>{@code XCBR.Pos} breaker position →
+ *       {@link MeasurementSignal} with value {@code 1.0} for CLOSED and
+ *       {@code 0.0} for OPEN. The 11-IEC61850.md §5 mapping names
+ *       {@code InterlockSignal} for state semantics; the framework reserves
+ *       that signal type for the aggregator's interlock-trip path
+ *       (00-FRAMEWORK §0 rule 2), so a state observation from a breaker
+ *       lives on the measurement channel — never as a directive.</li>
+ *   <li>{@code PIOC}/{@code PTOC} operate signals →
+ *       {@link AlarmSignal} with severity from the binding's
+ *       {@code severityMap}. These are protection trips — read-only
+ *       awareness, not commands.</li>
+ *   <li>Other Logical Node classes default to {@link AlarmPriority#JOURNAL}.</li>
+ * </ul>
+ *
+ * <p>Per 00-FRAMEWORK §0 rule 5, quality propagates unmodified: an
+ * {@code INVALID} {@code q} attribute becomes {@link Quality#BAD};
+ * {@code QUESTIONABLE} and {@code SUBSTITUTED} both become
+ * {@link Quality#UNCERTAIN}. Untrustworthy data is never silently
+ * promoted to "good".
+ */
+public final class Iec61850SignalMapper {
+
+    /** Conservative default if a Logical Node class is not in the binding's severity map. */
+    public static final AlarmPriority DEFAULT_ALARM_PRIORITY = AlarmPriority.JOURNAL;
+
+    private Iec61850SignalMapper() {}
+
+    /** §5 quality mapping. {@code null} maps to {@link Quality#UNCERTAIN}. */
+    public static Quality mapQuality(Iec61850MmsClient.Iec61850Quality q) {
+        if (q == null) return Quality.UNCERTAIN;
+        return switch (q) {
+            case GOOD -> Quality.GOOD;
+            case INVALID -> Quality.BAD;
+            case QUESTIONABLE, SUBSTITUTED -> Quality.UNCERTAIN;
+        };
+    }
+
+    /**
+     * Build the input signal a DA read produces, or {@code null} if the
+     * read is absent (no current value reported by the IED).
+     */
+    public static IInputSignal mapDaRead(Iec61850DaBinding binding,
+                                         Iec61850MmsClient.MmsRead read) {
+        Objects.requireNonNull(binding, "binding");
+        Objects.requireNonNull(read, "read");
+        if (read.isAbsent()) return null;
+        long ts = read.sourceTimestampMillis() != null
+                ? read.sourceTimestampMillis() : System.currentTimeMillis();
+        Quality quality = mapQuality(read.quality());
+
+        return switch (binding.targetSignal()) {
+            case MEASUREMENT -> new MeasurementSignal(
+                    binding.signalTag(),
+                    read.numericValue() != null ? read.numericValue()
+                            : (Boolean.TRUE.equals(read.booleanValue()) ? 1.0 : 0.0),
+                    quality, ts);
+            case STATUS -> {
+                boolean closed = Boolean.TRUE.equals(read.booleanValue());
+                yield new MeasurementSignal(
+                        binding.signalTag(),
+                        closed ? 1.0 : 0.0,
+                        quality, ts);
+            }
+            case ALARM -> new AlarmSignal(
+                    DEFAULT_ALARM_PRIORITY, binding.signalTag(),
+                    summariseDaPath(binding.daPath()), ts);
+        };
+    }
+
+    /**
+     * Build the alarm signals one Report Control Block report produces.
+     * Severity is looked up per Logical Node class against the binding's
+     * {@code severityMap} (11-IEC61850.md §6); entries whose LN class is
+     * absent from the map fall through to {@link #DEFAULT_ALARM_PRIORITY}.
+     */
+    public static List<IInputSignal> mapReport(Iec61850BridgeConfig.ReportEventConfig event,
+                                               Iec61850MmsClient.MmsReport report,
+                                               String signalTagPrefix) {
+        Objects.requireNonNull(event, "event");
+        Objects.requireNonNull(report, "report");
+        long ts = report.sourceTimestampMillis() > 0
+                ? report.sourceTimestampMillis() : System.currentTimeMillis();
+        List<IInputSignal> out = new ArrayList<>(report.entries().size());
+        Map<String, String> sev = event.severityMap();
+        String prefix = signalTagPrefix == null ? event.bindingId() : signalTagPrefix;
+        for (Iec61850MmsClient.MmsReport.Entry entry : report.entries()) {
+            AlarmPriority p = priorityFor(entry.logicalNodeClass(), sev);
+            String tag = prefix + "." + entry.logicalNodeClass();
+            String reason = entry.reason() == null
+                    ? protectionConditionFor(entry.logicalNodeClass()) : entry.reason();
+            out.add(new AlarmSignal(p, tag, reason, ts));
+        }
+        return out;
+    }
+
+    private static AlarmPriority priorityFor(String lnClass, Map<String, String> sev) {
+        if (lnClass == null) return DEFAULT_ALARM_PRIORITY;
+        String configured = sev.get(lnClass);
+        if (configured == null) return DEFAULT_ALARM_PRIORITY;
+        // §6 vocabulary: CRITICAL / HIGH / LOW / JOURNAL. CRITICAL maps to
+        // URGENT in ISA-18.2 (the closest in-tree priority — there is no
+        // CRITICAL value on AlarmPriority).
+        return switch (configured.toUpperCase()) {
+            case "CRITICAL", "URGENT" -> AlarmPriority.URGENT;
+            case "HIGH" -> AlarmPriority.HIGH;
+            case "LOW" -> AlarmPriority.LOW;
+            default -> AlarmPriority.JOURNAL;
+        };
+    }
+
+    /**
+     * Default condition code for the protection-LN classes called out in
+     * the spec (§5 — "PIOC/PTOC operate signals").
+     */
+    private static String protectionConditionFor(String lnClass) {
+        if (lnClass == null) return "EVENT";
+        return switch (lnClass) {
+            case "PIOC", "PTOC", "PTUV", "PTOV", "PDIF" -> "PROTECTION_OPERATE";
+            case "XCBR", "XSWI" -> "BREAKER_POSITION_CHANGE";
+            default -> "EVENT";
+        };
+    }
+
+    private static String summariseDaPath(String daPath) {
+        int slash = daPath.indexOf('/');
+        return slash < 0 ? daPath : daPath.substring(slash + 1);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/InMemoryIec61850MmsClient.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/InMemoryIec61850MmsClient.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.iec61850;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+
+/**
+ * In-memory {@link Iec61850MmsClient} used by acceptance tests
+ * (11-IEC61850.md §9 S7, S8, S10).
+ *
+ * <p>Lets a test pre-load latest values per {@code <iedId, daPath>} pair
+ * and trigger Report Control Block reports on demand. No network is
+ * involved — the in-memory client mirrors the simulator-driven setup
+ * described in §8 phase 1 (run libiec61850's
+ * {@code server_example_basic_io} on {@code localhost:102}) but without
+ * shelling out to native code.
+ *
+ * <p>Like the production seam, this implementation exposes <b>no write
+ * methods</b>: there is no path to set a Data Attribute on the
+ * simulated IED.
+ */
+public final class InMemoryIec61850MmsClient implements Iec61850MmsClient {
+
+    private final Map<String, MmsRead> values = new ConcurrentHashMap<>();
+    private final Map<String, List<Subscription>> subscriptions = new ConcurrentHashMap<>();
+    private volatile boolean ready = true;
+    private volatile boolean failNextRead;
+    private volatile IOException nextException;
+
+    public InMemoryIec61850MmsClient putMeasurement(String iedId, String daPath,
+                                                    double value,
+                                                    Iec61850Quality quality,
+                                                    long sourceTimestampMillis) {
+        values.put(key(iedId, daPath),
+                MmsRead.measurement(value, quality, sourceTimestampMillis));
+        return this;
+    }
+
+    public InMemoryIec61850MmsClient putStatus(String iedId, String daPath,
+                                               boolean closed,
+                                               Iec61850Quality quality,
+                                               long sourceTimestampMillis) {
+        values.put(key(iedId, daPath),
+                MmsRead.status(closed, quality, sourceTimestampMillis));
+        return this;
+    }
+
+    public InMemoryIec61850MmsClient setReady(boolean ready) {
+        this.ready = ready;
+        return this;
+    }
+
+    public InMemoryIec61850MmsClient failNextReadWith(IOException ex) {
+        this.failNextRead = true;
+        this.nextException = Objects.requireNonNull(ex, "ex");
+        return this;
+    }
+
+    /**
+     * Fan out a synthetic report to every active subscriber of
+     * {@code reportControlBlock} on {@code iedId}.
+     */
+    public void emitReport(String iedId, String reportControlBlock, MmsReport report) {
+        List<Subscription> subs = subscriptions.get(key(iedId, reportControlBlock));
+        if (subs == null) return;
+        for (Subscription s : List.copyOf(subs)) {
+            if (s.active) s.consumer.accept(report);
+        }
+    }
+
+    @Override
+    public boolean isReady() {
+        return ready;
+    }
+
+    @Override
+    public MmsRead readDa(String iedId, String daPath) throws IOException {
+        if (failNextRead) {
+            failNextRead = false;
+            IOException ex = nextException;
+            nextException = null;
+            throw ex == null ? new IOException("simulated read failure") : ex;
+        }
+        MmsRead v = values.get(key(iedId, daPath));
+        return v == null ? MmsRead.none() : v;
+    }
+
+    @Override
+    public AutoCloseable subscribeReport(String iedId, String reportControlBlock,
+                                         Consumer<MmsReport> consumer) {
+        Objects.requireNonNull(consumer, "consumer");
+        String k = key(iedId, reportControlBlock);
+        Subscription s = new Subscription(consumer);
+        subscriptions.computeIfAbsent(k, kk -> new ArrayList<>()).add(s);
+        return () -> {
+            s.active = false;
+            List<Subscription> list = subscriptions.get(k);
+            if (list != null) list.remove(s);
+        };
+    }
+
+    @Override
+    public void close() {
+        subscriptions.clear();
+    }
+
+    /** Snapshot the registered values (test inspection only). */
+    public Map<String, MmsRead> snapshot() {
+        return new LinkedHashMap<>(values);
+    }
+
+    private static String key(String iedId, String tail) {
+        return iedId + "::" + tail;
+    }
+
+    private static final class Subscription {
+        final Consumer<MmsReport> consumer;
+        volatile boolean active = true;
+        Subscription(Consumer<MmsReport> consumer) {
+            this.consumer = consumer;
+        }
+    }
+
+    /** Convenience: build a Logical-Node-keyed report entry list. */
+    public static List<MmsReport.Entry> entriesFor(Map<String, String> lnClassToCondition) {
+        List<MmsReport.Entry> out = new ArrayList<>(lnClassToCondition.size());
+        for (Map.Entry<String, String> e : new HashMap<>(lnClassToCondition).entrySet()) {
+            out.add(new MmsReport.Entry(null, e.getKey(), null, Boolean.TRUE,
+                    Iec61850Quality.GOOD, e.getValue()));
+        }
+        return out;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/SclParser.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/SclParser.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.iec61850;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Minimal SCL (Substation Configuration Language) parser
+ * (11-IEC61850.md §7 — {@code SclParser.java}).
+ *
+ * <p>SCL is the ground-truth data model for an IED — parsing it lets the
+ * bridge resolve Data Attribute paths and Logical Node classes without
+ * relying on runtime introspection of the device. This parser is
+ * intentionally narrow: it extracts the
+ * {@code IED → AccessPoint → Server → LDevice → LN → DO → DA} skeleton
+ * needed to validate read bindings and identify Logical Node classes
+ * (so the bridge can map an {@code PIOC} report entry to the right
+ * severity per §5).
+ *
+ * <p>SCL dialect drift between vendors is mitigated by:
+ * <ul>
+ *   <li>Ignoring namespaces — the parser is element-name driven.</li>
+ *   <li>Ignoring attributes the bridge does not use (data types, addresses,
+ *       services). This keeps the parser stable across ABB, Schneider, SEL
+ *       and other vendor stacks (§10 R3).</li>
+ * </ul>
+ *
+ * <p>The bridge <b>fails fast at startup</b> if the SCL file is missing or
+ * malformed (§9 S9; §6 last line).
+ */
+public final class SclParser {
+
+    private SclParser() {}
+
+    /** Parse an SCL file by path. Throws {@link IOException} if the file is missing. */
+    public static SclModel parseFile(Path file) throws IOException {
+        if (!Files.exists(file)) {
+            throw new IOException(
+                    "IEC 61850 bridge: SCL file not found at " + file
+                            + " (11-IEC61850.md §6 — SCL is required ground-truth; "
+                            + "the bridge fails fast at startup).");
+        }
+        try (InputStream in = Files.newInputStream(file)) {
+            return parse(in);
+        }
+    }
+
+    /** Parse an SCL stream. */
+    public static SclModel parse(InputStream in) throws IOException {
+        Objects.requireNonNull(in, "in");
+        XMLInputFactory factory = XMLInputFactory.newFactory();
+        factory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false);
+        factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+
+        List<Ied> ieds = new ArrayList<>();
+        Ied currentIed = null;
+        LDevice currentLd = null;
+        LNode currentLn = null;
+        DataObject currentDo = null;
+
+        try {
+            XMLStreamReader r = factory.createXMLStreamReader(in);
+            while (r.hasNext()) {
+                int event = r.next();
+                if (event == XMLStreamReader.START_ELEMENT) {
+                    String name = localName(r.getLocalName());
+                    switch (name) {
+                        case "IED" -> currentIed = new Ied(attr(r, "name"));
+                        case "LDevice" -> {
+                            if (currentIed != null) {
+                                currentLd = new LDevice(attr(r, "inst"));
+                                currentIed.devices.add(currentLd);
+                            }
+                        }
+                        case "LN0", "LN" -> {
+                            if (currentLd != null) {
+                                String lnClass = attr(r, "lnClass");
+                                String prefix = attr(r, "prefix");
+                                String inst = attr(r, "inst");
+                                currentLn = new LNode(lnClass, prefix, inst);
+                                currentLd.nodes.add(currentLn);
+                            }
+                        }
+                        case "DOI" -> {
+                            if (currentLn != null) {
+                                currentDo = new DataObject(attr(r, "name"));
+                                currentLn.dataObjects.add(currentDo);
+                            }
+                        }
+                        case "DAI" -> {
+                            if (currentDo != null) {
+                                currentDo.attributes.add(new DataAttribute(
+                                        attr(r, "name"), attr(r, "valKind")));
+                            }
+                        }
+                        default -> { /* ignore */ }
+                    }
+                } else if (event == XMLStreamReader.END_ELEMENT) {
+                    String name = localName(r.getLocalName());
+                    switch (name) {
+                        case "IED" -> { if (currentIed != null) { ieds.add(currentIed); currentIed = null; } }
+                        case "LDevice" -> currentLd = null;
+                        case "LN0", "LN" -> currentLn = null;
+                        case "DOI" -> currentDo = null;
+                        default -> { /* ignore */ }
+                    }
+                }
+            }
+            r.close();
+        } catch (XMLStreamException e) {
+            throw new IOException(
+                    "IEC 61850 bridge: malformed SCL — " + e.getMessage()
+                            + " (11-IEC61850.md §6 — bridge fails fast at startup "
+                            + "if SCL is missing or malformed).", e);
+        }
+        return new SclModel(ieds);
+    }
+
+    private static String localName(String n) {
+        int idx = n.indexOf(':');
+        return idx < 0 ? n : n.substring(idx + 1);
+    }
+
+    private static String attr(XMLStreamReader r, String name) {
+        for (int i = 0; i < r.getAttributeCount(); i++) {
+            if (name.equals(r.getAttributeLocalName(i))) return r.getAttributeValue(i);
+        }
+        return null;
+    }
+
+    /** Parsed SCL document, narrowed to the fields the bridge uses. */
+    public static final class SclModel {
+        private final List<Ied> ieds;
+
+        SclModel(List<Ied> ieds) {
+            this.ieds = List.copyOf(ieds);
+        }
+
+        public List<Ied> ieds() { return ieds; }
+
+        public Ied iedByName(String name) {
+            for (Ied i : ieds) if (name.equals(i.name())) return i;
+            return null;
+        }
+
+        /**
+         * Find the Logical Node class for a Data Attribute path of the form
+         * {@code "<LD>/<LN>.<DO>.<DA>..."} where {@code <LN>} may include a
+         * prefix and instance suffix. Returns {@code null} if the path
+         * cannot be resolved against this SCL.
+         */
+        public String resolveLogicalNodeClass(String daPath) {
+            if (daPath == null) return null;
+            int slash = daPath.indexOf('/');
+            if (slash < 0) return null;
+            String ldInst = daPath.substring(0, slash);
+            String tail = daPath.substring(slash + 1);
+            int dot = tail.indexOf('.');
+            String lnToken = dot < 0 ? tail : tail.substring(0, dot);
+            for (Ied ied : ieds) {
+                for (LDevice ld : ied.devices) {
+                    if (ldInst.equals(ld.inst())) {
+                        for (LNode ln : ld.nodes) {
+                            if (lnToken.equals(ln.combinedName())) return ln.lnClass();
+                        }
+                        for (LNode ln : ld.nodes) {
+                            if (ln.lnClass() != null && lnToken.startsWith(ln.lnClass())) {
+                                return ln.lnClass();
+                            }
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+
+        /** Distinct list of Logical Node classes present in the SCL. */
+        public List<String> logicalNodeClasses() {
+            Map<String, Boolean> seen = new LinkedHashMap<>();
+            for (Ied ied : ieds) {
+                for (LDevice ld : ied.devices) {
+                    for (LNode ln : ld.nodes) {
+                        if (ln.lnClass() != null) seen.put(ln.lnClass(), Boolean.TRUE);
+                    }
+                }
+            }
+            return new ArrayList<>(seen.keySet());
+        }
+    }
+
+    /** IED element in SCL. */
+    public static final class Ied {
+        private final String name;
+        private final List<LDevice> devices = new ArrayList<>();
+        Ied(String name) { this.name = name; }
+        public String name() { return name; }
+        public List<LDevice> devices() { return List.copyOf(devices); }
+    }
+
+    /** Logical Device element. */
+    public static final class LDevice {
+        private final String inst;
+        private final List<LNode> nodes = new ArrayList<>();
+        LDevice(String inst) { this.inst = inst; }
+        public String inst() { return inst; }
+        public List<LNode> nodes() { return List.copyOf(nodes); }
+    }
+
+    /** Logical Node element ({@code LN0}/{@code LN}). */
+    public static final class LNode {
+        private final String lnClass;
+        private final String prefix;
+        private final String inst;
+        private final List<DataObject> dataObjects = new ArrayList<>();
+        LNode(String lnClass, String prefix, String inst) {
+            this.lnClass = lnClass;
+            this.prefix = prefix;
+            this.inst = inst;
+        }
+        public String lnClass() { return lnClass; }
+        public String prefix() { return prefix; }
+        public String inst() { return inst; }
+        public List<DataObject> dataObjects() { return List.copyOf(dataObjects); }
+
+        /** Canonical {@code <prefix><lnClass><inst>} token used in DA paths. */
+        public String combinedName() {
+            StringBuilder sb = new StringBuilder();
+            if (prefix != null) sb.append(prefix);
+            if (lnClass != null) sb.append(lnClass);
+            if (inst != null) sb.append(inst);
+            return sb.toString();
+        }
+    }
+
+    /** Data Object element. */
+    public static final class DataObject {
+        private final String name;
+        private final List<DataAttribute> attributes = new ArrayList<>();
+        DataObject(String name) { this.name = name; }
+        public String name() { return name; }
+        public List<DataAttribute> attributes() { return List.copyOf(attributes); }
+    }
+
+    /** Data Attribute leaf. */
+    public record DataAttribute(String name, String valKind) {}
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/package-info.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * IEC 61850 bridge — Bridge 11 (11-IEC61850.md).
+ *
+ * <p>Adapter that converts substation measurements, statuses and events
+ * produced by IEDs (protection relays, merging units, breaker controls)
+ * — surfaced through IEC 61850 MMS reads and report-control subscriptions
+ * — into {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal},
+ * {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.InterlockSignal}
+ * and
+ * {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal}
+ * instances that the Jneopallium pipeline can integrate with state
+ * estimation, anomaly detection and equipment-degradation modelling.
+ *
+ * <p><b>Bridge ceiling: READ-ONLY — initially.</b> This package contains no
+ * aggregator / output / write class (11-IEC61850.md §3, §4 diagram, §7
+ * "No aggregator class"). The {@link com.rakovpublic.jneuropallium.worker.bridge.iec61850.Iec61850MmsClient}
+ * seam exposes only read primitives — no method writes a Data Attribute,
+ * issues a select-before-operate, or controls a breaker. Substation
+ * control writes are a SIL-classified function that belongs on certified
+ * RTUs and protection relays; a Jneopallium bridge writing to an
+ * {@code Oper} attribute would act outside its certification scope
+ * (11-IEC61850.md §3).
+ *
+ * <p>A {@code writes:} block in the bridge YAML is rejected at
+ * config-load with a clear message
+ * ({@link com.rakovpublic.jneuropallium.worker.bridge.iec61850.Iec61850BridgeConfig#create}).
+ *
+ * <p>Acceptance tests use {@link com.rakovpublic.jneuropallium.worker.bridge.iec61850.InMemoryIec61850MmsClient}
+ * to simulate an IED without depending on a native MMS stack. A production
+ * adapter against {@code org.openmuc:iec61850bean} (or the JNI bindings of
+ * {@code libiec61850}) implements the same seam and slots in unchanged
+ * (11-IEC61850.md §2).
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.iec61850;

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850BridgeConfigLoaderTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850BridgeConfigLoaderTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.iec61850;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 11-IEC61850.md §6 — {@code writes:} block is rejected at config-load
+ * with a clear message; verifies the structural rejection mechanism
+ * plus the basic load-success path.
+ */
+class Iec61850BridgeConfigLoaderTest {
+
+    @Test
+    void writesBlockIsRejectedAtLoad() {
+        String yaml = """
+                ied:
+                  - id: "RELAY-A1"
+                    host: "10.50.1.10"
+                    port: 102
+                    sclFile: "/etc/jneopallium/scl/SUB1.icd"
+                audit:
+                  localAuditFile: "/tmp/iec61850.jsonl"
+                writes:
+                  - bindingId: ANY
+                """;
+        Exception ex = assertThrows(Exception.class, () -> Iec61850BridgeConfigLoader.load(yaml));
+        Throwable cause = unwrap(ex);
+        assertTrue(cause.getMessage().contains("writes:"),
+                "expected message to mention the writes: block, was: " + cause.getMessage());
+        assertTrue(cause.getMessage().contains("READ-ONLY"),
+                "expected message to reference READ-ONLY ceiling, was: " + cause.getMessage());
+        assertTrue(cause.getMessage().contains("iec61850-control"),
+                "expected message to point to the separate control bridge, was: "
+                        + cause.getMessage());
+    }
+
+    @Test
+    void minimalConfigLoads() throws IOException {
+        String yaml = """
+                ied:
+                  - id: "RELAY-A1"
+                    host: "10.50.1.10"
+                    port: 102
+                    sclFile: "/etc/jneopallium/scl/SUB1.icd"
+                    reportControlBlock: "LD0/LLN0.RP.urcbA01"
+                reads:
+                  - bindingId: "BUSBAR-V"
+                    iedId: "RELAY-A1"
+                    daPath: "LD0/MMXU1.PhV.phsA.cVal.mag.f"
+                    signalTag: "SUB1.BUSBAR.VA"
+                  - bindingId: "BREAKER-CB1-POS"
+                    iedId: "RELAY-A1"
+                    daPath: "LD0/XCBR1.Pos.stVal"
+                    signalTag: "SUB1.CB1.POS"
+                events:
+                  - bindingId: "PROT-OPS"
+                    iedId: "RELAY-A1"
+                    reportControlBlock: "LD0/LLN0.RP.urcbProt01"
+                    targetSignal: "ALARM"
+                    severityMap:
+                      PIOC: CRITICAL
+                      PTOC: CRITICAL
+                      PTUV: HIGH
+                audit:
+                  localAuditFile: "/tmp/iec61850.jsonl"
+                """;
+        Iec61850BridgeConfig cfg = Iec61850BridgeConfigLoader.load(yaml);
+        assertEquals(1, cfg.ied().size());
+        assertEquals("RELAY-A1", cfg.ied().get(0).id());
+        assertEquals(2, cfg.reads().size());
+        assertEquals(Iec61850BridgeConfig.TargetSignal.MEASUREMENT,
+                cfg.reads().get(0).targetSignal());
+        assertEquals(Iec61850BridgeConfig.TargetSignal.STATUS,
+                cfg.reads().get(1).targetSignal(),
+                "DA paths under XCBR/XSWI must auto-classify as STATUS");
+        assertEquals(1, cfg.events().size());
+        assertEquals("CRITICAL", cfg.events().get(0).severityMap().get("PIOC"));
+        assertNotNull(cfg.audit());
+    }
+
+    @Test
+    void unknownIedIdInReadBindingIsRejected() {
+        String yaml = """
+                ied:
+                  - id: "RELAY-A1"
+                    host: "10.50.1.10"
+                    port: 102
+                    sclFile: "/tmp/SUB1.icd"
+                reads:
+                  - bindingId: "ORPHAN"
+                    iedId: "DOES-NOT-EXIST"
+                    daPath: "LD0/MMXU1.PhV.phsA.cVal.mag.f"
+                    signalTag: "x"
+                audit:
+                  localAuditFile: "/tmp/iec61850.jsonl"
+                """;
+        Exception ex = assertThrows(Exception.class, () -> Iec61850BridgeConfigLoader.load(yaml));
+        Throwable cause = unwrap(ex);
+        assertTrue(cause.getMessage().contains("DOES-NOT-EXIST"),
+                "expected the unknown iedId in the message, was: " + cause.getMessage());
+    }
+
+    @Test
+    void duplicateBindingIdIsRejected() {
+        String yaml = """
+                ied:
+                  - id: "RELAY-A1"
+                    host: "10.50.1.10"
+                    port: 102
+                    sclFile: "/tmp/SUB1.icd"
+                reads:
+                  - bindingId: "DUP"
+                    iedId: "RELAY-A1"
+                    daPath: "LD0/MMXU1.PhV.phsA.cVal.mag.f"
+                    signalTag: "x"
+                  - bindingId: "DUP"
+                    iedId: "RELAY-A1"
+                    daPath: "LD0/MMXU2.A.phsA.cVal.mag.f"
+                    signalTag: "y"
+                audit:
+                  localAuditFile: "/tmp/iec61850.jsonl"
+                """;
+        Exception ex = assertThrows(Exception.class, () -> Iec61850BridgeConfigLoader.load(yaml));
+        Throwable cause = unwrap(ex);
+        assertTrue(cause.getMessage().contains("duplicate bindingId"),
+                "expected duplicate bindingId rejection, was: " + cause.getMessage());
+    }
+
+    @Test
+    void unknownKeyIsRejected() {
+        String yaml = """
+                ied:
+                  - id: "RELAY-A1"
+                    host: "10.50.1.10"
+                    port: 102
+                    sclFile: "/tmp/SUB1.icd"
+                audit:
+                  localAuditFile: "/tmp/iec61850.jsonl"
+                bogusKey: "should-fail"
+                """;
+        assertThrows(Exception.class, () -> Iec61850BridgeConfigLoader.load(yaml),
+                "FAIL_ON_UNKNOWN_PROPERTIES must reject typos at load time");
+    }
+
+    private static Throwable unwrap(Throwable t) {
+        Throwable cur = t;
+        while (cur instanceof JsonMappingException && cur.getCause() != null) {
+            cur = cur.getCause();
+        }
+        return cur;
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850BridgeIntegrationTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/Iec61850BridgeIntegrationTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.iec61850;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmPriority;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.Quality;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end tests for the IEC 61850 bridge (11-IEC61850.md §9 S7–S11
+ * plus 00-FRAMEWORK §5 universal scenarios S1, S2, S4, S5).
+ */
+class Iec61850BridgeIntegrationTest {
+
+    private static final String SCL = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+              <IED name="RELAY-A1">
+                <AccessPoint name="S1"><Server>
+                  <LDevice inst="LD0">
+                    <LN0 lnClass="LLN0" inst=""/>
+                    <LN lnClass="MMXU" inst="1"/>
+                    <LN lnClass="MMXU" inst="2"/>
+                    <LN lnClass="XCBR" inst="1"/>
+                    <LN lnClass="PIOC" inst="1"/>
+                    <LN lnClass="PTOC" inst="1"/>
+                  </LDevice>
+                </Server></AccessPoint>
+              </IED>
+            </SCL>
+            """;
+
+    private Path writeScl(Path tmp) throws IOException {
+        Path scl = tmp.resolve("SUB1.icd");
+        Files.writeString(scl, SCL, StandardCharsets.UTF_8);
+        return scl;
+    }
+
+    private Iec61850BridgeConfig baseConfig(Path tmp, Path auditFile) throws IOException {
+        Path scl = writeScl(tmp);
+        return new Iec61850BridgeConfig(
+                List.of(new Iec61850BridgeConfig.IedConfig(
+                        "RELAY-A1", "10.50.1.10", 102,
+                        scl.toString(), "LD0/LLN0.RP.urcbA01")),
+                List.of(
+                        new Iec61850BridgeConfig.DaReadConfig(
+                                "BUSBAR-V", "RELAY-A1",
+                                "LD0/MMXU1.PhV.phsA.cVal.mag.f",
+                                "SUB1.BUSBAR.VA",
+                                Iec61850BridgeConfig.TargetSignal.MEASUREMENT),
+                        new Iec61850BridgeConfig.DaReadConfig(
+                                "FEEDER-1-CURRENT", "RELAY-A1",
+                                "LD0/MMXU2.A.phsA.cVal.mag.f",
+                                "SUB1.FEED1.IA",
+                                Iec61850BridgeConfig.TargetSignal.MEASUREMENT),
+                        new Iec61850BridgeConfig.DaReadConfig(
+                                "BREAKER-CB1-POS", "RELAY-A1",
+                                "LD0/XCBR1.Pos.stVal",
+                                "SUB1.CB1.POS",
+                                Iec61850BridgeConfig.TargetSignal.STATUS)),
+                List.of(new Iec61850BridgeConfig.ReportEventConfig(
+                        "PROT-OPS", "RELAY-A1",
+                        "LD0/LLN0.RP.urcbProt01",
+                        "ALARM",
+                        Map.of("PIOC", "CRITICAL", "PTOC", "CRITICAL", "PTUV", "HIGH"))),
+                new Iec61850BridgeConfig.AuditConfig(auditFile.toString()),
+                null);
+    }
+
+    /** §9 S7 + framework S1 — Pure read against a simulated IED. */
+    @Test
+    void s7_pureReadEmitsMeasurementSignals(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        Iec61850BridgeConfig cfg = baseConfig(tmp, auditFile);
+        InMemoryIec61850MmsClient mms = new InMemoryIec61850MmsClient()
+                .putMeasurement("RELAY-A1",
+                        "LD0/MMXU1.PhV.phsA.cVal.mag.f", 11_002.5,
+                        Iec61850MmsClient.Iec61850Quality.GOOD, 1_700_000_000_000L)
+                .putMeasurement("RELAY-A1",
+                        "LD0/MMXU2.A.phsA.cVal.mag.f", 320.4,
+                        Iec61850MmsClient.Iec61850Quality.GOOD, 1_700_000_000_000L)
+                .putStatus("RELAY-A1",
+                        "LD0/XCBR1.Pos.stVal", true,
+                        Iec61850MmsClient.Iec61850Quality.GOOD, 1_700_000_000_000L);
+        try (Iec61850AuditOutput audit = new Iec61850AuditOutput(auditFile);
+             Iec61850ClientService svc = new Iec61850ClientService(cfg, mms, audit)) {
+            svc.start();
+            svc.poll();
+            Iec61850MeasurementInput input = new Iec61850MeasurementInput(
+                    "iec-demo", svc,
+                    List.of("BUSBAR-V", "FEEDER-1-CURRENT", "BREAKER-CB1-POS"));
+            List<IInputSignal> signals = input.readSignals();
+            assertEquals(3, signals.size(),
+                    "expected one signal per binding, was: " + signals);
+            MeasurementSignal busbar = (MeasurementSignal) signals.get(0);
+            assertEquals("SUB1.BUSBAR.VA", busbar.getTag());
+            assertEquals(11_002.5, busbar.getMeasurement(), 1e-9);
+            assertEquals(Quality.GOOD, busbar.getQuality());
+            assertEquals(1_700_000_000_000L, busbar.getTimestamp(),
+                    "framework §0 rule 6 — source timestamp wins");
+
+            MeasurementSignal pos = (MeasurementSignal) signals.get(2);
+            assertEquals(1.0, pos.getMeasurement(), 1e-9,
+                    "CLOSED breaker maps to 1.0 (status as observation, not directive)");
+        }
+    }
+
+    /** §9 S8 + framework S2 — Quality propagation. */
+    @Test
+    void s8_qualityPropagation(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        Iec61850BridgeConfig cfg = baseConfig(tmp, auditFile);
+        InMemoryIec61850MmsClient mms = new InMemoryIec61850MmsClient()
+                .putMeasurement("RELAY-A1",
+                        "LD0/MMXU1.PhV.phsA.cVal.mag.f", 11_000.0,
+                        Iec61850MmsClient.Iec61850Quality.INVALID, 1_700_000_000_000L);
+        try (Iec61850AuditOutput audit = new Iec61850AuditOutput(auditFile);
+             Iec61850ClientService svc = new Iec61850ClientService(cfg, mms, audit)) {
+            svc.start();
+            svc.poll();
+            Iec61850MeasurementInput input = new Iec61850MeasurementInput(
+                    "iec", svc, List.of("BUSBAR-V"));
+            List<IInputSignal> signals = input.readSignals();
+            assertEquals(1, signals.size());
+            MeasurementSignal s = (MeasurementSignal) signals.get(0);
+            assertEquals(Quality.BAD, s.getQuality(),
+                    "INVALID q-attribute must propagate as Quality.BAD (framework §0 rule 5)");
+            assertEquals(11_000.0, s.getMeasurement(), 1e-9,
+                    "value must be passed through unmodified despite bad quality");
+        }
+    }
+
+    /** §9 S9 — Bridge fails fast at startup when the SCL file is missing. */
+    @Test
+    void s9_missingSclFailsFastAtStartup(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        Iec61850BridgeConfig cfg = new Iec61850BridgeConfig(
+                List.of(new Iec61850BridgeConfig.IedConfig(
+                        "RELAY-A1", "10.50.1.10", 102,
+                        tmp.resolve("does-not-exist.icd").toString(), null)),
+                List.of(), List.of(),
+                new Iec61850BridgeConfig.AuditConfig(auditFile.toString()),
+                null);
+        InMemoryIec61850MmsClient mms = new InMemoryIec61850MmsClient();
+        try (Iec61850AuditOutput audit = new Iec61850AuditOutput(auditFile);
+             Iec61850ClientService svc = new Iec61850ClientService(cfg, mms, audit)) {
+            IOException ex = assertThrows(IOException.class, svc::start);
+            assertTrue(ex.getMessage().contains("SCL file not found"),
+                    "expected fail-fast on missing SCL, was: " + ex.getMessage());
+        }
+    }
+
+    /** §9 S10 — Report subscription emits AlarmSignal per report entry. */
+    @Test
+    void s10_reportSubscriptionEmitsAlarmSignals(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        Iec61850BridgeConfig cfg = baseConfig(tmp, auditFile);
+        InMemoryIec61850MmsClient mms = new InMemoryIec61850MmsClient();
+        try (Iec61850AuditOutput audit = new Iec61850AuditOutput(auditFile);
+             Iec61850ClientService svc = new Iec61850ClientService(cfg, mms, audit)) {
+            svc.start();
+            // Emit a synthetic protection trip on the subscribed RCB.
+            Map<String, String> reasons = new LinkedHashMap<>();
+            reasons.put("PIOC", "INST_OVERCURRENT");
+            reasons.put("PTOC", "TIMED_OVERCURRENT");
+            mms.emitReport("RELAY-A1", "LD0/LLN0.RP.urcbProt01",
+                    new Iec61850MmsClient.MmsReport(
+                            "LD0/LLN0.RP.urcbProt01",
+                            1_700_000_001_000L,
+                            InMemoryIec61850MmsClient.entriesFor(reasons)));
+
+            Iec61850EventInput input = new Iec61850EventInput(
+                    "iec-events", svc, List.of("PROT-OPS"));
+            List<IInputSignal> signals = input.readSignals();
+            assertEquals(2, signals.size(),
+                    "two report entries must produce two AlarmSignals");
+            AlarmSignal a = (AlarmSignal) signals.get(0);
+            assertEquals(AlarmPriority.URGENT, a.getPriority(),
+                    "PIOC/CRITICAL must escalate to URGENT (closest in-tree priority)");
+            assertNotNull(a.getConditionCode());
+            assertEquals(1_700_000_001_000L, a.getTimestamp(),
+                    "source-system timestamp must win (framework §0 rule 6)");
+        }
+    }
+
+    /**
+     * §9 S11 — Compile-time absence of an aggregator. There is no
+     * {@code Iec61850CommandOutputAggregator} class in this package; this
+     * test asserts it via {@link Class#forName} so the contract is
+     * enforced even if a future contributor tries to add one.
+     */
+    @Test
+    void s11_noWriteSurfaceExists() {
+        assertThrows(ClassNotFoundException.class,
+                () -> Class.forName(
+                        "com.rakovpublic.jneuropallium.worker.bridge.iec61850"
+                                + ".Iec61850CommandOutputAggregator"),
+                "11-IEC61850.md §7 — no aggregator class may exist in this package");
+    }
+
+    /** Framework §5 S4 — MMS not ready: poll cycle is a graceful no-op. */
+    @Test
+    void s4_mmsNotReadyIsGraceful(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        Iec61850BridgeConfig cfg = baseConfig(tmp, auditFile);
+        InMemoryIec61850MmsClient mms = new InMemoryIec61850MmsClient().setReady(false);
+        try (Iec61850AuditOutput audit = new Iec61850AuditOutput(auditFile);
+             Iec61850ClientService svc = new Iec61850ClientService(cfg, mms, audit)) {
+            svc.start();
+            svc.poll(); // must not throw
+            Iec61850MeasurementInput input = new Iec61850MeasurementInput(
+                    "iec", svc, List.of("BUSBAR-V"));
+            assertTrue(input.readSignals().isEmpty(),
+                    "no signals while MMS is not ready");
+        }
+    }
+
+    /**
+     * Framework §5 S5 — Audit failure isolation. A failing MMS read writes
+     * an audit record but does not throw out of {@code poll()}.
+     */
+    @Test
+    void s5_failingReadIsAuditedAndIsolated(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        Iec61850BridgeConfig cfg = baseConfig(tmp, auditFile);
+        InMemoryIec61850MmsClient mms = new InMemoryIec61850MmsClient()
+                .failNextReadWith(new IOException("association lost"))
+                .putMeasurement("RELAY-A1",
+                        "LD0/MMXU2.A.phsA.cVal.mag.f", 1.0,
+                        Iec61850MmsClient.Iec61850Quality.GOOD, 1L);
+        try (Iec61850AuditOutput audit = new Iec61850AuditOutput(auditFile);
+             Iec61850ClientService svc = new Iec61850ClientService(cfg, mms, audit)) {
+            svc.start();
+            svc.poll(); // must not throw
+        }
+        assertTrue(Files.exists(auditFile),
+                "audit JSONL must be created when MMS reads fail");
+        String content = Files.readString(auditFile);
+        assertTrue(content.contains("\"verdict\":\"FAILED\""),
+                "expected FAILED audit record on read failure, was: " + content);
+        assertTrue(content.contains("EXCEPTION:IOException"),
+                "expected EXCEPTION reason carrying the exception class, was: " + content);
+    }
+
+    /** Audit JSONL conformance to 00-FRAMEWORK §4 schema. */
+    @Test
+    void auditJsonlConformsToFrameworkSchema(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        Iec61850BridgeConfig cfg = baseConfig(tmp, auditFile);
+        InMemoryIec61850MmsClient mms = new InMemoryIec61850MmsClient()
+                .failNextReadWith(new IOException("simulated"));
+        try (Iec61850AuditOutput audit = new Iec61850AuditOutput(auditFile);
+             Iec61850ClientService svc = new Iec61850ClientService(cfg, mms, audit)) {
+            svc.start();
+            svc.poll();
+        }
+        String line = Files.readString(auditFile).strip();
+        assertTrue(line.startsWith("{") && line.endsWith("}"),
+                "audit must be one JSON object per line, was: " + line);
+        assertTrue(line.contains("\"bridge\":\"iec61850\""),
+                "audit must carry bridge identity, was: " + line);
+        assertTrue(line.contains("\"verdict\":"), "audit must carry verdict");
+        assertFalse(line.contains("\n"), "one record per line");
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/SclParserTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/iec61850/SclParserTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.iec61850;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 11-IEC61850.md §6 — SCL parser is the ground-truth resolver. Bridge
+ * fails fast when the SCL is missing or malformed.
+ */
+class SclParserTest {
+
+    @Test
+    void parsesMinimalSclIntoIeds(@TempDir Path tmp) throws IOException {
+        Path scl = tmp.resolve("SUB1.icd");
+        Files.writeString(scl, """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <SCL xmlns="http://www.iec.ch/61850/2003/SCL">
+                  <IED name="RELAY-A1">
+                    <AccessPoint name="S1">
+                      <Server>
+                        <LDevice inst="LD0">
+                          <LN0 lnClass="LLN0" inst=""/>
+                          <LN prefix="" lnClass="MMXU" inst="1">
+                            <DOI name="PhV"/>
+                          </LN>
+                          <LN prefix="" lnClass="XCBR" inst="1">
+                            <DOI name="Pos">
+                              <DAI name="stVal"/>
+                            </DOI>
+                          </LN>
+                          <LN prefix="" lnClass="PIOC" inst="1"/>
+                        </LDevice>
+                      </Server>
+                    </AccessPoint>
+                  </IED>
+                </SCL>
+                """, StandardCharsets.UTF_8);
+        SclParser.SclModel m = SclParser.parseFile(scl);
+        assertEquals(1, m.ieds().size());
+        assertNotNull(m.iedByName("RELAY-A1"));
+        assertEquals(1, m.iedByName("RELAY-A1").devices().size());
+        assertTrue(m.logicalNodeClasses().contains("MMXU"));
+        assertTrue(m.logicalNodeClasses().contains("XCBR"));
+        assertTrue(m.logicalNodeClasses().contains("PIOC"),
+                "PIOC class must be visible so the mapper can look up severity");
+    }
+
+    @Test
+    void resolvesLogicalNodeClassFromDaPath(@TempDir Path tmp) throws IOException {
+        Path scl = tmp.resolve("SUB1.icd");
+        Files.writeString(scl, """
+                <?xml version="1.0"?>
+                <SCL>
+                  <IED name="R">
+                    <AccessPoint name="S1"><Server>
+                      <LDevice inst="LD0">
+                        <LN0 lnClass="LLN0" inst=""/>
+                        <LN lnClass="MMXU" inst="1"/>
+                        <LN lnClass="XCBR" inst="1"/>
+                      </LDevice>
+                    </Server></AccessPoint>
+                  </IED>
+                </SCL>
+                """, StandardCharsets.UTF_8);
+        SclParser.SclModel m = SclParser.parseFile(scl);
+        assertEquals("MMXU", m.resolveLogicalNodeClass("LD0/MMXU1.PhV.phsA.cVal.mag.f"));
+        assertEquals("XCBR", m.resolveLogicalNodeClass("LD0/XCBR1.Pos.stVal"));
+    }
+
+    /** §9 S9 — bridge fails fast when SCL is missing. */
+    @Test
+    void missingSclFileThrowsIoException(@TempDir Path tmp) {
+        Path scl = tmp.resolve("nope.icd");
+        IOException ex = assertThrows(IOException.class, () -> SclParser.parseFile(scl));
+        assertTrue(ex.getMessage().contains("SCL file not found"),
+                "expected fail-fast on missing SCL, was: " + ex.getMessage());
+    }
+
+    @Test
+    void malformedSclFailsFast(@TempDir Path tmp) throws IOException {
+        Path scl = tmp.resolve("bad.icd");
+        Files.writeString(scl, "<SCL><IED name=\"R\"></SCL>");
+        IOException ex = assertThrows(IOException.class, () -> SclParser.parseFile(scl));
+        assertTrue(ex.getMessage().contains("malformed SCL"),
+                "expected fail-fast on malformed SCL, was: " + ex.getMessage());
+    }
+}


### PR DESCRIPTION
Read-only bridge for power-grid / substation automation. Reads MMXU measurements, XCBR/XSWI breaker status and PIOC/PTOC protection events from IEDs via MMS and Report Control Block subscriptions, and maps them to MeasurementSignal / AlarmSignal with quality and source-system timestamps propagated unmodified (00-FRAMEWORK rules 5 and 6).

The ceiling is structurally READ-ONLY: no aggregator class exists, the Iec61850MmsClient transport seam exposes no write methods, and a writes: block in YAML is rejected at config-load with a message pointing to the separate iec61850-control bridge that would require its own SIL certification. SCL is parsed at startup and the bridge fails fast if any IED's .icd/.cid/.scd is missing or malformed.

Tests cover 11-IEC61850.md §9 S7-S11 plus 00-FRAMEWORK §5 S1, S2, S4 and S5 using an in-memory MMS client; the production OpenMUC adapter slots behind the same seam.