### PR TITLE
Implement LTI / xAPI bridge (14-LTI-XAPI.md)

### DIFF
--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/InMemoryXapiTransport.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/InMemoryXapiTransport.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * In-memory {@link XapiTransport} for tests and the acceptance scenarios
+ * (14-LTI-XAPI.md §9 S7, S9, S11, S12). Holds preloaded statement lists
+ * by query, and records POSTed statements + AGS scores so the test can
+ * assert on egress.
+ */
+public final class InMemoryXapiTransport implements XapiTransport {
+
+    private final ObjectMapper mapper;
+    private final Map<String, List<JsonNode>> statementsByQuery = new LinkedHashMap<>();
+    private final List<JsonNode> postedStatements = new ArrayList<>();
+    private final List<PostedScore> postedScores = new ArrayList<>();
+    private boolean ready = true;
+
+    public InMemoryXapiTransport() {
+        this(new ObjectMapper());
+    }
+
+    public InMemoryXapiTransport(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    /** Seed a list of statements for one pollStatements query. */
+    public InMemoryXapiTransport putStatements(String query, JsonNode... statements) {
+        List<JsonNode> list = new ArrayList<>();
+        if (statements != null) for (JsonNode s : statements) if (s != null) list.add(s);
+        statementsByQuery.put(query, list);
+        return this;
+    }
+
+    public InMemoryXapiTransport setReady(boolean ready) {
+        this.ready = ready;
+        return this;
+    }
+
+    public List<JsonNode> postedStatements() { return List.copyOf(postedStatements); }
+    public List<PostedScore> postedScores() { return List.copyOf(postedScores); }
+
+    @Override
+    public JsonNode pollStatements(String query) throws IOException {
+        List<JsonNode> list = statementsByQuery.get(query);
+        ObjectNode body = mapper.createObjectNode();
+        ArrayNode arr = body.putArray("statements");
+        if (list != null) for (JsonNode n : list) arr.add(n);
+        body.put("more", "");
+        // Drain after first poll so a subsequent call returns empty (mirrors
+        // an LRS that respects {@code since=}).
+        if (list != null) list.clear();
+        return body;
+    }
+
+    @Override
+    public String postStatement(JsonNode statement) throws IOException {
+        postedStatements.add(statement.deepCopy());
+        return UUID.randomUUID().toString();
+    }
+
+    @Override
+    public void postAgsScore(String lineItemUrl, JsonNode score) throws IOException {
+        postedScores.add(new PostedScore(lineItemUrl, score.deepCopy()));
+    }
+
+    @Override
+    public boolean isReady() { return ready; }
+
+    /** Recorded AGS post for assertions. */
+    public record PostedScore(String lineItemUrl, JsonNode body) {}
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/JdkHttpXapiTransport.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/JdkHttpXapiTransport.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Objects;
+
+/**
+ * Production {@link XapiTransport} backed by {@link HttpClient}
+ * (14-LTI-XAPI.md §4 architecture diagram).
+ *
+ * <p>Reads (GET statements) and writes (POST statement / POST AGS Score)
+ * are the only methods this transport exposes — there is no surface that
+ * could auto-enrol a learner or modify the roster.
+ */
+public final class JdkHttpXapiTransport implements XapiTransport {
+
+    private static final Logger log = LoggerFactory.getLogger(JdkHttpXapiTransport.class);
+
+    /**
+     * Mandatory xAPI version header (xAPI 1.0.3 — the version supported by
+     * tincan-java and the public LRS implementations referenced by §2).
+     */
+    public static final String XAPI_VERSION = "1.0.3";
+
+    private final HttpClient http;
+    private final ObjectMapper mapper;
+    private final String baseUrl;
+    private final LtiBridgeConfig.AuthConfig auth;
+
+    public JdkHttpXapiTransport(LtiBridgeConfig config) {
+        this(config, HttpClient.newBuilder()
+                        .connectTimeout(Duration.ofSeconds(10))
+                        .followRedirects(HttpClient.Redirect.NORMAL)
+                        .build(),
+                new ObjectMapper());
+    }
+
+    public JdkHttpXapiTransport(LtiBridgeConfig config, HttpClient http, ObjectMapper mapper) {
+        Objects.requireNonNull(config, "config");
+        Objects.requireNonNull(config.xapi(), "config.xapi");
+        Objects.requireNonNull(config.xapi().lrs(), "config.xapi.lrs");
+        this.http = Objects.requireNonNull(http, "http");
+        this.mapper = Objects.requireNonNull(mapper, "mapper");
+        this.baseUrl = stripTrailingSlash(config.xapi().lrs().endpoint());
+        this.auth = config.xapi().lrs().auth() == null
+                ? new LtiBridgeConfig.AuthConfig(LtiBridgeConfig.AuthType.NONE, null, null, null)
+                : config.xapi().lrs().auth();
+    }
+
+    @Override
+    public JsonNode pollStatements(String query) throws IOException {
+        HttpRequest.Builder b = HttpRequest.newBuilder()
+                .uri(URI.create(absoluteUrl(query)))
+                .header("Accept", "application/json")
+                .header("X-Experience-API-Version", XAPI_VERSION)
+                .GET()
+                .timeout(Duration.ofSeconds(30));
+        applyAuth(b);
+        return send(b.build());
+    }
+
+    @Override
+    public String postStatement(JsonNode statement) throws IOException {
+        byte[] body = mapper.writeValueAsBytes(statement);
+        HttpRequest.Builder b = HttpRequest.newBuilder()
+                .uri(URI.create(absoluteUrl("statements")))
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json")
+                .header("X-Experience-API-Version", XAPI_VERSION)
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                .timeout(Duration.ofSeconds(30));
+        applyAuth(b);
+        JsonNode response = send(b.build());
+        if (response.isArray() && response.size() > 0) {
+            return response.get(0).asText();
+        }
+        return null;
+    }
+
+    @Override
+    public void postAgsScore(String lineItemUrl, JsonNode score) throws IOException {
+        byte[] body = mapper.writeValueAsBytes(score);
+        HttpRequest.Builder b = HttpRequest.newBuilder()
+                .uri(URI.create(lineItemUrl + "/scores"))
+                .header("Accept", "application/vnd.ims.lis.v1.score+json")
+                .header("Content-Type", "application/vnd.ims.lis.v1.score+json")
+                .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                .timeout(Duration.ofSeconds(30));
+        applyAuth(b);
+        send(b.build());
+    }
+
+    private JsonNode send(HttpRequest req) throws IOException {
+        try {
+            HttpResponse<byte[]> resp = http.send(req, HttpResponse.BodyHandlers.ofByteArray());
+            int code = resp.statusCode();
+            if (code >= 400) {
+                throw new IOException("xAPI " + req.method() + " "
+                        + req.uri() + " returned " + code);
+            }
+            byte[] body = resp.body();
+            if (body == null || body.length == 0) {
+                return mapper.createObjectNode();
+            }
+            return mapper.readTree(body);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while issuing xAPI request", e);
+        }
+    }
+
+    private void applyAuth(HttpRequest.Builder b) {
+        switch (auth.type()) {
+            case BASIC_AUTH -> {
+                String user = auth.usernameEnv() == null
+                        ? null : System.getenv(auth.usernameEnv());
+                String pass = auth.passwordEnv() == null
+                        ? null : System.getenv(auth.passwordEnv());
+                if (user != null && pass != null) {
+                    String enc = Base64.getEncoder().encodeToString(
+                            (user + ":" + pass).getBytes(StandardCharsets.UTF_8));
+                    b.header("Authorization", "Basic " + enc);
+                } else {
+                    log.warn("xAPI BasicAuth not configured ({}={}, {}={})",
+                            auth.usernameEnv(), user == null ? "null" : "(set)",
+                            auth.passwordEnv(), pass == null ? "null" : "(set)");
+                }
+            }
+            case BEARER_TOKEN -> {
+                String token = auth.tokenEnv() == null
+                        ? null : System.getenv(auth.tokenEnv());
+                if (token != null) b.header("Authorization", "Bearer " + token);
+            }
+            case NONE -> { /* no header */ }
+        }
+    }
+
+    private String absoluteUrl(String relativeOrAbsolute) {
+        if (relativeOrAbsolute == null || relativeOrAbsolute.isEmpty()) return baseUrl;
+        if (relativeOrAbsolute.startsWith("http://") || relativeOrAbsolute.startsWith("https://")) {
+            return relativeOrAbsolute;
+        }
+        String rel = relativeOrAbsolute.startsWith("/")
+                ? relativeOrAbsolute.substring(1)
+                : relativeOrAbsolute;
+        return baseUrl + "/" + rel;
+    }
+
+    private static String stripTrailingSlash(String s) {
+        if (s == null) return "";
+        return s.endsWith("/") ? s.substring(0, s.length() - 1) : s;
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/LtiAdvisoryOutputAggregator.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/LtiAdvisoryOutputAggregator.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.rakovpublic.jneuropallium.worker.application.IOutputAggregator;
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import com.rakovpublic.jneuropallium.worker.net.layers.IResult;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.ContentRecommendationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.HintSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.InterventionSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.MasteryUpdateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.ScaffoldingSignal;
+import com.rakovpublic.jneuropallium.worker.util.IContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Egress for the LTI / xAPI bridge (14-LTI-XAPI.md §3, §4, §5 egress
+ * table).
+ *
+ * <p><b>This aggregator never auto-grades and never auto-enrols.</b>
+ * Egress channels:
+ *
+ * <ol>
+ *   <li>xAPI {@code recommended} statement to the LRS — the bridge is the
+ *       actor, never the learner (so the LRS record makes it clear the
+ *       statement came from Jneopallium, not the learner).</li>
+ *   <li>xAPI {@code experienced} statement for hints / scaffolds rendered
+ *       in the tool UI — same actor invariant.</li>
+ *   <li>AGS {@code Score} with {@code gradingProgress=PendingManual} when
+ *       a {@link MasteryUpdateSignal} is bound to an AGS line item — the
+ *       LMS is responsible for the instructor confirmation step.</li>
+ *   <li>Local JSONL advisory file — the always-on record an instructor /
+ *       reviewer / SIS audit can consume offline.</li>
+ * </ol>
+ *
+ * <p>Every egress event also produces a row in the universal bridge audit
+ * record file (00-FRAMEWORK §4).
+ */
+public final class LtiAdvisoryOutputAggregator implements IOutputAggregator, AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(LtiAdvisoryOutputAggregator.class);
+
+    public static final String VERDICT_ADVISORY  = "ADVISORY";
+    public static final String VERDICT_PROPOSAL  = "SCORE_PROPOSAL";
+    public static final String VERDICT_HINT      = "HINT";
+    public static final String VERDICT_INTERVENE = "INTERVENTION";
+
+    /** Default tool actor written into xAPI statements when no override binds. */
+    public static final String DEFAULT_TOOL_ACTOR = "Jneopallium-Tutor";
+
+    private final XapiClientService svc;
+    private final AbstractBridgeAuditOutput audit;
+    private final ObjectMapper mapper;
+    private final Path advisoryFile;
+    private BufferedWriter advisoryWriter;
+    private boolean advisoryDegraded;
+    private LtiClientService.LaunchContext activeLaunch;
+
+    public LtiAdvisoryOutputAggregator(XapiClientService svc, AbstractBridgeAuditOutput audit) {
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.audit = Objects.requireNonNull(audit, "audit");
+        this.mapper = new ObjectMapper().disable(SerializationFeature.INDENT_OUTPUT);
+        LtiBridgeConfig.AuditConfig auditCfg = svc.config().audit();
+        this.advisoryFile = auditCfg.advisoryFile() == null
+                ? null : Paths.get(auditCfg.advisoryFile());
+        openAdvisoryWriter();
+    }
+
+    /** Bind an active LTI launch so AGS / line-item URLs are available for proposals. */
+    public synchronized void setActiveLaunch(LtiClientService.LaunchContext ctx) {
+        this.activeLaunch = ctx;
+    }
+
+    public synchronized LtiClientService.LaunchContext activeLaunch() {
+        return activeLaunch;
+    }
+
+    private synchronized void openAdvisoryWriter() {
+        if (advisoryFile == null) return;
+        try {
+            if (advisoryFile.getParent() != null) Files.createDirectories(advisoryFile.getParent());
+            advisoryWriter = Files.newBufferedWriter(advisoryFile, StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            log.warn("LtiAdvisoryOutputAggregator: advisory file {} unwritable, degraded: {}",
+                    advisoryFile, e.getMessage());
+            advisoryWriter = null;
+            advisoryDegraded = true;
+        }
+    }
+
+    @Override
+    public synchronized void save(List<IResult> results, long timestamp, long run, IContext context) {
+        if (results == null || results.isEmpty()) return;
+        LtiBridgeConfig.WriteBindingConfig recommendBinding = findWriteBinding("recommend");
+        LtiBridgeConfig.WriteBindingConfig agsBinding = findAgsBinding();
+        for (IResult r : results) {
+            if (r == null) continue;
+            IResultSignal<?> s = r.getResult();
+            try {
+                if (s instanceof ContentRecommendationSignal rec) {
+                    handleRecommendation(rec, recommendBinding, timestamp, run, r.getNeuronId());
+                } else if (s instanceof MasteryUpdateSignal mu) {
+                    handleMastery(mu, agsBinding, timestamp, run, r.getNeuronId());
+                } else if (s instanceof HintSignal h) {
+                    handleHint(h, timestamp, run, r.getNeuronId());
+                } else if (s instanceof InterventionSignal i) {
+                    handleIntervention(i, timestamp, run, r.getNeuronId());
+                } else if (s instanceof ScaffoldingSignal sc) {
+                    handleScaffold(sc, timestamp, run, r.getNeuronId());
+                }
+            } catch (RuntimeException ex) {
+                audit.append(new BridgeAuditRecord(
+                        timestamp, run, XapiClientService.BRIDGE_NAME,
+                        BridgeAuditRecord.Verdict.FAILED,
+                        null, null, null, null,
+                        BridgeAuditRecord.RejectReason.EXCEPTION + ":" + ex.getClass().getSimpleName(),
+                        BridgeSafetyMode.ADVISORY, List.of()));
+                log.warn("LtiAdvisoryOutputAggregator: signal {} failed: {}",
+                        s == null ? "null" : s.getClass().getSimpleName(), ex.getMessage());
+            }
+        }
+    }
+
+    private void handleRecommendation(ContentRecommendationSignal rec,
+                                      LtiBridgeConfig.WriteBindingConfig binding,
+                                      long ts, long run, Long neuronId) {
+        String actor = binding == null || binding.targetActor() == null
+                ? DEFAULT_TOOL_ACTOR : binding.targetActor();
+        String tag = binding == null ? "TUTOR.RECOMMEND" : binding.signalTag();
+        String verb = binding == null || binding.xapiVerb() == null
+                ? XapiStatementMapper.VERB_EXPERIENCED : binding.xapiVerb();
+        ObjectNode stmt = recommendedStatement(actor, verb, rec.getItemId(), rec.getRationale(),
+                rec.getExpectedZPD());
+        postStatementBestEffort(stmt, tag, "recommendation");
+        AdvisoryRecord adv = new AdvisoryRecord(ts, run, VERDICT_ADVISORY,
+                rec.getItemId(), rec.getRationale(), rec.getExpectedZPD(),
+                learnerPseudonym(), null, null,
+                neuronId == null ? null : String.valueOf(neuronId));
+        writeAdvisory(adv);
+        audit.append(new BridgeAuditRecord(
+                ts, run, XapiClientService.BRIDGE_NAME,
+                BridgeAuditRecord.Verdict.APPLIED,
+                "advisory", tag, null, rec.getExpectedZPD(),
+                "RECOMMEND",
+                BridgeSafetyMode.ADVISORY,
+                neuronId == null ? List.of() : List.of(String.valueOf(neuronId))));
+    }
+
+    private void handleMastery(MasteryUpdateSignal mu,
+                               LtiBridgeConfig.WriteBindingConfig binding,
+                               long ts, long run, Long neuronId) {
+        // §3 — mastery update is purely a proposal. The aggregator posts an
+        // AGS Score with gradingProgress=PendingManual when the binding asks
+        // for it; otherwise the proposal is advisory-only.
+        if (binding != null && binding.ltiAgs()
+                && activeLaunch != null && activeLaunch.agsLineItemUrl() != null) {
+            ObjectNode score = mapper.createObjectNode();
+            score.put("scoreGiven", mu.getNewMasteryLevel());
+            score.put("scoreMaximum", 1.0);
+            score.put("activityProgress", "Submitted");
+            score.put("gradingProgress", LtiBridgeConfig.GradingProgress.PENDING_MANUAL);
+            score.put("timestamp", Instant.ofEpochMilli(ts).toString());
+            score.put("userId", learnerPseudonym() == null ? "" : learnerPseudonym());
+            try {
+                svc.transport().postAgsScore(activeLaunch.agsLineItemUrl(), score);
+            } catch (IOException | RuntimeException e) {
+                log.warn("AGS post failed: {}", e.getMessage());
+            }
+        }
+        AdvisoryRecord adv = new AdvisoryRecord(ts, run, VERDICT_PROPOSAL,
+                mu.getConceptId(), null, mu.getNewMasteryLevel(),
+                learnerPseudonym(), null,
+                LtiBridgeConfig.GradingProgress.PENDING_MANUAL,
+                neuronId == null ? null : String.valueOf(neuronId));
+        writeAdvisory(adv);
+        audit.append(new BridgeAuditRecord(
+                ts, run, XapiClientService.BRIDGE_NAME,
+                BridgeAuditRecord.Verdict.APPLIED,
+                "advisory",
+                binding == null ? "TUTOR.SCORE.PROPOSAL" : binding.signalTag(),
+                null, mu.getNewMasteryLevel(),
+                "PROPOSED_SCORE:gradingProgress=" + LtiBridgeConfig.GradingProgress.PENDING_MANUAL,
+                BridgeSafetyMode.ADVISORY,
+                neuronId == null ? List.of() : List.of(String.valueOf(neuronId))));
+    }
+
+    private void handleHint(HintSignal h, long ts, long run, Long neuronId) {
+        ObjectNode stmt = experiencedStatement(DEFAULT_TOOL_ACTOR, h.getItemId(),
+                h.getLevel() == null ? "hint" : h.getLevel().name());
+        postStatementBestEffort(stmt, "TUTOR.HINT", "hint");
+        AdvisoryRecord adv = new AdvisoryRecord(ts, run, VERDICT_HINT,
+                h.getItemId(),
+                h.getLevel() == null ? null : h.getLevel().name(),
+                null, learnerPseudonym(),
+                null, null,
+                neuronId == null ? null : String.valueOf(neuronId));
+        writeAdvisory(adv);
+        audit.append(new BridgeAuditRecord(
+                ts, run, XapiClientService.BRIDGE_NAME,
+                BridgeAuditRecord.Verdict.APPLIED,
+                "advisory", "TUTOR.HINT", null, null,
+                "HINT:" + (h.getLevel() == null ? "n/a" : h.getLevel().name()),
+                BridgeSafetyMode.ADVISORY,
+                neuronId == null ? List.of() : List.of(String.valueOf(neuronId))));
+    }
+
+    private void handleIntervention(InterventionSignal i, long ts, long run, Long neuronId) {
+        ObjectNode stmt = experiencedStatement(DEFAULT_TOOL_ACTOR,
+                i.getType() == null ? "intervention" : i.getType().name(),
+                i.getReason());
+        postStatementBestEffort(stmt, "TUTOR.INTERVENE", "intervention");
+        AdvisoryRecord adv = new AdvisoryRecord(ts, run, VERDICT_INTERVENE,
+                i.getType() == null ? null : i.getType().name(),
+                i.getReason(), null, learnerPseudonym(),
+                null, null,
+                neuronId == null ? null : String.valueOf(neuronId));
+        writeAdvisory(adv);
+        audit.append(new BridgeAuditRecord(
+                ts, run, XapiClientService.BRIDGE_NAME,
+                BridgeAuditRecord.Verdict.APPLIED,
+                "advisory", "TUTOR.INTERVENE", null, null,
+                "INTERVENTION:" + (i.getType() == null ? "n/a" : i.getType().name()),
+                BridgeSafetyMode.ADVISORY,
+                neuronId == null ? List.of() : List.of(String.valueOf(neuronId))));
+    }
+
+    private void handleScaffold(ScaffoldingSignal sc, long ts, long run, Long neuronId) {
+        String typeName = sc.getType() == null ? "scaffolding" : sc.getType().name();
+        ObjectNode stmt = experiencedStatement(DEFAULT_TOOL_ACTOR, "scaffolding", typeName);
+        postStatementBestEffort(stmt, "TUTOR.SCAFFOLD", "scaffold");
+        AdvisoryRecord adv = new AdvisoryRecord(ts, run, VERDICT_ADVISORY,
+                "scaffolding", typeName, null, learnerPseudonym(),
+                null, null,
+                neuronId == null ? null : String.valueOf(neuronId));
+        writeAdvisory(adv);
+        audit.append(new BridgeAuditRecord(
+                ts, run, XapiClientService.BRIDGE_NAME,
+                BridgeAuditRecord.Verdict.APPLIED,
+                "advisory", "TUTOR.SCAFFOLD", null, null,
+                "SCAFFOLD",
+                BridgeSafetyMode.ADVISORY,
+                neuronId == null ? List.of() : List.of(String.valueOf(neuronId))));
+    }
+
+    private void postStatementBestEffort(ObjectNode stmt, String tag, String kind) {
+        if (svc.transport() == null) return;
+        try {
+            svc.transport().postStatement(stmt);
+        } catch (IOException | RuntimeException e) {
+            log.warn("xAPI {} post failed: {}", kind, e.getMessage());
+            audit.append(new BridgeAuditRecord(
+                    System.currentTimeMillis(), 0, XapiClientService.BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.FAILED,
+                    "advisory", tag, null, null,
+                    BridgeAuditRecord.RejectReason.EXCEPTION + ":" + e.getClass().getSimpleName(),
+                    BridgeSafetyMode.ADVISORY, List.of()));
+        }
+    }
+
+    private LtiBridgeConfig.WriteBindingConfig findWriteBinding(String verbContains) {
+        for (LtiBridgeConfig.WriteBindingConfig w : svc.config().writes()) {
+            if (w.xapiVerb() != null && w.xapiVerb().toLowerCase().contains(verbContains)) {
+                return w;
+            }
+        }
+        return null;
+    }
+
+    private LtiBridgeConfig.WriteBindingConfig findAgsBinding() {
+        for (LtiBridgeConfig.WriteBindingConfig w : svc.config().writes()) {
+            if (w.ltiAgs()) return w;
+        }
+        return null;
+    }
+
+    private String learnerPseudonym() {
+        if (activeLaunch == null || activeLaunch.subject() == null) return null;
+        return svc.pseudonymService().pseudonymise(activeLaunch.subject());
+    }
+
+    private ObjectNode recommendedStatement(String actor, String verb,
+                                            String itemId, String rationale, double zpd) {
+        ObjectNode stmt = mapper.createObjectNode();
+        ObjectNode a = stmt.putObject("actor");
+        a.put("name", actor);
+        a.putObject("account").put("homePage", "https://jneopallium.rakov.org")
+                .put("name", actor);
+        stmt.putObject("verb").put("id", verb);
+        ObjectNode obj = stmt.putObject("object");
+        obj.put("id", itemId == null ? "" : itemId);
+        obj.put("objectType", "Activity");
+        if (rationale != null) {
+            stmt.putObject("result").putObject("extensions")
+                    .put("https://jneopallium.rakov.org/xapi/extensions/rationale", rationale)
+                    .put("https://jneopallium.rakov.org/xapi/extensions/zpd", zpd);
+        }
+        stmt.put("timestamp", Instant.now().toString());
+        return stmt;
+    }
+
+    private ObjectNode experiencedStatement(String actor, String itemId, String detail) {
+        ObjectNode stmt = mapper.createObjectNode();
+        ObjectNode a = stmt.putObject("actor");
+        a.put("name", actor);
+        a.putObject("account").put("homePage", "https://jneopallium.rakov.org")
+                .put("name", actor);
+        stmt.putObject("verb").put("id", XapiStatementMapper.VERB_EXPERIENCED);
+        ObjectNode obj = stmt.putObject("object");
+        obj.put("id", itemId == null ? "" : itemId);
+        obj.put("objectType", "Activity");
+        if (detail != null) {
+            stmt.putObject("result").putObject("extensions")
+                    .put("https://jneopallium.rakov.org/xapi/extensions/detail", detail);
+        }
+        stmt.put("timestamp", Instant.now().toString());
+        return stmt;
+    }
+
+    private synchronized void writeAdvisory(AdvisoryRecord record) {
+        if (advisoryWriter == null) return;
+        try {
+            advisoryWriter.write(mapper.writeValueAsString(record));
+            advisoryWriter.newLine();
+            advisoryWriter.flush();
+        } catch (IOException e) {
+            if (!advisoryDegraded) {
+                log.warn("Advisory writer degraded: {}", e.getMessage());
+                advisoryDegraded = true;
+            }
+        }
+    }
+
+    public boolean isAdvisoryDegraded() { return advisoryDegraded; }
+
+    @Override
+    public synchronized void close() {
+        if (advisoryWriter != null) {
+            try { advisoryWriter.close(); } catch (IOException e) {
+                log.warn("Advisory writer close threw: {}", e.getMessage());
+            }
+            advisoryWriter = null;
+        }
+    }
+
+    /**
+     * Single-line JSON record written to the advisory file. Field shape is
+     * stable so downstream tooling (instructor dashboard, LMS side-panel,
+     * SIS audit) can deserialise the same schema regardless of verdict.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonPropertyOrder({
+            "ts", "run", "verdict", "code", "detail", "scoreOrZpd",
+            "learnerPseudonym", "severity", "gradingProgress", "evidenceNeuron"
+    })
+    public record AdvisoryRecord(
+            long ts,
+            long run,
+            String verdict,
+            String code,
+            String detail,
+            Double scoreOrZpd,
+            String learnerPseudonym,
+            String severity,
+            String gradingProgress,
+            String evidenceNeuron
+    ) {}
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/LtiAuditOutput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/LtiAuditOutput.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+
+import java.nio.file.Path;
+
+/**
+ * JSONL audit sink for the LTI / xAPI bridge (00-FRAMEWORK §4, §6;
+ * 14-LTI-XAPI.md §6 {@code audit.localAuditFile}).
+ *
+ * <p>14-LTI-XAPI.md §10 R1 — every audit record carries the pseudonymous
+ * actor id, never the raw learner identifier. {@link XapiClientService}
+ * and {@link LtiAdvisoryOutputAggregator} are the only producers; the
+ * sink does not mirror to an external channel by default.
+ */
+public final class LtiAuditOutput extends AbstractBridgeAuditOutput {
+    public LtiAuditOutput(Path file) { super(file); }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/LtiBridgeConfig.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/LtiBridgeConfig.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+
+import java.time.Duration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Top-level LTI / xAPI bridge configuration (14-LTI-XAPI.md §6).
+ *
+ * <p>The bridge ceiling is structurally <b>ADVISORY</b> (14-LTI-XAPI.md §0,
+ * §3, §11). Key structural defences:
+ *
+ * <ol>
+ *   <li>Egress to an LMS never sets {@code gradingProgress=FullyGraded}.
+ *       The loader rejects that value unconditionally (§9 S10).</li>
+ *   <li>Egress to an LMS never declares {@code AUTONOMOUS} safety mode.
+ *       The loader rejects {@code AUTONOMOUS} unconditionally.</li>
+ *   <li>The bridge has no auto-enrolment / auto-roster / auto-grade API
+ *       on its egress surface; only xAPI {@code recommended} statements
+ *       and AGS {@code Score} proposals with {@code PendingManual}.</li>
+ * </ol>
+ */
+public record LtiBridgeConfig(
+        LtiSection lti,
+        XapiSection xapi,
+        CohortConfig cohort,
+        List<ReadBindingConfig> reads,
+        List<WriteBindingConfig> writes,
+        PrivacyConfig privacy,
+        AuditConfig audit,
+        Map<String, BridgeSafetyMode> perTagSafetyMode,
+        Duration tickInterval
+) {
+
+    /** Minimum poll interval — protects LRS endpoints (mirrors §10 R2 of the FHIR bridge). */
+    public static final long MIN_POLL_INTERVAL_SECONDS = 15L;
+
+    public LtiBridgeConfig {
+        Objects.requireNonNull(audit, "audit");
+        reads = reads == null ? List.of() : List.copyOf(reads);
+        writes = writes == null ? List.of() : List.copyOf(writes);
+        tickInterval = tickInterval == null ? Duration.ofMillis(500) : tickInterval;
+        perTagSafetyMode = perTagSafetyMode == null ? Map.of() : Map.copyOf(perTagSafetyMode);
+        privacy = privacy == null ? PrivacyConfig.defaults() : privacy;
+        cohort = cohort == null ? new CohortConfig(List.of()) : cohort;
+
+        Set<String> seenReads = new LinkedHashSet<>();
+        for (ReadBindingConfig r : reads) {
+            if (!seenReads.add(r.bindingId())) {
+                throw new IllegalArgumentException(
+                        "LTI bridge: duplicate read bindingId: " + r.bindingId());
+            }
+        }
+        Set<String> seenWrites = new LinkedHashSet<>();
+        for (WriteBindingConfig w : writes) {
+            if (!seenWrites.add(w.bindingId())) {
+                throw new IllegalArgumentException(
+                        "LTI bridge: duplicate write bindingId: " + w.bindingId());
+            }
+            if (w.ltiAgs() && w.gradingProgress() != null
+                    && !GradingProgress.PENDING_MANUAL.equals(w.gradingProgress())) {
+                throw new IllegalArgumentException(
+                        "LTI bridge: write bindingId '" + w.bindingId()
+                                + "' declares gradingProgress=" + w.gradingProgress()
+                                + " — 14-LTI-XAPI.md §9 S10 only permits PendingManual.");
+            }
+        }
+        if (xapi != null && xapi.lrs() != null
+                && xapi.lrs().pollIntervalSeconds() < MIN_POLL_INTERVAL_SECONDS) {
+            throw new IllegalArgumentException(
+                    "LTI bridge: xapi.lrs.pollIntervalSeconds="
+                            + xapi.lrs().pollIntervalSeconds()
+                            + " is below the minimum " + MIN_POLL_INTERVAL_SECONDS + "s.");
+        }
+        for (Map.Entry<String, BridgeSafetyMode> e : perTagSafetyMode.entrySet()) {
+            if (e.getValue() == BridgeSafetyMode.AUTONOMOUS) {
+                throw new IllegalArgumentException(
+                        "LTI bridge: perTagSafetyMode entry '" + e.getKey()
+                                + "' declares AUTONOMOUS — rejected by the LTI/xAPI "
+                                + "advisory ceiling (14-LTI-XAPI.md §3, §6).");
+            }
+        }
+    }
+
+    @JsonCreator
+    public static LtiBridgeConfig create(
+            @JsonProperty("lti") LtiSection lti,
+            @JsonProperty("xapi") XapiSection xapi,
+            @JsonProperty("cohort") CohortConfig cohort,
+            @JsonProperty("reads") List<ReadBindingConfig> reads,
+            @JsonProperty("writes") List<WriteBindingConfig> writes,
+            @JsonProperty("privacy") PrivacyConfig privacy,
+            @JsonProperty("audit") AuditConfig audit,
+            @JsonProperty("perTagSafetyMode") Map<String, BridgeSafetyMode> perTagSafetyMode,
+            @JsonProperty("tickInterval") Duration tickInterval) {
+        return new LtiBridgeConfig(lti, xapi, cohort, reads, writes,
+                privacy, audit, perTagSafetyMode, tickInterval);
+    }
+
+    /** xAPI ingestion mode (§6 — bridge polls an LRS, or accepts statements as an endpoint). */
+    public enum XapiMode { PULL, PUSH }
+
+    /** AGS gradingProgress vocabulary surfaced in config. */
+    public static final class GradingProgress {
+        private GradingProgress() {}
+        /** The only value the bridge will accept (§5 egress table, §9 S10). */
+        public static final String PENDING_MANUAL = "PendingManual";
+        public static final String FULLY_GRADED = "FullyGraded";
+    }
+
+    /** Target Jneopallium signal for an xAPI read binding (§5 signal mapping). */
+    public enum TargetSignal {
+        RESPONSE,
+        MASTERY,
+        ENGAGEMENT,
+        AFFECT
+    }
+
+    /** §6 {@code lti:} block — tool registration metadata. */
+    public record LtiSection(
+            String toolName,
+            List<PlatformConfig> platforms,
+            String toolPrivateKeyPath,
+            String toolPublicJwksUrl
+    ) {
+        public LtiSection {
+            platforms = platforms == null ? List.of() : List.copyOf(platforms);
+        }
+
+        @JsonCreator
+        public static LtiSection of(
+                @JsonProperty("toolName") String toolName,
+                @JsonProperty("platforms") List<PlatformConfig> platforms,
+                @JsonProperty("toolPrivateKeyPath") String toolPrivateKeyPath,
+                @JsonProperty("toolPublicJwksUrl") String toolPublicJwksUrl) {
+            return new LtiSection(toolName, platforms, toolPrivateKeyPath, toolPublicJwksUrl);
+        }
+    }
+
+    /** §6 — one LMS platform registered against the tool. */
+    public record PlatformConfig(
+            String issuer,
+            String clientId,
+            String authLoginUrl,
+            String authTokenUrl,
+            String keysetUrl,
+            List<String> deploymentIds
+    ) {
+        public PlatformConfig {
+            Objects.requireNonNull(issuer, "issuer");
+            Objects.requireNonNull(clientId, "clientId");
+            deploymentIds = deploymentIds == null ? List.of() : List.copyOf(deploymentIds);
+        }
+
+        @JsonCreator
+        public static PlatformConfig of(
+                @JsonProperty("issuer") String issuer,
+                @JsonProperty("clientId") String clientId,
+                @JsonProperty("authLoginUrl") String authLoginUrl,
+                @JsonProperty("authTokenUrl") String authTokenUrl,
+                @JsonProperty("keysetUrl") String keysetUrl,
+                @JsonProperty("deploymentIds") List<String> deploymentIds) {
+            return new PlatformConfig(issuer, clientId, authLoginUrl, authTokenUrl,
+                    keysetUrl, deploymentIds);
+        }
+    }
+
+    /** §6 {@code xapi:} block. */
+    public record XapiSection(
+            XapiMode mode,
+            LrsConfig lrs
+    ) {
+        @JsonCreator
+        public static XapiSection of(
+                @JsonProperty("mode") XapiMode mode,
+                @JsonProperty("lrs") LrsConfig lrs) {
+            return new XapiSection(mode == null ? XapiMode.PULL : mode, lrs);
+        }
+    }
+
+    /** §6 — LRS endpoint + auth. */
+    public record LrsConfig(
+            String endpoint,
+            AuthConfig auth,
+            long pollIntervalSeconds
+    ) {
+        public LrsConfig {
+            Objects.requireNonNull(endpoint, "endpoint");
+            if (pollIntervalSeconds <= 0) pollIntervalSeconds = 60L;
+        }
+
+        @JsonCreator
+        public static LrsConfig of(
+                @JsonProperty("endpoint") String endpoint,
+                @JsonProperty("auth") AuthConfig auth,
+                @JsonProperty("pollIntervalSeconds") Long pollIntervalSeconds) {
+            return new LrsConfig(endpoint, auth,
+                    pollIntervalSeconds == null ? 60L : pollIntervalSeconds);
+        }
+    }
+
+    /** §6 — LRS auth (BasicAuth, OAuth2 bearer, or none). */
+    public record AuthConfig(
+            AuthType type,
+            String usernameEnv,
+            String passwordEnv,
+            String tokenEnv
+    ) {
+        public AuthConfig {
+            if (type == null) type = AuthType.NONE;
+        }
+
+        @JsonCreator
+        public static AuthConfig of(
+                @JsonProperty("type") AuthType type,
+                @JsonProperty("usernameEnv") String usernameEnv,
+                @JsonProperty("passwordEnv") String passwordEnv,
+                @JsonProperty("tokenEnv") String tokenEnv) {
+            return new AuthConfig(type == null ? AuthType.NONE : type,
+                    usernameEnv, passwordEnv, tokenEnv);
+        }
+    }
+
+    public enum AuthType { NONE, BASIC_AUTH, BEARER_TOKEN }
+
+    /** §6 {@code cohort:} block. */
+    public record CohortConfig(List<String> courseIds) {
+        public CohortConfig {
+            courseIds = courseIds == null ? List.of() : List.copyOf(courseIds);
+        }
+
+        @JsonCreator
+        public static CohortConfig of(@JsonProperty("courseIds") List<String> courseIds) {
+            return new CohortConfig(courseIds);
+        }
+    }
+
+    /** §6 {@code reads:} entry. */
+    public record ReadBindingConfig(
+            String bindingId,
+            String xapiVerb,
+            TargetSignal targetSignal,
+            String signalTagPrefix
+    ) {
+        public ReadBindingConfig {
+            Objects.requireNonNull(bindingId, "bindingId");
+            Objects.requireNonNull(xapiVerb, "xapiVerb");
+            Objects.requireNonNull(targetSignal, "targetSignal");
+        }
+
+        @JsonCreator
+        public static ReadBindingConfig of(
+                @JsonProperty("bindingId") String bindingId,
+                @JsonProperty("xapiVerb") String xapiVerb,
+                @JsonProperty("targetSignal") TargetSignal targetSignal,
+                @JsonProperty("signalTagPrefix") String signalTagPrefix) {
+            return new ReadBindingConfig(bindingId, xapiVerb, targetSignal, signalTagPrefix);
+        }
+    }
+
+    /** §6 {@code writes:} entry. */
+    public record WriteBindingConfig(
+            String bindingId,
+            String xapiVerb,
+            String targetActor,
+            boolean ltiAgs,
+            String gradingProgress,
+            String signalTag
+    ) {
+        public WriteBindingConfig {
+            Objects.requireNonNull(bindingId, "bindingId");
+        }
+
+        @JsonCreator
+        public static WriteBindingConfig of(
+                @JsonProperty("bindingId") String bindingId,
+                @JsonProperty("xapiVerb") String xapiVerb,
+                @JsonProperty("targetActor") String targetActor,
+                @JsonProperty("ltiAgs") Boolean ltiAgs,
+                @JsonProperty("gradingProgress") String gradingProgress,
+                @JsonProperty("signalTag") String signalTag) {
+            return new WriteBindingConfig(bindingId, xapiVerb, targetActor,
+                    ltiAgs != null && ltiAgs, gradingProgress, signalTag);
+        }
+    }
+
+    /** §6 {@code privacy:} block. */
+    public record PrivacyConfig(
+            boolean pseudonymise,
+            String saltEnv,
+            boolean redactFreeText
+    ) {
+        public static PrivacyConfig defaults() {
+            return new PrivacyConfig(true, null, true);
+        }
+
+        @JsonCreator
+        public static PrivacyConfig of(
+                @JsonProperty("pseudonymise") Boolean pseudonymise,
+                @JsonProperty("saltEnv") String saltEnv,
+                @JsonProperty("redactFreeText") Boolean redactFreeText) {
+            return new PrivacyConfig(
+                    pseudonymise == null || pseudonymise,
+                    saltEnv,
+                    redactFreeText == null || redactFreeText);
+        }
+    }
+
+    /** §6 {@code audit:} block. */
+    public record AuditConfig(
+            String localAuditFile,
+            String advisoryFile
+    ) {
+        public AuditConfig {
+            Objects.requireNonNull(localAuditFile, "localAuditFile");
+        }
+
+        @JsonCreator
+        public static AuditConfig of(
+                @JsonProperty("localAuditFile") String localAuditFile,
+                @JsonProperty("advisoryFile") String advisoryFile) {
+            return new AuditConfig(localAuditFile, advisoryFile);
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/LtiBridgeConfigLoader.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/LtiBridgeConfigLoader.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+/**
+ * Loads {@link LtiBridgeConfig} from YAML (14-LTI-XAPI.md §6).
+ *
+ * <p>{@code FAIL_ON_UNKNOWN_PROPERTIES = true} per 00-FRAMEWORK §3 — typos
+ * in a learner-bridge config must surface at load time, not silently
+ * change behaviour at runtime.
+ */
+public final class LtiBridgeConfigLoader {
+
+    private LtiBridgeConfigLoader() {}
+
+    public static LtiBridgeConfig load(Path yaml) throws IOException {
+        return mapper().readValue(yaml.toFile(), LtiBridgeConfig.class);
+    }
+
+    public static LtiBridgeConfig load(InputStream in) throws IOException {
+        return mapper().readValue(in, LtiBridgeConfig.class);
+    }
+
+    public static LtiBridgeConfig load(String yamlContent) throws IOException {
+        return mapper().readValue(yamlContent, LtiBridgeConfig.class);
+    }
+
+    private static ObjectMapper mapper() {
+        return new ObjectMapper(new YAMLFactory())
+                .registerModule(new JavaTimeModule())
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/LtiClientService.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/LtiClientService.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * LTI 1.3 launch handling (14-LTI-XAPI.md §4 architecture, §7
+ * {@code LtiClientService}).
+ *
+ * <p>The service parses an OpenID Connect {@code id_token} carrying the
+ * LTI launch claims, verifies the structural invariants (iss / aud /
+ * exp / nonce / deployment id) against a registered
+ * {@link LtiPlatformBinding}, and exposes the parsed
+ * {@link LaunchContext} (learner, course, role, line items) so the
+ * {@link LtiAdvisoryOutputAggregator} can scope its egress.
+ *
+ * <p><b>Signature verification.</b> The bridge keeps its dependency
+ * footprint small (no Nimbus / java-jwt). For deployments wired against
+ * a real LMS, plug in a {@link JwtVerifier} that validates the JWT
+ * signature against the platform's JWKS. The default
+ * {@link JwtVerifier#permissive()} accepts any well-formed JWT and is
+ * meant for tests + the structural acceptance scenarios. Production
+ * code MUST install a real verifier — the {@link #verifyLaunch} method
+ * refuses to run with the permissive verifier when
+ * {@code requireSignedJwt = true}.
+ *
+ * <p>This is intentionally minimal — the spec calls out (§2) that a
+ * maintained 1EdTech LTI 1.3 client should replace this scaffolding
+ * once available. The seam is here so a future drop-in does not need to
+ * touch the rest of the bridge.
+ */
+public final class LtiClientService {
+
+    private static final Logger log = LoggerFactory.getLogger(LtiClientService.class);
+
+    /** LTI 1.3 claim namespace. */
+    public static final String CLAIM_DEPLOYMENT_ID =
+            "https://purl.imsglobal.org/spec/lti/claim/deployment_id";
+    public static final String CLAIM_CONTEXT =
+            "https://purl.imsglobal.org/spec/lti/claim/context";
+    public static final String CLAIM_ROLES =
+            "https://purl.imsglobal.org/spec/lti/claim/roles";
+    public static final String CLAIM_AGS =
+            "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint";
+    public static final String CLAIM_NRPS =
+            "https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice";
+
+    /** ADL-style instructor / learner roles. */
+    public static final String ROLE_LEARNER =
+            "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner";
+    public static final String ROLE_INSTRUCTOR =
+            "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor";
+
+    private final List<LtiPlatformBinding> platforms;
+    private final ObjectMapper mapper;
+    private final JwtVerifier verifier;
+    private final boolean requireSignedJwt;
+
+    public LtiClientService(LtiBridgeConfig config) {
+        this(config, new ObjectMapper(), JwtVerifier.permissive(), false);
+    }
+
+    public LtiClientService(LtiBridgeConfig config,
+                            ObjectMapper mapper,
+                            JwtVerifier verifier,
+                            boolean requireSignedJwt) {
+        Objects.requireNonNull(config, "config");
+        this.mapper = Objects.requireNonNull(mapper, "mapper");
+        this.verifier = Objects.requireNonNull(verifier, "verifier");
+        this.requireSignedJwt = requireSignedJwt;
+        List<LtiPlatformBinding> bindings = new java.util.ArrayList<>();
+        if (config.lti() != null) {
+            for (LtiBridgeConfig.PlatformConfig p : config.lti().platforms()) {
+                bindings.add(LtiPlatformBinding.fromConfig(p));
+            }
+        }
+        this.platforms = List.copyOf(bindings);
+    }
+
+    public List<LtiPlatformBinding> platforms() { return platforms; }
+
+    /**
+     * Decode and validate an LTI 1.3 launch JWT (id_token). On success
+     * returns a {@link LaunchContext}; on any structural failure
+     * (signature, iss/aud, expiry, deployment id) throws
+     * {@link LaunchVerificationException}.
+     */
+    public LaunchContext verifyLaunch(String idToken) throws LaunchVerificationException {
+        if (idToken == null || idToken.isEmpty()) {
+            throw new LaunchVerificationException("empty id_token");
+        }
+        String[] parts = idToken.split("\\.");
+        if (parts.length != 3) {
+            throw new LaunchVerificationException("id_token must have 3 dot-separated parts");
+        }
+        JsonNode header = decodeJsonPart(parts[0]);
+        JsonNode payload = decodeJsonPart(parts[1]);
+        if (requireSignedJwt && verifier == JwtVerifier.permissive()) {
+            throw new LaunchVerificationException(
+                    "permissive verifier rejected — production deployments must install a real JwtVerifier");
+        }
+        if (!verifier.verify(parts[0], parts[1], parts[2], header, payload)) {
+            throw new LaunchVerificationException("signature verification failed");
+        }
+        String iss = textOrNull(payload.get("iss"));
+        String aud = audAsString(payload.get("aud"));
+        long exp = payload.has("exp") ? payload.get("exp").asLong(0L) : 0L;
+        if (exp > 0L && exp * 1000L < System.currentTimeMillis()) {
+            throw new LaunchVerificationException("id_token expired");
+        }
+        String deploymentId = textOrNull(payload.get(CLAIM_DEPLOYMENT_ID));
+        LtiPlatformBinding platform = matchPlatform(iss, aud, deploymentId);
+        if (platform == null) {
+            throw new LaunchVerificationException(
+                    "no registered platform accepts iss=" + iss + " aud=" + aud
+                            + " deployment=" + deploymentId);
+        }
+        String sub = textOrNull(payload.get("sub"));
+        String nonce = textOrNull(payload.get("nonce"));
+        String contextId = nestedText(payload.get(CLAIM_CONTEXT), "id");
+        String contextTitle = nestedText(payload.get(CLAIM_CONTEXT), "title");
+        List<String> roles = stringList(payload.get(CLAIM_ROLES));
+        JsonNode agsNode = payload.get(CLAIM_AGS);
+        String agsLineItem = agsNode == null ? null : textOrNull(agsNode.get("lineitem"));
+        String agsLineItems = agsNode == null ? null : textOrNull(agsNode.get("lineitems"));
+        String nrps = nestedText(payload.get(CLAIM_NRPS), "context_memberships_url");
+        return new LaunchContext(platform, iss, aud, sub, nonce,
+                contextId, contextTitle, roles, deploymentId,
+                agsLineItem, agsLineItems, nrps);
+    }
+
+    private LtiPlatformBinding matchPlatform(String iss, String aud, String deploymentId) {
+        for (LtiPlatformBinding p : platforms) {
+            if (p.accepts(iss, aud, deploymentId)) return p;
+        }
+        return null;
+    }
+
+    private JsonNode decodeJsonPart(String b64) throws LaunchVerificationException {
+        try {
+            byte[] decoded = Base64.getUrlDecoder().decode(padBase64(b64));
+            return mapper.readTree(decoded);
+        } catch (RuntimeException | java.io.IOException e) {
+            throw new LaunchVerificationException("malformed JWT segment: " + e.getMessage());
+        }
+    }
+
+    private static String padBase64(String s) {
+        int rem = s.length() % 4;
+        if (rem == 0) return s;
+        return s + "====".substring(rem);
+    }
+
+    private static String textOrNull(JsonNode n) {
+        return n == null || n.isNull() ? null : n.asText();
+    }
+
+    private static String audAsString(JsonNode aud) {
+        if (aud == null || aud.isNull()) return null;
+        if (aud.isArray()) {
+            StringBuilder sb = new StringBuilder();
+            for (JsonNode n : aud) {
+                if (sb.length() > 0) sb.append(",");
+                sb.append(n.asText());
+            }
+            return sb.toString();
+        }
+        return aud.asText();
+    }
+
+    private static String nestedText(JsonNode parent, String field) {
+        if (parent == null || parent.isNull()) return null;
+        JsonNode child = parent.get(field);
+        return child == null || child.isNull() ? null : child.asText();
+    }
+
+    private static List<String> stringList(JsonNode arr) {
+        if (arr == null || !arr.isArray()) return List.of();
+        List<String> out = new java.util.ArrayList<>();
+        for (JsonNode n : arr) if (n != null && !n.isNull()) out.add(n.asText());
+        return List.copyOf(out);
+    }
+
+    /**
+     * Verified launch context, scoped per learner / course / line item.
+     * Contains every field the {@link LtiAdvisoryOutputAggregator} needs
+     * to scope an AGS Score proposal or an xAPI {@code recommended}
+     * statement.
+     */
+    public record LaunchContext(
+            LtiPlatformBinding platform,
+            String issuer,
+            String audience,
+            String subject,
+            String nonce,
+            String contextId,
+            String contextTitle,
+            List<String> roles,
+            String deploymentId,
+            String agsLineItemUrl,
+            String agsLineItemsUrl,
+            String nrpsContextMembershipsUrl
+    ) {
+        public LaunchContext {
+            roles = roles == null ? List.of() : List.copyOf(roles);
+        }
+
+        public boolean isLearner() { return roles.contains(ROLE_LEARNER); }
+        public boolean isInstructor() { return roles.contains(ROLE_INSTRUCTOR); }
+    }
+
+    /** Thrown when a launch JWT fails any of the structural invariants. */
+    public static final class LaunchVerificationException extends Exception {
+        public LaunchVerificationException(String message) { super(message); }
+    }
+
+    /**
+     * Signature-verification seam. Production deployments install an
+     * implementation backed by a JWKS fetcher (Nimbus, java-jwt, etc.);
+     * tests use {@link #permissive()}.
+     */
+    public interface JwtVerifier {
+        boolean verify(String headerB64, String payloadB64, String signatureB64,
+                       JsonNode header, JsonNode payload);
+
+        static JwtVerifier permissive() { return PERMISSIVE; }
+        JwtVerifier PERMISSIVE = (h, p, s, hN, pN) -> true;
+    }
+
+    /**
+     * Helper for §9 S8 — pretty-print a {@link LaunchContext} for the
+     * launch audit record (raw {@code sub} pseudonymised; nonce + iss
+     * preserved so a replay can be detected during forensic review).
+     */
+    public Map<String, String> toAuditFields(LaunchContext ctx, PseudonymService pseudonyms) {
+        Map<String, String> m = new LinkedHashMap<>();
+        m.put("iss", ctx.issuer());
+        m.put("aud", ctx.audience());
+        m.put("deployment", ctx.deploymentId());
+        m.put("context", ctx.contextId());
+        m.put("learner", pseudonyms.pseudonymise(ctx.subject()));
+        m.put("hasAgs", ctx.agsLineItemUrl() == null ? "false" : "true");
+        return m;
+    }
+
+    /**
+     * Convenience for tests — build a permissive id_token from the given
+     * claims. Not used by the production code path.
+     */
+    public static String buildPermissiveIdToken(JsonNode header, JsonNode payload) {
+        try {
+            ObjectMapper m = new ObjectMapper();
+            String h = Base64.getUrlEncoder().withoutPadding().encodeToString(
+                    m.writeValueAsBytes(header));
+            String p = Base64.getUrlEncoder().withoutPadding().encodeToString(
+                    m.writeValueAsBytes(payload));
+            return h + "." + p + "." + "permissive";
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private static String b64UrlEncode(byte[] bytes) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    @SuppressWarnings("unused")
+    private static String utf8(byte[] bytes) {
+        return new String(bytes, StandardCharsets.UTF_8);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/LtiPlatformBinding.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/LtiPlatformBinding.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Runtime registration of one LMS platform against the tool
+ * (14-LTI-XAPI.md §7).
+ *
+ * <p>Used by {@link LtiClientService} to verify LTI 1.3 launch JWTs:
+ * {@code iss} must match {@link #issuer()}, {@code aud} must contain
+ * {@link #clientId()}, the {@code lti_deployment_id} claim must be in
+ * {@link #deploymentIds()}, and the signature is verified against keys
+ * fetched from {@link #keysetUrl()}.
+ */
+public record LtiPlatformBinding(
+        String issuer,
+        String clientId,
+        String authLoginUrl,
+        String authTokenUrl,
+        String keysetUrl,
+        List<String> deploymentIds
+) {
+
+    public LtiPlatformBinding {
+        Objects.requireNonNull(issuer, "issuer");
+        Objects.requireNonNull(clientId, "clientId");
+        deploymentIds = deploymentIds == null ? List.of() : List.copyOf(deploymentIds);
+    }
+
+    public static LtiPlatformBinding fromConfig(LtiBridgeConfig.PlatformConfig p) {
+        return new LtiPlatformBinding(p.issuer(), p.clientId(),
+                p.authLoginUrl(), p.authTokenUrl(),
+                p.keysetUrl(), p.deploymentIds());
+    }
+
+    public boolean accepts(String issuerClaim, String audienceClaim, String deploymentIdClaim) {
+        if (!issuer.equals(issuerClaim)) return false;
+        if (audienceClaim == null || !audienceClaim.contains(clientId)) return false;
+        if (deploymentIds.isEmpty()) return true;
+        return deploymentIdClaim != null && deploymentIds.contains(deploymentIdClaim);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/PseudonymService.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/PseudonymService.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Objects;
+
+/**
+ * Pseudonymises xAPI actor identifiers (14-LTI-XAPI.md §6 {@code privacy:},
+ * §9 S11, §10 R1).
+ *
+ * <p>The bridge never persists the raw learner identifier; every signal,
+ * audit record and advisory line carries
+ * {@code SHA-256(rawId || ":" || salt)} truncated to {@link #ID_LEN}
+ * hexadecimal characters. The salt comes from an operator-controlled
+ * environment variable so the pseudonym mapping is non-reversible without
+ * access to the secret.
+ *
+ * <p>This is intentionally a separate class from the FHIR bridge's
+ * {@code PseudonymService}; the spec notes the implementation is shared
+ * <i>conceptually</i> ("shared with FHIR if both deployed"), not by code
+ * reference — keeping the bridges independently buildable.
+ */
+public final class PseudonymService {
+
+    /** Length of the pseudonymous id surfaced to signals (hex chars). */
+    public static final int ID_LEN = 24;
+
+    private final boolean enabled;
+    private final byte[] salt;
+
+    public PseudonymService(boolean enabled, String salt) {
+        this.enabled = enabled;
+        this.salt = (salt == null ? "" : salt).getBytes(StandardCharsets.UTF_8);
+    }
+
+    /** Convenience constructor — reads the salt from {@code System.getenv}. */
+    public static PseudonymService fromConfig(LtiBridgeConfig.PrivacyConfig privacy) {
+        Objects.requireNonNull(privacy, "privacy");
+        if (!privacy.pseudonymise()) {
+            return new PseudonymService(false, null);
+        }
+        String saltEnv = privacy.saltEnv();
+        String salt = saltEnv == null ? "" : System.getenv(saltEnv);
+        if (salt == null) salt = "";
+        return new PseudonymService(true, salt);
+    }
+
+    /**
+     * Apply pseudonymisation to a raw actor identifier. Empty or
+     * {@code null} input is mapped to {@code null} so callers do not
+     * accidentally emit empty pseudonyms downstream.
+     */
+    public String pseudonymise(String rawId) {
+        if (rawId == null || rawId.isEmpty()) return null;
+        if (!enabled) return rawId;
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(rawId.getBytes(StandardCharsets.UTF_8));
+            md.update((byte) ':');
+            md.update(salt);
+            byte[] digest = md.digest();
+            StringBuilder sb = new StringBuilder(ID_LEN);
+            int hexChars = Math.min(ID_LEN, digest.length * 2);
+            for (int i = 0; i < (hexChars + 1) / 2; i++) {
+                int v = digest[i] & 0xFF;
+                sb.append(Character.forDigit(v >>> 4, 16));
+                sb.append(Character.forDigit(v & 0x0F, 16));
+            }
+            return sb.substring(0, ID_LEN);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+    public boolean isEnabled() { return enabled; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/XapiAffectInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/XapiAffectInput.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IInitInput} draining xAPI affect bindings (for LSL-paired
+ * deployments — 14-LTI-XAPI.md §1, §5, §7 — {@code XapiAffectInput}).
+ * Emits {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.AffectObservationSignal}s
+ * decoded from the {@code https://jneopallium.rakov.org/xapi/extensions/affect}
+ * extension.
+ */
+public final class XapiAffectInput implements IInitInput {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
+
+    private final String name;
+    private final XapiClientService svc;
+    private final List<String> bindingIds;
+
+    public XapiAffectInput(String name, XapiClientService svc, List<String> bindingIds) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.bindingIds = List.copyOf(Objects.requireNonNull(bindingIds, "bindingIds"));
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        List<IInputSignal> out = new ArrayList<>();
+        for (String b : bindingIds) out.addAll(svc.drain(b));
+        return out;
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() { return new HashMap<>(); }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() { return PROCESSING_FREQUENCY; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/XapiClientService.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/XapiClientService.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.rakovpublic.jneuropallium.worker.bridge.common.AbstractBridgeAuditOutput;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeAuditRecord;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * xAPI LRS polling client + per-binding cache (14-LTI-XAPI.md §4 architecture
+ * diagram, §7 package layout).
+ *
+ * <p>Owns:
+ * <ul>
+ *   <li>The {@link XapiTransport} seam — pulls statements from the LRS
+ *       (PULL mode) or pushes them into the bridge's queue when the
+ *       bridge itself is the LRS endpoint (PUSH mode).</li>
+ *   <li>Per-binding queues of decoded {@link IInputSignal}s, drained by
+ *       the {@link XapiResponseInput} / {@link XapiEngagementInput} /
+ *       {@link XapiAffectInput} adapters once per tick.</li>
+ *   <li>Pseudonymisation — applied by {@link XapiStatementMapper} so
+ *       queues never carry a raw learner identifier.</li>
+ * </ul>
+ */
+public final class XapiClientService implements AutoCloseable {
+
+    private static final Logger log = LoggerFactory.getLogger(XapiClientService.class);
+
+    /** Bridge name carried in every audit record (00-FRAMEWORK §4). */
+    public static final String BRIDGE_NAME = "lti";
+
+    /** Default per-binding ring-buffer cap so a slow pipeline cannot exhaust heap. */
+    public static final int DEFAULT_RING_BUFFER = 4096;
+
+    private final LtiBridgeConfig config;
+    private final XapiTransport transport;
+    private final AbstractBridgeAuditOutput audit;
+    private final XapiStatementMapper mapper;
+    private final PseudonymService pseudonyms;
+
+    private final Map<String, XapiVerbBinding> bindings = new LinkedHashMap<>();
+    private final Map<String, Deque<IInputSignal>> queueByBinding = new ConcurrentHashMap<>();
+    private final List<IInputSignal> events = new ArrayList<>();
+
+    private final AtomicBoolean started = new AtomicBoolean();
+    private final AtomicBoolean closed = new AtomicBoolean();
+
+    public XapiClientService(LtiBridgeConfig config,
+                             XapiTransport transport,
+                             AbstractBridgeAuditOutput audit) {
+        this.config = Objects.requireNonNull(config, "config");
+        this.transport = Objects.requireNonNull(transport, "transport");
+        this.audit = Objects.requireNonNull(audit, "audit");
+        this.pseudonyms = PseudonymService.fromConfig(config.privacy());
+        this.mapper = new XapiStatementMapper(pseudonyms, config.privacy().redactFreeText());
+    }
+
+    /** §6 — register every read binding. */
+    public synchronized void start() {
+        if (started.get() || closed.get()) return;
+        for (LtiBridgeConfig.ReadBindingConfig r : config.reads()) {
+            XapiVerbBinding b = XapiVerbBinding.fromConfig(r);
+            bindings.put(b.bindingId(), b);
+            queueByBinding.put(b.bindingId(), new ArrayDeque<>());
+        }
+        started.set(true);
+        log.info("XapiClientService started; mode={} bindings={} pseudonymise={}",
+                config.xapi() == null ? "<none>" : config.xapi().mode(),
+                bindings.size(), pseudonyms.isEnabled());
+    }
+
+    /**
+     * Run one polling cycle. For every read binding, issue the configured
+     * xAPI {@code statements?verb=...} query through the transport and
+     * decode every statement into typed signals.
+     *
+     * <p>Failures are logged and audited but do not propagate — a single
+     * unreachable LRS should not stop the rest of the cohort.
+     */
+    public synchronized void poll() {
+        if (!isStarted()) return;
+        if (config.xapi() == null || config.xapi().mode() != LtiBridgeConfig.XapiMode.PULL) {
+            return; // PUSH mode: statements arrive via acceptStatement.
+        }
+        if (!transport.isReady()) {
+            log.debug("XapiClientService.poll: transport not ready, skipping cycle");
+            return;
+        }
+        for (XapiVerbBinding b : bindings.values()) {
+            pollBinding(b);
+        }
+        int redacted = mapper.drainRedactionCount();
+        if (redacted > 0) {
+            audit.append(new BridgeAuditRecord(
+                    System.currentTimeMillis(), 0, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.APPLIED, null, null, null, null,
+                    "FREE_TEXT_REDACTED:count=" + redacted, null, List.of()));
+        }
+    }
+
+    /**
+     * Accept a statement that arrived via the bridge's PUSH endpoint
+     * (14-LTI-XAPI.md §4 — "bridge acts as the LRS endpoint"). Routes the
+     * statement to every read binding whose verb matches.
+     */
+    public synchronized void acceptStatement(JsonNode statement) {
+        if (!isStarted() || statement == null || statement.isNull()) return;
+        String verb = statement.get("verb") == null ? null
+                : statement.get("verb").get("id") == null ? null
+                : statement.get("verb").get("id").asText();
+        for (XapiVerbBinding b : bindings.values()) {
+            if (verb != null && verb.equals(b.xapiVerb())) {
+                IInputSignal sig = mapper.map(statement, b.targetSignal());
+                if (sig != null) enqueue(b.bindingId(), sig);
+            }
+        }
+    }
+
+    private void pollBinding(XapiVerbBinding b) {
+        String query = "statements?verb=" + urlEncode(b.xapiVerb());
+        try {
+            JsonNode response = transport.pollStatements(query);
+            int decoded = 0;
+            for (JsonNode stmt : mapper.statements(response)) {
+                IInputSignal signal = mapper.map(stmt, b.targetSignal());
+                if (signal == null) continue;
+                enqueue(b.bindingId(), signal);
+                decoded++;
+            }
+            log.debug("XapiClientService: binding={} verb={} decoded={}",
+                    b.bindingId(), b.xapiVerb(), decoded);
+        } catch (IOException | RuntimeException e) {
+            audit.append(new BridgeAuditRecord(
+                    System.currentTimeMillis(), 0, BRIDGE_NAME,
+                    BridgeAuditRecord.Verdict.FAILED, b.loopId(), b.signalTag(),
+                    null, null,
+                    BridgeAuditRecord.RejectReason.EXCEPTION + ":" + e.getClass().getSimpleName(),
+                    null, List.of()));
+            log.warn("XapiClientService: poll '{}' failed: {}", query, e.getMessage());
+        }
+    }
+
+    private void enqueue(String bindingId, IInputSignal signal) {
+        Deque<IInputSignal> q = queueByBinding.get(bindingId);
+        if (q == null) return;
+        synchronized (q) {
+            int dropped = 0;
+            while (q.size() >= DEFAULT_RING_BUFFER) {
+                q.pollFirst();
+                dropped++;
+            }
+            q.addLast(signal);
+            if (dropped > 0) {
+                audit.append(new BridgeAuditRecord(
+                        System.currentTimeMillis(), 0, BRIDGE_NAME,
+                        BridgeAuditRecord.Verdict.REJECTED, bindingId, null, null, null,
+                        "RING_BUFFER_OVERFLOW:dropped=" + dropped, null, List.of()));
+            }
+        }
+    }
+
+    /** Drain (and clear) the decoded signal queue for one binding. */
+    public List<IInputSignal> drain(String bindingId) {
+        Deque<IInputSignal> q = queueByBinding.get(bindingId);
+        if (q == null || q.isEmpty()) return List.of();
+        synchronized (q) {
+            List<IInputSignal> snap = new ArrayList<>(q);
+            q.clear();
+            return snap;
+        }
+    }
+
+    /** Drain bridge-level events (e.g. reconnect advisories). */
+    public List<IInputSignal> drainEvents() {
+        synchronized (events) {
+            if (events.isEmpty()) return List.of();
+            List<IInputSignal> snap = new ArrayList<>(events);
+            events.clear();
+            return snap;
+        }
+    }
+
+    public final boolean isStarted() { return started.get() && !closed.get(); }
+
+    public Map<String, XapiVerbBinding> bindings() { return Map.copyOf(bindings); }
+
+    public LtiBridgeConfig config() { return config; }
+
+    public PseudonymService pseudonymService() { return pseudonyms; }
+
+    public XapiStatementMapper statementMapper() { return mapper; }
+
+    public XapiTransport transport() { return transport; }
+
+    public AbstractBridgeAuditOutput audit() { return audit; }
+
+    @Override
+    public synchronized void close() {
+        if (!closed.compareAndSet(false, true)) return;
+        try { transport.close(); } catch (RuntimeException e) {
+            log.warn("XapiTransport close threw: {}", e.getMessage());
+        }
+    }
+
+    private static String urlEncode(String s) {
+        return java.net.URLEncoder.encode(s, java.nio.charset.StandardCharsets.UTF_8);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/XapiEngagementInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/XapiEngagementInput.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IInitInput} draining xAPI engagement bindings
+ * (14-LTI-XAPI.md §7 — {@code XapiEngagementInput}). Emits
+ * {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.EngagementSignal}s
+ * decoded by {@link XapiStatementMapper#mapEngagement}.
+ */
+public final class XapiEngagementInput implements IInitInput {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
+
+    private final String name;
+    private final XapiClientService svc;
+    private final List<String> bindingIds;
+
+    public XapiEngagementInput(String name, XapiClientService svc, List<String> bindingIds) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.bindingIds = List.copyOf(Objects.requireNonNull(bindingIds, "bindingIds"));
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        List<IInputSignal> out = new ArrayList<>();
+        for (String b : bindingIds) out.addAll(svc.drain(b));
+        return out;
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() { return new HashMap<>(); }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() { return PROCESSING_FREQUENCY; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/XapiResponseInput.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/XapiResponseInput.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.storage.IInitInput;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * {@link IInitInput} that drains xAPI response bindings
+ * (14-LTI-XAPI.md §7 — {@code XapiResponseInput}). Each configured
+ * binding emits {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.ResponseSignal}s
+ * or {@link com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.MasteryUpdateSignal}s
+ * decoded by {@link XapiStatementMapper} inside {@link XapiClientService}.
+ */
+public final class XapiResponseInput implements IInitInput {
+
+    public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
+
+    private final String name;
+    private final XapiClientService svc;
+    private final List<String> bindingIds;
+
+    public XapiResponseInput(String name, XapiClientService svc, List<String> bindingIds) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.svc = Objects.requireNonNull(svc, "svc");
+        this.bindingIds = List.copyOf(Objects.requireNonNull(bindingIds, "bindingIds"));
+    }
+
+    @Override
+    public List<IInputSignal> readSignals() {
+        List<IInputSignal> out = new ArrayList<>();
+        for (String b : bindingIds) out.addAll(svc.drain(b));
+        return out;
+    }
+
+    @Override public String getName() { return name; }
+
+    @Override
+    public HashMap<String, List<IResultSignal>> getDesiredResults() { return new HashMap<>(); }
+
+    @Override
+    public ProcessingFrequency getDefaultProcessingFrequency() { return PROCESSING_FREQUENCY; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/XapiStatementMapper.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/XapiStatementMapper.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.tutoring.EngagementSource;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.AffectObservationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.EngagementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.MasteryUpdateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.ResponseSignal;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Pure functions converting xAPI statement JSON to Jneopallium tutoring
+ * signals (14-LTI-XAPI.md §5 mapping table). Stateless apart from a
+ * counter of redactions performed in the current poll cycle so the
+ * bridge can record a count without leaking the redacted content.
+ *
+ * <p>14-LTI-XAPI.md §10 R1 + §11 S11 — the mapper:
+ * <ul>
+ *   <li>Pseudonymises every actor identifier
+ *       ({@code actor.account.name}, {@code actor.mbox},
+ *       {@code actor.openid}).</li>
+ *   <li>Drops {@code result.response} when
+ *       {@link LtiBridgeConfig.PrivacyConfig#redactFreeText()} is set
+ *       and increments the redaction counter.</li>
+ * </ul>
+ *
+ * <p>R4 — unknown verbs are emitted as {@link EngagementSignal} with
+ * {@link EngagementSource#MULTI_MODAL} so the pipeline still sees some
+ * activity signal rather than silently dropping the statement.
+ */
+public final class XapiStatementMapper {
+
+    /** §5 — well-known xAPI verb IRIs. */
+    public static final String VERB_ATTEMPTED   = "http://adlnet.gov/expapi/verbs/attempted";
+    public static final String VERB_ANSWERED    = "http://adlnet.gov/expapi/verbs/answered";
+    public static final String VERB_MASTERED    = "http://adlnet.gov/expapi/verbs/mastered";
+    public static final String VERB_FAILED      = "http://adlnet.gov/expapi/verbs/failed";
+    public static final String VERB_PASSED      = "http://adlnet.gov/expapi/verbs/passed";
+    public static final String VERB_INTERACTED  = "http://adlnet.gov/expapi/verbs/interacted";
+    public static final String VERB_EXPERIENCED = "http://adlnet.gov/expapi/verbs/experienced";
+
+    /** xAPI extension carrying behavioural affect (§5). */
+    public static final String EXT_AFFECT =
+            "https://jneopallium.rakov.org/xapi/extensions/affect";
+
+    private final PseudonymService pseudonyms;
+    private final boolean redactFreeText;
+    private int redactionCount;
+
+    public XapiStatementMapper(PseudonymService pseudonyms, boolean redactFreeText) {
+        this.pseudonyms = pseudonyms;
+        this.redactFreeText = redactFreeText;
+    }
+
+    /** Returns and resets the count of free-text fields redacted since the last call. */
+    public synchronized int drainRedactionCount() {
+        int c = redactionCount;
+        redactionCount = 0;
+        return c;
+    }
+
+    /* ==== Statement-list helpers ========================================= */
+
+    /**
+     * Iterate the statements of an LRS response. The LRS spec returns
+     * statements either as a top-level array or wrapped in
+     * {@code {"statements": [...]}}; both are handled.
+     */
+    public List<JsonNode> statements(JsonNode response) {
+        List<JsonNode> out = new ArrayList<>();
+        if (response == null || response.isMissingNode() || response.isNull()) return out;
+        JsonNode arr = response.isArray() ? response : response.get("statements");
+        if (arr == null || !arr.isArray()) return out;
+        for (Iterator<JsonNode> it = arr.elements(); it.hasNext(); ) {
+            JsonNode n = it.next();
+            if (n != null && !n.isNull()) out.add(n);
+        }
+        return out;
+    }
+
+    /* ==== Decoders ======================================================= */
+
+    /** Dispatch a statement to the correct decoder for {@code targetSignal}. */
+    public IInputSignal map(JsonNode statement, LtiBridgeConfig.TargetSignal targetSignal) {
+        if (statement == null || statement.isNull() || targetSignal == null) return null;
+        return switch (targetSignal) {
+            case RESPONSE   -> mapResponse(statement);
+            case MASTERY    -> mapMastery(statement);
+            case ENGAGEMENT -> mapEngagement(statement);
+            case AFFECT     -> mapAffect(statement);
+        };
+    }
+
+    /** §5 — {@code attempted} / {@code answered} statement on an item. */
+    public ResponseSignal mapResponse(JsonNode stmt) {
+        String verb = verbId(stmt);
+        if (verb == null) return null;
+        // Accept the canonical attempted/answered verbs, and treat passed/failed as
+        // response statements as well — they carry result.success too.
+        if (!VERB_ATTEMPTED.equals(verb) && !VERB_ANSWERED.equals(verb)
+                && !VERB_PASSED.equals(verb) && !VERB_FAILED.equals(verb)) {
+            return null;
+        }
+        String itemId = objectId(stmt);
+        JsonNode result = stmt.get("result");
+        boolean correct;
+        if (VERB_PASSED.equals(verb)) {
+            correct = true;
+        } else if (VERB_FAILED.equals(verb)) {
+            correct = false;
+        } else {
+            correct = booleanOrFalse(result == null ? null : result.get("success"));
+        }
+        long latencyMs = parseDurationMillis(result == null ? null : result.get("duration"));
+        String responsePayload = freeTextOrNull(result == null ? null : result.get("response"));
+        ResponseSignal r = new ResponseSignal(itemId, correct, latencyMs, responsePayload);
+        r.setName(pseudonyms.pseudonymise(actorId(stmt)));
+        return r;
+    }
+
+    /** §5 — {@code mastered} / {@code failed} on a competency. */
+    public MasteryUpdateSignal mapMastery(JsonNode stmt) {
+        String verb = verbId(stmt);
+        if (verb == null) return null;
+        if (!VERB_MASTERED.equals(verb) && !VERB_FAILED.equals(verb)
+                && !VERB_PASSED.equals(verb)) {
+            return null;
+        }
+        String competencyId = objectId(stmt);
+        double newLevel;
+        if (VERB_MASTERED.equals(verb) || VERB_PASSED.equals(verb)) {
+            newLevel = 1.0;
+        } else {
+            newLevel = 0.0;
+        }
+        JsonNode result = stmt.get("result");
+        Double scaled = result == null ? null : numberOrNull(
+                result.has("score") ? result.get("score").get("scaled") : null);
+        if (scaled != null) {
+            newLevel = Math.max(0.0, Math.min(1.0, scaled));
+        }
+        MasteryUpdateSignal m = new MasteryUpdateSignal(competencyId, newLevel);
+        m.setName(pseudonyms.pseudonymise(actorId(stmt)));
+        return m;
+    }
+
+    /** §5 — {@code interacted} / {@code experienced} → engagement. */
+    public EngagementSignal mapEngagement(JsonNode stmt) {
+        String verb = verbId(stmt);
+        if (verb == null) return null;
+        double score;
+        if (VERB_INTERACTED.equals(verb)) {
+            score = 0.8;
+        } else if (VERB_EXPERIENCED.equals(verb)) {
+            score = 0.5;
+        } else {
+            // §10 R4 — unknown verbs surface as low-confidence engagement so the
+            // pipeline keeps awareness without inventing semantics.
+            score = 0.3;
+        }
+        JsonNode result = stmt.get("result");
+        long dwellMs = parseDurationMillis(result == null ? null : result.get("duration"));
+        if (dwellMs > 0L) {
+            // Convert dwell (clamped to 10 minutes) into a [0..1] activity score and
+            // average with the verb-based prior.
+            double dwellScore = Math.min(1.0, dwellMs / (10.0 * 60_000.0));
+            score = (score + dwellScore) / 2.0;
+        }
+        EngagementSignal e = new EngagementSignal(score, EngagementSource.MULTI_MODAL);
+        e.setName(pseudonyms.pseudonymise(actorId(stmt)));
+        return e;
+    }
+
+    /** §5 — affect extension (paired with LSL deployments). */
+    public AffectObservationSignal mapAffect(JsonNode stmt) {
+        JsonNode context = stmt == null ? null : stmt.get("context");
+        JsonNode ext = context == null ? null : context.get("extensions");
+        JsonNode affect = ext == null ? null : ext.get(EXT_AFFECT);
+        if (affect == null || affect.isNull()) return null;
+        double valence = doubleOrZero(affect.get("valence"));
+        double arousal = doubleOrZero(affect.get("arousal"));
+        double confidence = doubleOrZero(affect.get("confidence"));
+        if (confidence == 0.0) confidence = 0.5;
+        AffectObservationSignal a = new AffectObservationSignal(valence, arousal, confidence);
+        a.setName(pseudonyms.pseudonymise(actorId(stmt)));
+        return a;
+    }
+
+    /* ==== Field extractors ============================================== */
+
+    private static String verbId(JsonNode stmt) {
+        if (stmt == null) return null;
+        JsonNode verb = stmt.get("verb");
+        if (verb == null || verb.isNull()) return null;
+        return textOrNull(verb.get("id"));
+    }
+
+    private static String objectId(JsonNode stmt) {
+        if (stmt == null) return null;
+        JsonNode obj = stmt.get("object");
+        if (obj == null || obj.isNull()) return null;
+        String id = textOrNull(obj.get("id"));
+        if (id != null) return id;
+        // ActivityDefinition / SubStatement / Agent fallback.
+        return textOrNull(obj.get("name"));
+    }
+
+    /**
+     * Extract the raw actor identifier. Priority order matches the xAPI
+     * Inverse Functional Identifier rules: {@code mbox} →
+     * {@code account.name} → {@code openid} → {@code name}.
+     */
+    static String actorId(JsonNode stmt) {
+        if (stmt == null) return null;
+        JsonNode actor = stmt.get("actor");
+        if (actor == null || actor.isNull()) return null;
+        String mbox = textOrNull(actor.get("mbox"));
+        if (mbox != null) return mbox;
+        JsonNode account = actor.get("account");
+        if (account != null && !account.isNull()) {
+            String acctName = textOrNull(account.get("name"));
+            String homePage = textOrNull(account.get("homePage"));
+            if (acctName != null && homePage != null) return homePage + "#" + acctName;
+            if (acctName != null) return acctName;
+        }
+        String openid = textOrNull(actor.get("openid"));
+        if (openid != null) return openid;
+        return textOrNull(actor.get("name"));
+    }
+
+    private synchronized String freeTextOrNull(JsonNode value) {
+        if (value == null || value.isNull()) return null;
+        if (redactFreeText) {
+            redactionCount++;
+            return null;
+        }
+        return value.asText();
+    }
+
+    private static boolean booleanOrFalse(JsonNode n) {
+        return n != null && !n.isNull() && n.isBoolean() && n.asBoolean();
+    }
+
+    private static Double numberOrNull(JsonNode n) {
+        if (n == null || n.isNull() || !n.isNumber()) return null;
+        return n.asDouble();
+    }
+
+    private static double doubleOrZero(JsonNode n) {
+        if (n == null || n.isNull() || !n.isNumber()) return 0.0;
+        return n.asDouble();
+    }
+
+    private static String textOrNull(JsonNode n) {
+        return n == null || n.isNull() ? null : n.asText();
+    }
+
+    /**
+     * Parse an ISO-8601 duration ({@code PT12.34S}, {@code PT1M30S}, …)
+     * into milliseconds. Returns {@code 0L} when the field is absent or
+     * unparseable — the bridge degrades gracefully rather than failing
+     * the whole poll cycle on one malformed statement.
+     */
+    static long parseDurationMillis(JsonNode duration) {
+        String iso = textOrNull(duration);
+        if (iso == null || iso.isEmpty()) return 0L;
+        try {
+            return java.time.Duration.parse(iso).toMillis();
+        } catch (RuntimeException e) {
+            return 0L;
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/XapiTransport.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/XapiTransport.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+
+/**
+ * Test seam between {@link XapiClientService} and a real xAPI Learning
+ * Record Store (14-LTI-XAPI.md §4 architecture diagram, §7).
+ *
+ * <p>The seam exposes two operations:
+ *
+ * <ul>
+ *   <li>{@link #pollStatements} — pull statements from the LRS as a
+ *       client. Used in PULL mode.</li>
+ *   <li>{@link #postStatement} — POST an xAPI statement back to the LRS
+ *       <b>only for the bridge's own advisory verbs</b>
+ *       ({@code recommended}, {@code experienced} for hints, {@code
+ *       inferred} for affect). The implementation does <b>not</b> permit
+ *       arbitrary write of statements on behalf of the learner — the
+ *       {@link LtiAdvisoryOutputAggregator} validates the actor identity
+ *       and verb before posting.</li>
+ * </ul>
+ *
+ * <p>Production wiring constructs a {@code JdkHttpXapiTransport} backed
+ * by {@code java.net.http.HttpClient}. Acceptance scenarios drive an
+ * {@link InMemoryXapiTransport} that holds a preloaded queue.
+ */
+public interface XapiTransport extends AutoCloseable {
+
+    /**
+     * Pull a page of statements from the LRS. The {@code query} is a
+     * relative URL of the form
+     * {@code "statements?verb=...&since=2026-01-01T00:00:00Z"}. Returns
+     * the parsed response — either a JSON array or an object with a
+     * {@code statements} field.
+     */
+    JsonNode pollStatements(String query) throws IOException;
+
+    /**
+     * POST a single xAPI statement to the LRS. Returns the statement id
+     * assigned by the LRS, or {@code null} when the transport has no
+     * persistent backing (in-memory tests).
+     */
+    String postStatement(JsonNode statement) throws IOException;
+
+    /**
+     * POST an AGS {@code Score} to the LMS. The {@code lineItemUrl} comes
+     * from the LTI launch claims (line-item URL) — the bridge does not
+     * know what line items exist until a learner has been launched against
+     * them.
+     */
+    default void postAgsScore(String lineItemUrl, JsonNode score) throws IOException {
+        throw new UnsupportedOperationException(
+                "AGS scoring not supported by this transport");
+    }
+
+    /** Best-effort liveness check. */
+    default boolean isReady() { return true; }
+
+    @Override
+    default void close() { /* default: no-op */ }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/XapiVerbBinding.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/XapiVerbBinding.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeBinding;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeBindingDirection;
+
+import java.util.Objects;
+
+/**
+ * Resolved per-verb xAPI read binding (14-LTI-XAPI.md §7).
+ *
+ * <p>READ-only — the bridge consumes statements from an LRS (pull) or
+ * accepts them at an endpoint (push) and decodes them into Jneopallium
+ * signals. Write bindings are modelled separately by
+ * {@link LtiBridgeConfig.WriteBindingConfig} and consumed by
+ * {@link LtiAdvisoryOutputAggregator}.
+ */
+public record XapiVerbBinding(
+        String bindingId,
+        String xapiVerb,
+        LtiBridgeConfig.TargetSignal targetSignal,
+        String signalTagPrefix
+) implements BridgeBinding {
+
+    public XapiVerbBinding {
+        Objects.requireNonNull(bindingId, "bindingId");
+        Objects.requireNonNull(xapiVerb, "xapiVerb");
+        Objects.requireNonNull(targetSignal, "targetSignal");
+    }
+
+    public static XapiVerbBinding fromConfig(LtiBridgeConfig.ReadBindingConfig r) {
+        return new XapiVerbBinding(r.bindingId(), r.xapiVerb(), r.targetSignal(),
+                r.signalTagPrefix());
+    }
+
+    @Override public String signalTag() { return signalTagPrefix; }
+    @Override public BridgeBindingDirection direction() { return BridgeBindingDirection.READ; }
+    @Override public String loopId() { return bindingId; }
+    @Override public Double failSafeValue() { return null; }
+    @Override public Double rampRateMaxPerSec() { return null; }
+    @Override public Double minClampValue() { return null; }
+    @Override public Double maxClampValue() { return null; }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/package-info.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/bridge/lti/package-info.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+/**
+ * LTI / xAPI bridge — Bridge 14 (14-LTI-XAPI.md).
+ *
+ * <p>Wires Jneopallium's tutoring signal pipeline into a learning
+ * environment over the 1EdTech LTI 1.3 standard (course launch + identity
+ * + AGS / NRPS services) and xAPI (Experience API) statements pulled from
+ * or posted to a Learning Record Store.
+ *
+ * <ul>
+ *   <li>{@link LtiClientService} parses and verifies LTI 1.3 launch JWTs
+ *       and exposes the learner / course / line-item context.</li>
+ *   <li>{@link XapiClientService} pulls xAPI statements from an LRS in
+ *       PULL mode or accepts statements posted to the bridge in PUSH
+ *       mode, decoding them into Jneopallium tutoring signals via
+ *       {@link XapiStatementMapper}.</li>
+ *   <li>{@link LtiAdvisoryOutputAggregator} emits xAPI
+ *       {@code recommended} / {@code experienced} statements and
+ *       (optionally) AGS {@code Score} proposals back to the LMS, with
+ *       {@code gradingProgress=PendingManual} permanently locked in
+ *       config — the loader rejects {@code FullyGraded}.</li>
+ * </ul>
+ *
+ * <p><b>Bridge ceiling: ADVISORY.</b> The bridge cannot auto-grade,
+ * auto-enrol, or modify a learner's record without instructor
+ * confirmation:
+ *
+ * <ol>
+ *   <li>{@link LtiBridgeConfigLoader} rejects {@code AUTONOMOUS} in
+ *       {@code perTagSafetyMode} (14-LTI-XAPI.md §6, §9 S10).</li>
+ *   <li>{@link LtiBridgeConfigLoader} rejects
+ *       {@code gradingProgress: FullyGraded} on any AGS write binding
+ *       (14-LTI-XAPI.md §5, §9 S10).</li>
+ *   <li>{@link PseudonymService} pseudonymises every actor identifier
+ *       before audit / advisory persistence (§9 S11, §10 R1).</li>
+ *   <li>{@link XapiStatementMapper} drops {@code result.response}
+ *       free-text by default (§9 S12, §10 R5).</li>
+ * </ol>
+ *
+ * <p>Production wiring constructs a {@link JdkHttpXapiTransport}
+ * (default) and a properly configured {@link LtiClientService.JwtVerifier}
+ * (Nimbus / java-jwt JWKS backed). Acceptance tests use
+ * {@link InMemoryXapiTransport}.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/tutoring/AffectObservationSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/tutoring/AffectObservationSignal.java
@@ -5,6 +5,7 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring;
 
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
@@ -12,7 +13,8 @@ import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
  * (engagement trajectory + response accuracy). Feeds the affect module.
  * ProcessingFrequency: loop=1, epoch=2.
  */
-public class AffectObservationSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class AffectObservationSignal extends AbstractSignal<Void>
+        implements ISignal<Void>, IInputSignal<Void> {
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
 

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/tutoring/ContentRecommendationSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/tutoring/ContentRecommendationSignal.java
@@ -5,6 +5,7 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring;
 
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
@@ -12,7 +13,8 @@ import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
  * development fit (Vygotsky 1978).
  * ProcessingFrequency: loop=1, epoch=3.
  */
-public class ContentRecommendationSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class ContentRecommendationSignal extends AbstractSignal<Void>
+        implements ISignal<Void>, IResultSignal<Void> {
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(3L, 1);
 
@@ -45,6 +47,8 @@ public class ContentRecommendationSignal extends AbstractSignal<Void> implements
     @Override public Class<Void> getParamClass() { return Void.class; }
     @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return ContentRecommendationSignal.class; }
     @Override public String getDescription() { return "ContentRecommendationSignal"; }
+    @Override public Void getResultObject() { return null; }
+    @Override public Class<Void> getResultObjectClass() { return Void.class; }
 
     @Override
     @SuppressWarnings("unchecked")

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/tutoring/EngagementSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/tutoring/EngagementSignal.java
@@ -6,13 +6,15 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring;
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.tutoring.EngagementSource;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
  * Fused attention/engagement estimate from a sensing channel.
  * ProcessingFrequency: loop=1, epoch=2.
  */
-public class EngagementSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class EngagementSignal extends AbstractSignal<Void>
+        implements ISignal<Void>, IInputSignal<Void> {
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
 

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/tutoring/HintSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/tutoring/HintSignal.java
@@ -6,6 +6,7 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring;
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.tutoring.HintLevel;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
@@ -13,7 +14,8 @@ import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
  * least-informative (meta-cognitive) to most-informative (worked example).
  * ProcessingFrequency: loop=1, epoch=2.
  */
-public class HintSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class HintSignal extends AbstractSignal<Void>
+        implements ISignal<Void>, IResultSignal<Void> {
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
 
@@ -47,6 +49,8 @@ public class HintSignal extends AbstractSignal<Void> implements ISignal<Void> {
     @Override public Class<Void> getParamClass() { return Void.class; }
     @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return HintSignal.class; }
     @Override public String getDescription() { return "HintSignal"; }
+    @Override public Void getResultObject() { return null; }
+    @Override public Class<Void> getResultObjectClass() { return Void.class; }
 
     @Override
     @SuppressWarnings("unchecked")

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/tutoring/InterventionSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/tutoring/InterventionSignal.java
@@ -6,6 +6,7 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring;
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.tutoring.InterventionType;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
@@ -13,7 +14,8 @@ import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
  * escalate to a human).
  * ProcessingFrequency: loop=2, epoch=1.
  */
-public class InterventionSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class InterventionSignal extends AbstractSignal<Void>
+        implements ISignal<Void>, IResultSignal<Void> {
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 2);
 
@@ -43,6 +45,8 @@ public class InterventionSignal extends AbstractSignal<Void> implements ISignal<
     @Override public Class<Void> getParamClass() { return Void.class; }
     @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return InterventionSignal.class; }
     @Override public String getDescription() { return "InterventionSignal"; }
+    @Override public Void getResultObject() { return null; }
+    @Override public Class<Void> getResultObjectClass() { return Void.class; }
 
     @Override
     @SuppressWarnings("unchecked")

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/tutoring/MasteryUpdateSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/tutoring/MasteryUpdateSignal.java
@@ -5,13 +5,16 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring;
 
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
  * Emitted when a concept's BKT mastery estimate is updated.
  * ProcessingFrequency: loop=2, epoch=3.
  */
-public class MasteryUpdateSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class MasteryUpdateSignal extends AbstractSignal<Void>
+        implements ISignal<Void>, IInputSignal<Void>, IResultSignal<Void> {
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(3L, 2);
 
@@ -42,6 +45,8 @@ public class MasteryUpdateSignal extends AbstractSignal<Void> implements ISignal
     @Override public Class<Void> getParamClass() { return Void.class; }
     @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return MasteryUpdateSignal.class; }
     @Override public String getDescription() { return "MasteryUpdateSignal"; }
+    @Override public Void getResultObject() { return null; }
+    @Override public Class<Void> getResultObjectClass() { return Void.class; }
 
     @Override
     @SuppressWarnings("unchecked")

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/tutoring/ResponseSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/tutoring/ResponseSignal.java
@@ -5,13 +5,15 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring;
 
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
  * Carries a learner response to a presented item.
  * ProcessingFrequency: loop=1, epoch=1.
  */
-public class ResponseSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class ResponseSignal extends AbstractSignal<Void>
+        implements ISignal<Void>, IInputSignal<Void> {
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(1L, 1);
 

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/tutoring/ScaffoldingSignal.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/net/signals/impl/tutoring/ScaffoldingSignal.java
@@ -6,6 +6,7 @@ package com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring;
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.cycleprocessing.ProcessingFrequency;
 import com.rakovpublic.jneuropallium.worker.net.neuron.impl.tutoring.ScaffoldType;
 import com.rakovpublic.jneuropallium.worker.net.signals.AbstractSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
 import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
 
 /**
@@ -13,7 +14,8 @@ import com.rakovpublic.jneuropallium.worker.net.signals.ISignal;
  * when the learner shows signs of overload.
  * ProcessingFrequency: loop=1, epoch=2.
  */
-public class ScaffoldingSignal extends AbstractSignal<Void> implements ISignal<Void> {
+public class ScaffoldingSignal extends AbstractSignal<Void>
+        implements ISignal<Void>, IResultSignal<Void> {
 
     public static final ProcessingFrequency PROCESSING_FREQUENCY = new ProcessingFrequency(2L, 1);
 
@@ -43,6 +45,8 @@ public class ScaffoldingSignal extends AbstractSignal<Void> implements ISignal<V
     @Override public Class<Void> getParamClass() { return Void.class; }
     @Override public Class<? extends ISignal<Void>> getCurrentSignalClass() { return ScaffoldingSignal.class; }
     @Override public String getDescription() { return "ScaffoldingSignal"; }
+    @Override public Void getResultObject() { return null; }
+    @Override public Class<Void> getResultObjectClass() { return Void.class; }
 
     @Override
     @SuppressWarnings("unchecked")

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/lti/LtiBridgeConfigLoaderTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/lti/LtiBridgeConfigLoaderTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link LtiBridgeConfigLoader} tests (14-LTI-XAPI.md §6, §9 S10, §10).
+ */
+class LtiBridgeConfigLoaderTest {
+
+    @Test
+    void loadsMinimalConfig() throws Exception {
+        String yaml = """
+                lti:
+                  toolName: "jneopallium-tutor"
+                  platforms:
+                    - issuer: "https://canvas.example.edu"
+                      clientId: "10000000000123"
+                      authLoginUrl: "https://canvas.example.edu/api/lti/authorize_redirect"
+                      authTokenUrl: "https://canvas.example.edu/login/oauth2/token"
+                      keysetUrl: "https://canvas.example.edu/api/lti/security/jwks"
+                      deploymentIds: ["1:abcdef"]
+                  toolPrivateKeyPath: "/etc/jneopallium/lti/tool-private.pem"
+                  toolPublicJwksUrl: "https://jneo-tutor.example.edu/.well-known/jwks.json"
+                xapi:
+                  mode: PULL
+                  lrs:
+                    endpoint: "https://lrs.example.edu/xapi"
+                    auth:
+                      type: BASIC_AUTH
+                      usernameEnv: XAPI_USER
+                      passwordEnv: XAPI_PASSWORD
+                    pollIntervalSeconds: 60
+                cohort:
+                  courseIds: ["course-101", "course-202"]
+                reads:
+                  - bindingId: ATTEMPTS
+                    xapiVerb: "http://adlnet.gov/expapi/verbs/attempted"
+                    targetSignal: RESPONSE
+                    signalTagPrefix: "TUTOR.ATTEMPT"
+                  - bindingId: ENGAGEMENT
+                    xapiVerb: "http://adlnet.gov/expapi/verbs/interacted"
+                    targetSignal: ENGAGEMENT
+                    signalTagPrefix: "TUTOR.ENGAGE"
+                writes:
+                  - bindingId: RECOMMENDATIONS
+                    xapiVerb: "http://activitystrea.ms/recommend"
+                    targetActor: "Jneopallium-Tutor"
+                    signalTag: "TUTOR.RECOMMEND"
+                  - bindingId: PROPOSED-SCORES
+                    ltiAgs: true
+                    gradingProgress: "PendingManual"
+                    signalTag: "TUTOR.SCORE.PROPOSAL"
+                privacy:
+                  pseudonymise: true
+                  saltEnv: TUTOR_PSEUDO_SALT
+                  redactFreeText: true
+                audit:
+                  localAuditFile: /var/log/jneopallium/lti-audit.jsonl
+                perTagSafetyMode:
+                  RECOMMENDATIONS: ADVISORY
+                  PROPOSED-SCORES: ADVISORY
+                """;
+        LtiBridgeConfig cfg = LtiBridgeConfigLoader.load(yaml);
+        assertEquals("jneopallium-tutor", cfg.lti().toolName());
+        assertEquals(1, cfg.lti().platforms().size());
+        assertEquals("https://canvas.example.edu", cfg.lti().platforms().get(0).issuer());
+        assertEquals(LtiBridgeConfig.XapiMode.PULL, cfg.xapi().mode());
+        assertEquals("https://lrs.example.edu/xapi", cfg.xapi().lrs().endpoint());
+        assertEquals(2, cfg.reads().size());
+        assertEquals(2, cfg.writes().size());
+        assertEquals(LtiBridgeConfig.TargetSignal.RESPONSE,
+                cfg.reads().get(0).targetSignal());
+        assertEquals("PendingManual", cfg.writes().get(1).gradingProgress());
+        assertTrue(cfg.privacy().pseudonymise());
+        assertNotNull(cfg.audit().localAuditFile());
+    }
+
+    /** §9 S10 — FullyGraded must be rejected at config load. */
+    @Test
+    void fullyGradedIsRejected() {
+        String yaml = """
+                xapi:
+                  mode: PULL
+                  lrs:
+                    endpoint: "https://lrs.example.edu/xapi"
+                    pollIntervalSeconds: 60
+                audit:
+                  localAuditFile: /tmp/x.jsonl
+                writes:
+                  - bindingId: AGS-SCORE
+                    ltiAgs: true
+                    gradingProgress: "FullyGraded"
+                """;
+        String msg = causeMessage(() -> LtiBridgeConfigLoader.load(yaml));
+        assertTrue(msg.contains("PendingManual") || msg.contains("FullyGraded"),
+                "loader must mention PendingManual / FullyGraded, got: " + msg);
+    }
+
+    /** §6 — AUTONOMOUS rejected by validator. */
+    @Test
+    void autonomousModeIsRejected() {
+        String yaml = """
+                xapi:
+                  mode: PULL
+                  lrs:
+                    endpoint: "https://lrs.example.edu/xapi"
+                    pollIntervalSeconds: 60
+                audit:
+                  localAuditFile: /tmp/x.jsonl
+                perTagSafetyMode:
+                  ANY: AUTONOMOUS
+                """;
+        String msg = causeMessage(() -> LtiBridgeConfigLoader.load(yaml));
+        assertTrue(msg.contains("AUTONOMOUS"),
+                "loader must mention AUTONOMOUS, got: " + msg);
+    }
+
+    /** 00-FRAMEWORK §3 — unknown YAML keys fail at load. */
+    @Test
+    void unknownKeyIsRejected() {
+        String yaml = """
+                xapi:
+                  mode: PULL
+                  lrs:
+                    endpoint: "https://lrs.example.edu/xapi"
+                    pollIntervalSeconds: 60
+                audit:
+                  localAuditFile: /tmp/x.jsonl
+                bogusKey: 42
+                """;
+        assertThrows(UnrecognizedPropertyException.class,
+                () -> LtiBridgeConfigLoader.load(yaml));
+    }
+
+    /** Poll interval must not run below the 15-second floor. */
+    @Test
+    void pollIntervalBelowFloorIsRejected() {
+        String yaml = """
+                xapi:
+                  mode: PULL
+                  lrs:
+                    endpoint: "https://lrs.example.edu/xapi"
+                    pollIntervalSeconds: 5
+                audit:
+                  localAuditFile: /tmp/x.jsonl
+                """;
+        String msg = causeMessage(() -> LtiBridgeConfigLoader.load(yaml));
+        assertTrue(msg.contains("pollIntervalSeconds"),
+                "loader must mention pollIntervalSeconds, got: " + msg);
+    }
+
+    /** Duplicate read or write binding ids are rejected. */
+    @Test
+    void duplicateBindingIdIsRejected() {
+        String yaml = """
+                xapi:
+                  mode: PULL
+                  lrs:
+                    endpoint: "https://lrs.example.edu/xapi"
+                    pollIntervalSeconds: 60
+                audit:
+                  localAuditFile: /tmp/x.jsonl
+                reads:
+                  - bindingId: DUP
+                    xapiVerb: "http://adlnet.gov/expapi/verbs/attempted"
+                    targetSignal: RESPONSE
+                  - bindingId: DUP
+                    xapiVerb: "http://adlnet.gov/expapi/verbs/interacted"
+                    targetSignal: ENGAGEMENT
+                """;
+        String msg = causeMessage(() -> LtiBridgeConfigLoader.load(yaml));
+        assertTrue(msg.contains("duplicate"),
+                "loader must mention duplicate, got: " + msg);
+    }
+
+    @Test
+    void shadowAndAdvisoryAccepted() throws Exception {
+        String yaml = """
+                xapi:
+                  mode: PULL
+                  lrs:
+                    endpoint: "https://lrs.example.edu/xapi"
+                    pollIntervalSeconds: 60
+                audit:
+                  localAuditFile: /tmp/x.jsonl
+                perTagSafetyMode:
+                  R: ADVISORY
+                  S: SHADOW
+                """;
+        LtiBridgeConfig cfg = LtiBridgeConfigLoader.load(yaml);
+        assertEquals(BridgeSafetyMode.ADVISORY, cfg.perTagSafetyMode().get("R"));
+        assertEquals(BridgeSafetyMode.SHADOW, cfg.perTagSafetyMode().get("S"));
+    }
+
+    private static String causeMessage(org.junit.jupiter.api.function.Executable e) {
+        Throwable t = assertThrows(Throwable.class, e);
+        while (t.getCause() != null && t.getCause() != t) t = t.getCause();
+        return t.getMessage() == null ? "" : t.getMessage();
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/lti/LtiBridgeIntegrationTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/lti/LtiBridgeIntegrationTest.java
@@ -1,0 +1,419 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import com.rakovpublic.jneuropallium.worker.net.layers.IResult;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.IResultSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.ContentRecommendationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.EngagementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.MasteryUpdateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.ResponseSignal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end LTI / xAPI bridge tests (14-LTI-XAPI.md §9 acceptance
+ * scenarios S7, S8, S9, S10, S11, S12).
+ */
+class LtiBridgeIntegrationTest {
+
+    private final ObjectMapper json = new ObjectMapper();
+
+    private static final class FakeResult implements IResult<IResultSignal> {
+        private final IResultSignal signal;
+        FakeResult(IResultSignal s) { this.signal = s; }
+        @Override public IResultSignal getResult() { return signal; }
+        @Override public Long getNeuronId() { return 42L; }
+    }
+
+    private LtiBridgeConfig baseConfig(Path auditFile, Path advisoryFile) {
+        return new LtiBridgeConfig(
+                new LtiBridgeConfig.LtiSection(
+                        "jneopallium-tutor",
+                        List.of(new LtiBridgeConfig.PlatformConfig(
+                                "https://canvas.example.edu",
+                                "10000000000123",
+                                "https://canvas.example.edu/api/lti/authorize_redirect",
+                                "https://canvas.example.edu/login/oauth2/token",
+                                "https://canvas.example.edu/api/lti/security/jwks",
+                                List.of("1:abcdef"))),
+                        null, null),
+                new LtiBridgeConfig.XapiSection(
+                        LtiBridgeConfig.XapiMode.PULL,
+                        new LtiBridgeConfig.LrsConfig(
+                                "https://lrs.example.edu/xapi",
+                                new LtiBridgeConfig.AuthConfig(
+                                        LtiBridgeConfig.AuthType.NONE, null, null, null),
+                                60L)),
+                new LtiBridgeConfig.CohortConfig(List.of("course-101")),
+                List.of(
+                        new LtiBridgeConfig.ReadBindingConfig(
+                                "ATTEMPTS",
+                                XapiStatementMapper.VERB_ATTEMPTED,
+                                LtiBridgeConfig.TargetSignal.RESPONSE,
+                                "TUTOR.ATTEMPT"),
+                        new LtiBridgeConfig.ReadBindingConfig(
+                                "ENGAGEMENT",
+                                XapiStatementMapper.VERB_INTERACTED,
+                                LtiBridgeConfig.TargetSignal.ENGAGEMENT,
+                                "TUTOR.ENGAGE")),
+                List.of(
+                        new LtiBridgeConfig.WriteBindingConfig(
+                                "RECOMMENDATIONS",
+                                "http://activitystrea.ms/recommend",
+                                "Jneopallium-Tutor",
+                                false, null, "TUTOR.RECOMMEND"),
+                        new LtiBridgeConfig.WriteBindingConfig(
+                                "PROPOSED-SCORES",
+                                null, null, true,
+                                LtiBridgeConfig.GradingProgress.PENDING_MANUAL,
+                                "TUTOR.SCORE.PROPOSAL")),
+                new LtiBridgeConfig.PrivacyConfig(true, null, true),
+                new LtiBridgeConfig.AuditConfig(auditFile.toString(), advisoryFile.toString()),
+                Map.of("RECOMMENDATIONS", BridgeSafetyMode.ADVISORY),
+                null);
+    }
+
+    /** §9 S7 — pull statements from an LRS and emit ResponseSignals + EngagementSignals. */
+    @Test
+    void s7_lrsPullEmitsResponseAndEngagementSignals(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        LtiBridgeConfig cfg = baseConfig(auditFile, tmp.resolve("advisory.jsonl"));
+        InMemoryXapiTransport transport = new InMemoryXapiTransport();
+        transport.putStatements(
+                "statements?verb=" + java.net.URLEncoder.encode(
+                        XapiStatementMapper.VERB_ATTEMPTED, java.nio.charset.StandardCharsets.UTF_8),
+                json.readTree("""
+                        {
+                          "actor": { "account": { "name": "alice@example.edu" } },
+                          "verb":  { "id": "http://adlnet.gov/expapi/verbs/attempted" },
+                          "object":{ "id": "item-42" },
+                          "result":{ "success": true, "duration": "PT12S" }
+                        }
+                        """));
+        transport.putStatements(
+                "statements?verb=" + java.net.URLEncoder.encode(
+                        XapiStatementMapper.VERB_INTERACTED, java.nio.charset.StandardCharsets.UTF_8),
+                json.readTree("""
+                        {
+                          "actor": { "account": { "name": "alice@example.edu" } },
+                          "verb":  { "id": "http://adlnet.gov/expapi/verbs/interacted" },
+                          "object":{ "id": "module-1" },
+                          "result":{ "duration": "PT5M" }
+                        }
+                        """));
+        try (LtiAuditOutput audit = new LtiAuditOutput(auditFile);
+             XapiClientService svc = new XapiClientService(cfg, transport, audit)) {
+            svc.start();
+            svc.poll();
+            XapiResponseInput rIn = new XapiResponseInput("attempts", svc, List.of("ATTEMPTS"));
+            XapiEngagementInput eIn = new XapiEngagementInput("engage", svc, List.of("ENGAGEMENT"));
+            List<IInputSignal> rSigs = rIn.readSignals();
+            List<IInputSignal> eSigs = eIn.readSignals();
+            assertEquals(1, rSigs.size());
+            assertEquals(1, eSigs.size());
+            assertTrue(rSigs.get(0) instanceof ResponseSignal);
+            assertTrue(eSigs.get(0) instanceof EngagementSignal);
+            ResponseSignal r = (ResponseSignal) rSigs.get(0);
+            assertEquals("item-42", r.getItemId());
+            assertTrue(r.isCorrect());
+        }
+    }
+
+    /** §9 S8 — successful LTI 1.3 launch decodes course context. */
+    @Test
+    void s8_ltiLaunchDecodesContext(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        LtiBridgeConfig cfg = baseConfig(auditFile, tmp.resolve("advisory.jsonl"));
+        LtiClientService lti = new LtiClientService(cfg);
+        ObjectNode header = json.createObjectNode();
+        header.put("alg", "RS256");
+        header.put("kid", "test-key-1");
+        ObjectNode payload = json.createObjectNode();
+        payload.put("iss", "https://canvas.example.edu");
+        payload.put("aud", "10000000000123");
+        payload.put("sub", "alice@example.edu");
+        payload.put("nonce", "n-1");
+        payload.put("exp", (System.currentTimeMillis() / 1000L) + 3600L);
+        payload.put(LtiClientService.CLAIM_DEPLOYMENT_ID, "1:abcdef");
+        ObjectNode ctx = payload.putObject(LtiClientService.CLAIM_CONTEXT);
+        ctx.put("id", "course-101");
+        ctx.put("title", "Introduction to Adaptive Tutoring");
+        payload.putArray(LtiClientService.CLAIM_ROLES)
+                .add(LtiClientService.ROLE_LEARNER);
+        payload.putObject(LtiClientService.CLAIM_AGS)
+                .put("lineitem", "https://canvas.example.edu/api/lti/courses/1/line_items/7")
+                .put("lineitems", "https://canvas.example.edu/api/lti/courses/1/line_items");
+        String idToken = LtiClientService.buildPermissiveIdToken(header, payload);
+        LtiClientService.LaunchContext launch = lti.verifyLaunch(idToken);
+        assertNotNull(launch);
+        assertEquals("https://canvas.example.edu", launch.issuer());
+        assertEquals("course-101", launch.contextId());
+        assertTrue(launch.isLearner());
+        assertFalse(launch.isInstructor());
+        assertNotNull(launch.agsLineItemUrl());
+    }
+
+    /** §9 S8 — wrong issuer / wrong audience are rejected. */
+    @Test
+    void s8_ltiLaunchWithWrongIssuerIsRejected(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        LtiBridgeConfig cfg = baseConfig(auditFile, tmp.resolve("advisory.jsonl"));
+        LtiClientService lti = new LtiClientService(cfg);
+        ObjectNode payload = json.createObjectNode();
+        payload.put("iss", "https://OTHER-platform.example.edu");
+        payload.put("aud", "10000000000123");
+        payload.put("sub", "bob");
+        payload.put("exp", (System.currentTimeMillis() / 1000L) + 3600L);
+        payload.put(LtiClientService.CLAIM_DEPLOYMENT_ID, "1:abcdef");
+        String idToken = LtiClientService.buildPermissiveIdToken(
+                json.createObjectNode().put("alg", "none"), payload);
+        assertThrows(LtiClientService.LaunchVerificationException.class,
+                () -> lti.verifyLaunch(idToken));
+    }
+
+    /** §9 S9 — pipeline emits a MasteryUpdate; an AGS Score is posted with PendingManual. */
+    @Test
+    void s9_masteryProposalIsPostedAsPendingManual(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        Path advisoryFile = tmp.resolve("advisory.jsonl");
+        LtiBridgeConfig cfg = baseConfig(auditFile, advisoryFile);
+        InMemoryXapiTransport transport = new InMemoryXapiTransport();
+        try (LtiAuditOutput audit = new LtiAuditOutput(auditFile);
+             XapiClientService svc = new XapiClientService(cfg, transport, audit);
+             LtiAdvisoryOutputAggregator agg = new LtiAdvisoryOutputAggregator(svc, audit)) {
+            svc.start();
+            agg.setActiveLaunch(new LtiClientService.LaunchContext(
+                    LtiPlatformBinding.fromConfig(cfg.lti().platforms().get(0)),
+                    "https://canvas.example.edu", "10000000000123",
+                    "alice@example.edu", "n-1",
+                    "course-101", "Course 101",
+                    List.of(LtiClientService.ROLE_LEARNER),
+                    "1:abcdef",
+                    "https://canvas.example.edu/api/lti/courses/1/line_items/7",
+                    "https://canvas.example.edu/api/lti/courses/1/line_items",
+                    null));
+            MasteryUpdateSignal mu = new MasteryUpdateSignal("competency-7", 0.92);
+            agg.save(List.<IResult>of(new FakeResult(mu)), 1_700_000_000L, 7L, null);
+        }
+        // AGS post must have happened with gradingProgress=PendingManual.
+        List<InMemoryXapiTransport.PostedScore> posts = transport.postedScores();
+        assertEquals(1, posts.size());
+        JsonNode score = posts.get(0).body();
+        assertEquals("PendingManual", score.get("gradingProgress").asText());
+        assertEquals(1.0, score.get("scoreMaximum").asDouble(), 1e-9);
+        String advisory = Files.readString(advisoryFile);
+        assertTrue(advisory.contains("SCORE_PROPOSAL"));
+        assertTrue(advisory.contains("PendingManual"));
+    }
+
+    /** §9 S10 — FullyGraded gradingProgress is rejected at config load. */
+    @Test
+    void s10_fullyGradedConfigIsRejected() {
+        String yaml = """
+                xapi:
+                  mode: PULL
+                  lrs:
+                    endpoint: "https://lrs.example.edu/xapi"
+                    pollIntervalSeconds: 60
+                audit:
+                  localAuditFile: /tmp/x.jsonl
+                writes:
+                  - bindingId: AGS-SCORE
+                    ltiAgs: true
+                    gradingProgress: "FullyGraded"
+                """;
+        Throwable t = assertThrows(Throwable.class, () -> LtiBridgeConfigLoader.load(yaml));
+        // Walk to the deepest cause.
+        while (t.getCause() != null && t.getCause() != t) t = t.getCause();
+        String msg = t.getMessage() == null ? "" : t.getMessage();
+        assertTrue(msg.contains("FullyGraded") || msg.contains("PendingManual"),
+                "S10 — loader must reject FullyGraded with a clear message, got: " + msg);
+    }
+
+    /** §9 S11 — actor.account.name pseudonymised; raw email never appears in audit JSONL. */
+    @Test
+    void s11_pseudonymisationKeepsRawEmailOutOfAudit(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        Path advisoryFile = tmp.resolve("advisory.jsonl");
+        LtiBridgeConfig cfg = baseConfig(auditFile, advisoryFile);
+        InMemoryXapiTransport transport = new InMemoryXapiTransport();
+        transport.putStatements(
+                "statements?verb=" + java.net.URLEncoder.encode(
+                        XapiStatementMapper.VERB_ATTEMPTED, java.nio.charset.StandardCharsets.UTF_8),
+                json.readTree("""
+                        {
+                          "actor": { "account": { "name": "alice@example.edu" } },
+                          "verb":  { "id": "http://adlnet.gov/expapi/verbs/attempted" },
+                          "object":{ "id": "item-42" },
+                          "result":{ "success": true }
+                        }
+                        """));
+        try (LtiAuditOutput audit = new LtiAuditOutput(auditFile);
+             XapiClientService svc = new XapiClientService(cfg, transport, audit);
+             LtiAdvisoryOutputAggregator agg = new LtiAdvisoryOutputAggregator(svc, audit)) {
+            svc.start();
+            svc.poll();
+            // emit a recommendation referencing the same learner to exercise advisory egress
+            agg.setActiveLaunch(new LtiClientService.LaunchContext(
+                    LtiPlatformBinding.fromConfig(cfg.lti().platforms().get(0)),
+                    "https://canvas.example.edu", "10000000000123",
+                    "alice@example.edu", "n-1",
+                    "course-101", null,
+                    List.of(LtiClientService.ROLE_LEARNER),
+                    "1:abcdef", null, null, null));
+            ContentRecommendationSignal rec =
+                    new ContentRecommendationSignal("next-item", "ZPD fit", 0.72);
+            agg.save(List.<IResult>of(new FakeResult(rec)), 1_700_000_000L, 7L, null);
+        }
+        String auditContent = Files.exists(auditFile) ? Files.readString(auditFile) : "";
+        String advisoryContent = Files.exists(advisoryFile) ? Files.readString(advisoryFile) : "";
+        assertFalse(auditContent.contains("alice@example.edu"),
+                "S11 — raw email must not appear in audit JSONL");
+        assertFalse(advisoryContent.contains("alice@example.edu"),
+                "S11 — raw email must not appear in advisory JSONL");
+    }
+
+    /** §9 S12 — result.response free-text is redacted; a count is recorded in audit. */
+    @Test
+    void s12_freeTextRedactionIsRecordedAsCountOnly(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        LtiBridgeConfig cfg = baseConfig(auditFile, tmp.resolve("advisory.jsonl"));
+        InMemoryXapiTransport transport = new InMemoryXapiTransport();
+        transport.putStatements(
+                "statements?verb=" + java.net.URLEncoder.encode(
+                        XapiStatementMapper.VERB_ATTEMPTED, java.nio.charset.StandardCharsets.UTF_8),
+                json.readTree("""
+                        {
+                          "actor": { "mbox": "mailto:alice@example.edu" },
+                          "verb":  { "id": "http://adlnet.gov/expapi/verbs/attempted" },
+                          "object":{ "id": "item-42" },
+                          "result":{ "success": false,
+                                     "response": "I think the answer is X because reasons" }
+                        }
+                        """));
+        try (LtiAuditOutput audit = new LtiAuditOutput(auditFile);
+             XapiClientService svc = new XapiClientService(cfg, transport, audit)) {
+            svc.start();
+            svc.poll();
+            XapiResponseInput in = new XapiResponseInput("attempts", svc, List.of("ATTEMPTS"));
+            List<IInputSignal> sigs = in.readSignals();
+            assertEquals(1, sigs.size());
+            ResponseSignal r = (ResponseSignal) sigs.get(0);
+            assertEquals(null, r.getResponsePayload(),
+                    "S12 — response text must be redacted before reaching the pipeline");
+        }
+        String content = Files.exists(auditFile) ? Files.readString(auditFile) : "";
+        assertFalse(content.contains("I think the answer"),
+                "S12 — sensitive response text must not appear in audit JSONL");
+        assertTrue(content.contains("FREE_TEXT_REDACTED"),
+                "S12 — audit must record a count of redactions, got: " + content);
+    }
+
+    /** PUSH mode — statements arrive via {@link XapiClientService#acceptStatement}. */
+    @Test
+    void pushModeRoutesAcceptedStatementsToBindings(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        LtiBridgeConfig cfg = new LtiBridgeConfig(
+                null,
+                new LtiBridgeConfig.XapiSection(LtiBridgeConfig.XapiMode.PUSH,
+                        new LtiBridgeConfig.LrsConfig(
+                                "https://lrs.example.edu/xapi", null, 60L)),
+                null,
+                List.of(new LtiBridgeConfig.ReadBindingConfig(
+                        "ATTEMPTS",
+                        XapiStatementMapper.VERB_ATTEMPTED,
+                        LtiBridgeConfig.TargetSignal.RESPONSE,
+                        "TUTOR.ATTEMPT")),
+                List.of(),
+                null,
+                new LtiBridgeConfig.AuditConfig(auditFile.toString(), null),
+                Map.of(),
+                null);
+        InMemoryXapiTransport transport = new InMemoryXapiTransport();
+        try (LtiAuditOutput audit = new LtiAuditOutput(auditFile);
+             XapiClientService svc = new XapiClientService(cfg, transport, audit)) {
+            svc.start();
+            // PULL poll should be a no-op in PUSH mode.
+            svc.poll();
+            svc.acceptStatement(json.readTree("""
+                    {
+                      "actor": { "name": "alice" },
+                      "verb":  { "id": "http://adlnet.gov/expapi/verbs/attempted" },
+                      "object":{ "id": "item-99" },
+                      "result":{ "success": true }
+                    }
+                    """));
+            XapiResponseInput in = new XapiResponseInput("attempts", svc, List.of("ATTEMPTS"));
+            List<IInputSignal> sigs = in.readSignals();
+            assertEquals(1, sigs.size());
+            ResponseSignal r = (ResponseSignal) sigs.get(0);
+            assertEquals("item-99", r.getItemId());
+        }
+    }
+
+    /** Transport not ready → PULL poll is a no-op. */
+    @Test
+    void transportNotReadyIsGraceful(@TempDir Path tmp) throws Exception {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        LtiBridgeConfig cfg = baseConfig(auditFile, tmp.resolve("advisory.jsonl"));
+        InMemoryXapiTransport transport = new InMemoryXapiTransport().setReady(false);
+        try (LtiAuditOutput audit = new LtiAuditOutput(auditFile);
+             XapiClientService svc = new XapiClientService(cfg, transport, audit)) {
+            svc.start();
+            svc.poll(); // must not throw
+            XapiResponseInput in = new XapiResponseInput("attempts", svc, List.of("ATTEMPTS"));
+            assertTrue(in.readSignals().isEmpty());
+        }
+    }
+
+    /** Recommendation egress posts an xAPI 'recommended' statement actor=tool, not learner. */
+    @Test
+    void recommendationActorIsTheToolNotTheLearner(@TempDir Path tmp) throws IOException {
+        Path auditFile = tmp.resolve("audit.jsonl");
+        Path advisoryFile = tmp.resolve("advisory.jsonl");
+        LtiBridgeConfig cfg = baseConfig(auditFile, advisoryFile);
+        InMemoryXapiTransport transport = new InMemoryXapiTransport();
+        try (LtiAuditOutput audit = new LtiAuditOutput(auditFile);
+             XapiClientService svc = new XapiClientService(cfg, transport, audit);
+             LtiAdvisoryOutputAggregator agg = new LtiAdvisoryOutputAggregator(svc, audit)) {
+            svc.start();
+            agg.setActiveLaunch(new LtiClientService.LaunchContext(
+                    LtiPlatformBinding.fromConfig(cfg.lti().platforms().get(0)),
+                    "https://canvas.example.edu", "10000000000123",
+                    "alice@example.edu", "n-1",
+                    "course-101", null,
+                    List.of(LtiClientService.ROLE_LEARNER),
+                    "1:abcdef", null, null, null));
+            ContentRecommendationSignal rec =
+                    new ContentRecommendationSignal("next-item", "ZPD fit", 0.72);
+            agg.save(List.<IResult>of(new FakeResult(rec)), 1_700_000_000L, 7L, null);
+        }
+        List<JsonNode> posted = transport.postedStatements();
+        assertEquals(1, posted.size());
+        JsonNode stmt = posted.get(0);
+        // Actor must be the tool, not the learner.
+        String actorName = stmt.get("actor").get("name").asText();
+        assertEquals(LtiAdvisoryOutputAggregator.DEFAULT_TOOL_ACTOR, actorName);
+        // Verb comes from the RECOMMENDATIONS write binding.
+        assertEquals("http://activitystrea.ms/recommend", stmt.get("verb").get("id").asText());
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/lti/PseudonymServiceTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/lti/PseudonymServiceTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PseudonymServiceTest {
+
+    @Test
+    void pseudonymiseProducesStableFixedLengthHex() {
+        PseudonymService svc = new PseudonymService(true, "salt");
+        String a = svc.pseudonymise("alice@example.edu");
+        String b = svc.pseudonymise("alice@example.edu");
+        assertEquals(a, b, "deterministic for same input");
+        assertEquals(PseudonymService.ID_LEN, a.length());
+        assertFalse(a.contains("alice"), "raw identifier must not leak");
+        assertNotNull(a);
+    }
+
+    @Test
+    void differentSaltsProduceDifferentPseudonyms() {
+        String s1 = new PseudonymService(true, "salt-a").pseudonymise("alice");
+        String s2 = new PseudonymService(true, "salt-b").pseudonymise("alice");
+        assertNotEquals(s1, s2);
+    }
+
+    @Test
+    void disabledModePassesThrough() {
+        PseudonymService svc = new PseudonymService(false, null);
+        assertEquals("alice", svc.pseudonymise("alice"));
+    }
+
+    @Test
+    void nullAndEmptyMapToNull() {
+        PseudonymService svc = new PseudonymService(true, "salt");
+        assertNull(svc.pseudonymise(null));
+        assertNull(svc.pseudonymise(""));
+    }
+
+    @Test
+    void fromConfigReadsSaltEnv() {
+        LtiBridgeConfig.PrivacyConfig p =
+                LtiBridgeConfig.PrivacyConfig.of(true, "NON_EXISTENT_SALT_VAR", true);
+        PseudonymService svc = PseudonymService.fromConfig(p);
+        assertTrue(svc.isEnabled());
+        // No env var bound — service still works, salt is empty string.
+        String pseudo = svc.pseudonymise("alice@example.edu");
+        assertEquals(PseudonymService.ID_LEN, pseudo.length());
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/lti/XapiStatementMapperTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/bridge/lti/XapiStatementMapperTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.bridge.lti;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.AffectObservationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.EngagementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.MasteryUpdateSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.tutoring.ResponseSignal;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class XapiStatementMapperTest {
+
+    private final ObjectMapper json = new ObjectMapper();
+
+    private XapiStatementMapper newMapper(boolean redact) {
+        return new XapiStatementMapper(
+                new PseudonymService(true, "test-salt"), redact);
+    }
+
+    @Test
+    void mapsAttemptedToResponseSignal() throws Exception {
+        XapiStatementMapper m = newMapper(false);
+        JsonNode stmt = json.readTree("""
+                {
+                  "actor": { "account": { "name": "alice@example.edu" } },
+                  "verb":  { "id": "http://adlnet.gov/expapi/verbs/attempted" },
+                  "object":{ "id": "item-42", "objectType": "Activity" },
+                  "result":{ "success": true, "duration": "PT12.34S",
+                             "response": "I think it is X" }
+                }
+                """);
+        ResponseSignal r = m.mapResponse(stmt);
+        assertNotNull(r);
+        assertEquals("item-42", r.getItemId());
+        assertTrue(r.isCorrect());
+        assertEquals(12340L, r.getLatencyMs());
+        // redactFreeText=false → response payload preserved
+        assertEquals("I think it is X", r.getResponsePayload());
+        assertFalse("alice@example.edu".equals(r.getName()),
+                "raw actor must not appear on emitted signal");
+    }
+
+    @Test
+    void responseFreeTextIsRedactedByDefault() throws Exception {
+        XapiStatementMapper m = newMapper(true);
+        JsonNode stmt = json.readTree("""
+                {
+                  "actor": { "mbox": "mailto:alice@example.edu" },
+                  "verb":  { "id": "http://adlnet.gov/expapi/verbs/answered" },
+                  "object":{ "id": "item-1" },
+                  "result":{ "success": false,
+                             "response": "secret answer text" }
+                }
+                """);
+        ResponseSignal r = m.mapResponse(stmt);
+        assertNotNull(r);
+        assertNull(r.getResponsePayload(), "response text must be redacted");
+        assertFalse(r.isCorrect());
+        assertEquals(1, m.drainRedactionCount());
+    }
+
+    @Test
+    void masteredVerbBecomesMasteryAtOne() throws Exception {
+        XapiStatementMapper m = newMapper(true);
+        JsonNode stmt = json.readTree("""
+                {
+                  "actor": { "openid": "https://op.example/u/alice" },
+                  "verb":  { "id": "http://adlnet.gov/expapi/verbs/mastered" },
+                  "object":{ "id": "competency-7" }
+                }
+                """);
+        MasteryUpdateSignal mu = m.mapMastery(stmt);
+        assertNotNull(mu);
+        assertEquals("competency-7", mu.getConceptId());
+        assertEquals(1.0, mu.getNewMasteryLevel(), 1e-9);
+    }
+
+    @Test
+    void scaledScoreOverridesVerbDefault() throws Exception {
+        XapiStatementMapper m = newMapper(true);
+        JsonNode stmt = json.readTree("""
+                {
+                  "actor": { "name": "alice" },
+                  "verb":  { "id": "http://adlnet.gov/expapi/verbs/failed" },
+                  "object":{ "id": "competency-7" },
+                  "result":{ "score": { "scaled": 0.4 } }
+                }
+                """);
+        MasteryUpdateSignal mu = m.mapMastery(stmt);
+        assertNotNull(mu);
+        assertEquals(0.4, mu.getNewMasteryLevel(), 1e-9);
+    }
+
+    @Test
+    void interactedBecomesEngagementWithDwell() throws Exception {
+        XapiStatementMapper m = newMapper(true);
+        JsonNode stmt = json.readTree("""
+                {
+                  "actor": { "name": "alice" },
+                  "verb":  { "id": "http://adlnet.gov/expapi/verbs/interacted" },
+                  "object":{ "id": "module-1" },
+                  "result":{ "duration": "PT5M" }
+                }
+                """);
+        EngagementSignal e = m.mapEngagement(stmt);
+        assertNotNull(e);
+        // verb prior 0.8 averaged with dwell 0.5 = 0.65
+        assertEquals(0.65, e.getAttentionScore(), 1e-6);
+    }
+
+    @Test
+    void affectExtensionBecomesAffectSignal() throws Exception {
+        XapiStatementMapper m = newMapper(true);
+        JsonNode stmt = json.readTree("""
+                {
+                  "actor": { "name": "alice" },
+                  "verb":  { "id": "http://adlnet.gov/expapi/verbs/experienced" },
+                  "object":{ "id": "module-1" },
+                  "context": { "extensions": {
+                      "https://jneopallium.rakov.org/xapi/extensions/affect": {
+                          "valence": 0.3, "arousal": 0.7, "confidence": 0.9
+                      }
+                  } }
+                }
+                """);
+        AffectObservationSignal a = m.mapAffect(stmt);
+        assertNotNull(a);
+        assertEquals(0.3, a.getValence(), 1e-9);
+        assertEquals(0.7, a.getArousal(), 1e-9);
+        assertEquals(0.9, a.getConfidence(), 1e-9);
+    }
+
+    @Test
+    void statementsHelperWalksBothShapes() throws Exception {
+        XapiStatementMapper m = newMapper(true);
+        JsonNode arr = json.readTree("""
+                [
+                  { "verb": { "id": "x" } },
+                  { "verb": { "id": "y" } }
+                ]
+                """);
+        JsonNode obj = json.readTree("""
+                { "statements": [
+                    { "verb": { "id": "x" } },
+                    { "verb": { "id": "y" } } ] }
+                """);
+        assertEquals(2, m.statements(arr).size());
+        assertEquals(2, m.statements(obj).size());
+    }
+
+    @Test
+    void unknownVerbReturnsNullForResponseMapper() throws Exception {
+        XapiStatementMapper m = newMapper(true);
+        JsonNode stmt = json.readTree("""
+                { "actor": { "name": "alice" },
+                  "verb":  { "id": "http://example.org/verbs/danced" },
+                  "object":{ "id": "item-1" } }
+                """);
+        assertNull(m.mapResponse(stmt),
+                "non-response verbs must not be mistakenly mapped to ResponseSignal");
+    }
+}


### PR DESCRIPTION
Adds the Bridge 14 LTI / xAPI adaptive-tutoring scaffolding under worker/bridge/lti with an ADVISORY ceiling: pulls statements from an LRS (or accepts pushed statements), maps them to ResponseSignal, MasteryUpdateSignal, EngagementSignal, and AffectObservationSignal, and posts xAPI 'recommended' / 'experienced' statements plus AGS Score proposals locked to gradingProgress=PendingManual. The loader rejects FullyGraded and AUTONOMOUS at config-load time; PseudonymService and XapiStatementMapper enforce actor pseudonymisation and free-text redaction by default. Tutoring egress signals now also implement IInputSignal / IResultSignal so they can flow through the framework's input adapters and IOutputAggregator save() path. Includes acceptance tests for §9 S7-S12 plus PUSH-mode and recommendation-actor invariants.