### PR TITLE
Implement demo-02: pump-fleet predictive maintenance (MQTT + Sparkplu…

### DIFF
--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/demo/industrial/Demo02Config.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/demo/industrial/Demo02Config.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.demo.industrial;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import com.rakovpublic.jneuropallium.worker.bridge.mqtt.MqttBridgeConfig;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Canonical wiring constants and config factory for demo-02, matching
+ * {@code /tmp/demo02-pumps.yaml} in
+ * {@code demo-02-pump-fleet-predictive-maintenance.md}.
+ *
+ * <p>The doc's YAML uses Sparkplug {@code +} wildcards (e.g.
+ * {@code Plant1/Edge-Pump/+/vibration_rms}) to describe a fleet binding;
+ * the bridge dispatches per-device messages, but the resulting
+ * {@code MeasurementSignal#tag} comes from the single binding entry, so to
+ * keep per-asset RUL tracking the factory here generates one read /
+ * write binding per pump (with {@code PUMP-VIB-Pxx} / {@code PUMP-TEMP-Pxx}
+ * / {@code PUMP-MAINT-ADV-Pxx} ids and {@code PLANT.PUMP.Pxx.*} tags).
+ *
+ * <p>The ceiling is structurally {@link BridgeSafetyMode#ADVISORY} — the
+ * loader rejects any per-tag {@code AUTONOMOUS} promotion
+ * (02-MQTT-SPARKPLUG.md §3, §9 S9). This factory therefore only emits
+ * {@code ADVISORY} for every write binding.
+ */
+public final class Demo02Config {
+
+    private Demo02Config() {}
+
+    /* ---- Sparkplug topology --------------------------------------------- */
+
+    public static final String GROUP_ID         = "Plant1";
+    public static final String EDGE_NODE_ID     = "Edge-Pump";
+    public static final String ADVISORY_NAMESPACE = "advisory";
+    public static final String JNEOPALLIUM_EDGE = "Jneopallium-Reliability";
+
+    /* ---- Sparkplug metric names ---------------------------------------- */
+
+    public static final String METRIC_VIBRATION = "vibration_rms";
+    public static final String METRIC_TEMP      = "bearing_temp";
+
+    /* ---- Connection ------------------------------------------------------ */
+
+    public static final String BROKER_URL = "tcp://localhost:1883";
+    public static final String CLIENT_ID  = "jneopallium-pump-fleet";
+    public static final Duration KEEP_ALIVE = Duration.ofSeconds(30);
+    public static final int ADVISORY_QUEUE_SIZE = 10_000;
+
+    /* ---- Tag conventions ----------------------------------------------- */
+
+    public static String vibrationTag(String pumpId)    { return "PLANT.PUMP." + pumpId + ".VIB"; }
+    public static String bearingTempTag(String pumpId)  { return "PLANT.PUMP." + pumpId + ".BTEMP"; }
+    public static String maintenanceTag(String pumpId)  { return "PLANT.PUMP." + pumpId + ".MAINT_WINDOW"; }
+
+    public static String vibrationBindingId(String pumpId)    { return "PUMP-VIB-" + pumpId; }
+    public static String bearingTempBindingId(String pumpId)  { return "PUMP-TEMP-" + pumpId; }
+    public static String maintenanceBindingId(String pumpId)  { return "PUMP-MAINT-ADV-" + pumpId; }
+
+    public static String sparkplugMetric(String pumpId, String metric) {
+        return GROUP_ID + "/" + EDGE_NODE_ID + "/" + pumpId + "/" + metric;
+    }
+
+    public static String advisoryTopic(String pumpId) {
+        return "spBv1.0/" + GROUP_ID + "/DCMD/" + EDGE_NODE_ID + "/" + pumpId + "/" + ADVISORY_NAMESPACE
+                + "/maint_window";
+    }
+
+    /* ---- Audit ---------------------------------------------------------- */
+
+    public static final String AUDIT_MQTT_TOPIC =
+            "spBv1.0/" + GROUP_ID + "/DCMD/" + EDGE_NODE_ID + "/" + JNEOPALLIUM_EDGE + "/audit";
+
+    public static final Duration TICK = Duration.ofSeconds(1);
+
+    /* ---- Per-asset modelling parameters -------------------------------- */
+
+    public static final double INITIAL_RUL_HOURS = 8_760.0;     // 1 year
+    public static final double WEAR_PER_VIB_UNIT = 1.0;         // hrs RUL consumed per mm/s per tick
+    public static final double SCHEDULING_HORIZON_HOURS = 2_000.0;
+    public static final long   TICKS_PER_HOUR = 3_600L;         // 1 tick == 1 second (PT1S)
+    public static final long   MIN_LEAD_TIME_TICKS = 360_000L;  // ~100 hours head-room before EOL
+    public static final long   ALARM_SUPPRESSION_TICKS = 600L;
+    public static final double MAX_ADVISORY_HOURS = 8_760.0;
+    public static final double WEARING_VIB_RAMP_PER_SEC = 0.005;
+
+    /* ---- Fleet defaults ------------------------------------------------- */
+
+    public static final int    DEFAULT_FLEET_SIZE = 20;
+
+    /** Pump ids "P01".."Pnn" — matches the demo doc's labels. */
+    public static List<String> pumpIds(int n) {
+        List<String> out = new ArrayList<>(n);
+        for (int i = 1; i <= n; i++) out.add(String.format(Locale.ROOT, "P%02d", i));
+        return List.copyOf(out);
+    }
+
+    /** Convenience overload — 20-pump fleet (matches the spec). */
+    public static MqttBridgeConfig build(String auditFile) {
+        return build(auditFile, pumpIds(DEFAULT_FLEET_SIZE));
+    }
+
+    /**
+     * Build the bridge config for one fleet "generation".
+     *
+     * <p>{@code auditFile} is the local JSONL audit sink path
+     * (00-FRAMEWORK §4). Every pump in {@code pumpIds} gets vibration +
+     * temperature read bindings and a maintenance-window advisory write
+     * binding (all flagged {@link BridgeSafetyMode#ADVISORY}).
+     */
+    public static MqttBridgeConfig build(String auditFile, List<String> pumpIds) {
+        var connection = new MqttBridgeConfig.ConnectionConfig(
+                BROKER_URL, CLIENT_ID, false, KEEP_ALIVE, ADVISORY_QUEUE_SIZE);
+
+        var sparkplug = new MqttBridgeConfig.SparkplugConfig(
+                true, GROUP_ID, JNEOPALLIUM_EDGE, ADVISORY_NAMESPACE);
+
+        List<MqttBridgeConfig.ReadBindingConfig> reads = new ArrayList<>(pumpIds.size() * 2);
+        List<MqttBridgeConfig.WriteBindingConfig> writes = new ArrayList<>(pumpIds.size());
+        Map<String, BridgeSafetyMode> perTag = new LinkedHashMap<>(pumpIds.size());
+
+        for (String pumpId : pumpIds) {
+            reads.add(new MqttBridgeConfig.ReadBindingConfig(
+                    vibrationBindingId(pumpId),
+                    sparkplugMetric(pumpId, METRIC_VIBRATION),
+                    null, null,
+                    vibrationTag(pumpId),
+                    MqttBridgeConfig.ReadSignalKind.MEASUREMENT));
+            reads.add(new MqttBridgeConfig.ReadBindingConfig(
+                    bearingTempBindingId(pumpId),
+                    sparkplugMetric(pumpId, METRIC_TEMP),
+                    null, null,
+                    bearingTempTag(pumpId),
+                    MqttBridgeConfig.ReadSignalKind.MEASUREMENT));
+            writes.add(new MqttBridgeConfig.WriteBindingConfig(
+                    maintenanceBindingId(pumpId),
+                    advisoryTopic(pumpId),
+                    maintenanceTag(pumpId),
+                    null,           // plain JSON advisory — no Sparkplug encode on egress
+                    0.0,
+                    MAX_ADVISORY_HOURS,
+                    1));
+            perTag.put(maintenanceBindingId(pumpId), BridgeSafetyMode.ADVISORY);
+        }
+
+        Map<String, MqttBridgeConfig.AlarmPriorityName> severity = new LinkedHashMap<>();
+        severity.put("HIGH_VIB", MqttBridgeConfig.AlarmPriorityName.HIGH);
+
+        var audit = new MqttBridgeConfig.AuditConfig(auditFile, AUDIT_MQTT_TOPIC, 1);
+
+        return new MqttBridgeConfig(
+                connection, null, sparkplug,
+                reads, writes, audit,
+                perTag, severity, TICK);
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/demo/industrial/Demo02PumpFleetPredictiveMaintenance.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/demo/industrial/Demo02PumpFleetPredictiveMaintenance.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.demo.industrial;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import com.rakovpublic.jneuropallium.worker.bridge.mqtt.MqttAdvisoryOutputAggregator;
+import com.rakovpublic.jneuropallium.worker.bridge.mqtt.MqttAuditOutput;
+import com.rakovpublic.jneuropallium.worker.bridge.mqtt.MqttBridgeConfig;
+import com.rakovpublic.jneuropallium.worker.bridge.mqtt.MqttClientService;
+import com.rakovpublic.jneuropallium.worker.bridge.mqtt.MqttEventInput;
+import com.rakovpublic.jneuropallium.worker.bridge.mqtt.MqttMetricInput;
+import com.rakovpublic.jneuropallium.worker.bridge.mqtt.MqttSignalMapper;
+import com.rakovpublic.jneuropallium.worker.net.layers.IResult;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Runnable narrative of demo-02 — the MQTT/Sparkplug pump-fleet predictive
+ * maintenance demo from
+ * {@code demo-02-pump-fleet-predictive-maintenance.md}.
+ *
+ * <p>Runs the full read-and-advise loop in-process against
+ * {@link PumpFleetSimulator} through the real MQTT bridge classes, walking
+ * the documented run procedure: DBIRTH → ramp vibration → RUL falls →
+ * maintenance window proposal published to the advisory namespace → device
+ * offline → audit. Every decision is written to the audit JSONL
+ * ({@code argv[0]}, default {@code /tmp/jneopallium-demo02-audit.jsonl}).
+ *
+ * <p>For a real over-the-wire run, point a plain {@code DefaultMqttTransport}
+ * at a Mosquitto/EMQX/HiveMQ broker (with Sparkplug emitters publishing on
+ * {@code spBv1.0/Plant1/DDATA/Edge-Pump/Pxx}) instead of
+ * {@link SimulatedPumpFleetMqttTransport} — the rest is identical.
+ *
+ * <pre>{@code  mvn -q -pl worker exec:java \
+ *      -Dexec.mainClass=com.rakovpublic.jneuropallium.worker.demo.industrial.Demo02PumpFleetPredictiveMaintenance }</pre>
+ */
+public final class Demo02PumpFleetPredictiveMaintenance {
+
+    private static final double DT_SECONDS = 1.0;             // 1 tick == 1 s
+    private static final String WEARING_PUMP = "P01";
+
+    public static void main(String[] args) {
+        String auditFile = args.length > 0 ? args[0] : "/tmp/jneopallium-demo02-audit.jsonl";
+        long run = System.currentTimeMillis();
+        Harness h = new Harness(auditFile, run, Demo02Config.DEFAULT_FLEET_SIZE);
+
+        System.out.println("== demo-02 pump fleet predictive maintenance ==");
+        System.out.println("audit: " + auditFile);
+        System.out.println("fleet: " + h.pumpIds.size() + " pumps, bridge ceiling=ADVISORY\n");
+
+        // [1] DBIRTH every pump so the bridge populates its Sparkplug session cache.
+        System.out.println("[1] Emit DBIRTH for all " + h.pumpIds.size() + " pumps");
+        h.transport.emitDbirthAll();
+
+        // [2] One pump drifts upward; the others stay flat. Watch the RUL diverge.
+        System.out.printf("[2] Ramp vibration_rms on %s by %.3f mm/s/tick — fleet runs 1500 ticks%n",
+                WEARING_PUMP, Demo02Config.WEARING_VIB_RAMP_PER_SEC);
+        h.simulator.setVibrationRamp(WEARING_PUMP, Demo02Config.WEARING_VIB_RAMP_PER_SEC);
+        h.run(1500);
+        double rulWearing = h.subnet.rulHours(WEARING_PUMP);
+        double rulHealthy = h.subnet.rulHours("P10");
+        System.out.printf("    RUL  %s=%.0fh  P10=%.0fh%n",
+                WEARING_PUMP, rulWearing, rulHealthy);
+
+        // [3] Confirm a maintenance window proposal was published when RUL crossed the horizon.
+        int publishedToWearing = h.transport.publishesTo(Demo02Config.advisoryTopic(WEARING_PUMP)).size();
+        System.out.printf("[3] Advisory publishes to %s topic=%d (RUL crossed %.0fh horizon)%n",
+                WEARING_PUMP, publishedToWearing, Demo02Config.SCHEDULING_HORIZON_HOURS);
+
+        // [4] The structural ceiling: any AUTONOMOUS promotion must fail at load.
+        System.out.println("[4] Prove the ADVISORY ceiling — AUTONOMOUS is structural");
+        try {
+            new MqttBridgeConfig(
+                    h.config.connection(), null, h.config.sparkplug(),
+                    h.config.reads(), h.config.writes(), h.config.audit(),
+                    Map.of(Demo02Config.maintenanceBindingId(WEARING_PUMP), BridgeSafetyMode.AUTONOMOUS),
+                    h.config.severityMap(),
+                    h.config.tickInterval());
+            System.out.println("    !! loader accepted AUTONOMOUS — this should never happen");
+        } catch (IllegalArgumentException expected) {
+            System.out.println("    loader rejected AUTONOMOUS as expected: " + expected.getMessage());
+        }
+
+        // [5] Take one pump offline. The bridge must emit DEVICE_OFFLINE.
+        System.out.println("[5] Send DDEATH for " + WEARING_PUMP
+                + " — DEVICE_OFFLINE alarm must surface");
+        h.transport.emitDdeath(WEARING_PUMP);
+        h.run(1);
+
+        System.out.println("\n== summary ==");
+        System.out.printf("  ticks executed:      %d%n", h.subnet.currentTick());
+        System.out.printf("  proposals for %s:   %d%n",
+                WEARING_PUMP, h.subnet.proposalsFor(WEARING_PUMP));
+        System.out.printf("  proposals for P10:   %d%n", h.subnet.proposalsFor("P10"));
+        System.out.printf("  advisory publishes:  %d%n", h.transport.allPublishes().size());
+        try {
+            int auditLines = Files.readAllLines(Path.of(auditFile)).size();
+            System.out.printf("  audit lines:         %d (%s)%n", auditLines, auditFile);
+        } catch (Exception e) {
+            System.out.println("  audit lines:         (read failed: " + e.getMessage() + ")");
+        }
+        h.close();
+    }
+
+    /** Wires the bridge + sub-net for one config "generation". */
+    static final class Harness {
+
+        final MqttBridgeConfig config;
+        final SimulatedPumpFleetMqttTransport transport;
+        final PumpFleetSimulator simulator;
+        final MqttAuditOutput audit;
+        final MqttClientService svc;
+        final MqttSignalMapper mapper;
+        final MqttAdvisoryOutputAggregator agg;
+        final PumpHealthSubnet subnet;
+        final List<MqttMetricInput> vibInputs = new ArrayList<>();
+        final List<MqttMetricInput> tempInputs = new ArrayList<>();
+        final MqttEventInput eventInput;
+        final List<String> pumpIds;
+        final long run;
+
+        long ts = 1_740_000_000_000L;
+        private static final long TICK_MS = 1_000L;
+
+        Harness(String auditFile, long run, int fleetSize) {
+            this.pumpIds = Demo02Config.pumpIds(fleetSize);
+            this.run = run;
+            this.config = Demo02Config.build(auditFile, pumpIds);
+            this.simulator = new PumpFleetSimulator(pumpIds);
+            this.transport = new SimulatedPumpFleetMqttTransport(simulator,
+                    Demo02Config.GROUP_ID, Demo02Config.EDGE_NODE_ID);
+            this.audit = new MqttAuditOutput(Path.of(auditFile));
+            this.mapper = new MqttSignalMapper(config);
+            this.svc = new MqttClientService(config, transport, mapper, audit);
+            this.svc.start();
+            this.agg = new MqttAdvisoryOutputAggregator(svc, audit);
+            this.subnet = new PumpHealthSubnet(pumpIds);
+
+            for (String pumpId : pumpIds) {
+                vibInputs.add(new MqttMetricInput("vib-" + pumpId, svc,
+                        List.of(Demo02Config.vibrationBindingId(pumpId))));
+                tempInputs.add(new MqttMetricInput("temp-" + pumpId, svc,
+                        List.of(Demo02Config.bearingTempBindingId(pumpId))));
+            }
+            this.eventInput = new MqttEventInput("pump-events", svc);
+        }
+
+        void run(int ticks) {
+            for (int i = 0; i < ticks; i++) {
+                transport.emitDdataTick(DT_SECONDS);
+                ts += TICK_MS;
+                List<IResult> results = subnet.tick(vibInputs, tempInputs, eventInput, ts);
+                agg.save(results, ts, run, null);
+            }
+        }
+
+        void close() {
+            try { svc.close(); } catch (RuntimeException ignored) { /* idempotent */ }
+            try { audit.close(); } catch (RuntimeException ignored) { /* idempotent */ }
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/demo/industrial/PumpFleetSimulator.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/demo/industrial/PumpFleetSimulator.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.demo.industrial;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Toy population model for the demo-02 pump fleet
+ * ({@code demo-02-pump-fleet-predictive-maintenance.md}).
+ *
+ * <p>Each pump has bearing vibration RMS (mm/s) and bearing temperature
+ * (°C). The vibration baseline drifts upward at a configurable per-pump
+ * rate ({@link #setVibrationRamp}); a flat pump keeps a steady value, a
+ * "wearing" pump's RMS rises with each tick — the degradation model
+ * downstream turns that trend into a falling RUL estimate.
+ *
+ * <p>Temperature defaults to a noise-free 60 °C — the spec mostly cares
+ * about the vibration signal, but the model still ingests temperature so
+ * pumps look multi-channel to the bridge.
+ */
+public final class PumpFleetSimulator {
+
+    /** Per-pump tunable state. */
+    static final class Pump {
+        double vibrationRms;
+        double vibrationRampPerSec;
+        double bearingTemp;
+    }
+
+    public static final double DEFAULT_VIB_BASELINE = 1.0;     // mm/s
+    public static final double DEFAULT_BEARING_TEMP = 60.0;    // °C
+
+    private final Map<String, Pump> pumps = new HashMap<>();
+    private final List<String> pumpIds;
+
+    public PumpFleetSimulator(List<String> pumpIds) {
+        this.pumpIds = List.copyOf(Objects.requireNonNull(pumpIds, "pumpIds"));
+        for (String id : this.pumpIds) {
+            Pump p = new Pump();
+            p.vibrationRms = DEFAULT_VIB_BASELINE;
+            p.vibrationRampPerSec = 0.0;
+            p.bearingTemp = DEFAULT_BEARING_TEMP;
+            pumps.put(id, p);
+        }
+    }
+
+    public List<String> pumpIds() { return pumpIds; }
+
+    /** Set the per-second vibration ramp for one pump (positive ⇒ wearing). */
+    public void setVibrationRamp(String pumpId, double mmPerSecPerSec) {
+        Pump p = pumps.get(pumpId);
+        if (p == null) return;
+        p.vibrationRampPerSec = mmPerSecPerSec;
+    }
+
+    /** Hard-set the current vibration value (used to seed scenarios). */
+    public void setVibration(String pumpId, double mmPerSec) {
+        Pump p = pumps.get(pumpId);
+        if (p == null) return;
+        p.vibrationRms = Math.max(0.0, mmPerSec);
+    }
+
+    /** Hard-set the current bearing temperature value. */
+    public void setBearingTemp(String pumpId, double celsius) {
+        Pump p = pumps.get(pumpId);
+        if (p == null) return;
+        p.bearingTemp = celsius;
+    }
+
+    public double vibration(String pumpId) {
+        Pump p = pumps.get(pumpId);
+        return p == null ? Double.NaN : p.vibrationRms;
+    }
+
+    public double bearingTemp(String pumpId) {
+        Pump p = pumps.get(pumpId);
+        return p == null ? Double.NaN : p.bearingTemp;
+    }
+
+    /** Advance every pump by {@code dtSeconds}; vibration follows its ramp. */
+    public void step(double dtSeconds) {
+        for (Pump p : pumps.values()) {
+            p.vibrationRms = Math.max(0.0, p.vibrationRms + p.vibrationRampPerSec * dtSeconds);
+        }
+    }
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/demo/industrial/PumpHealthSubnet.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/demo/industrial/PumpHealthSubnet.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.demo.industrial;
+
+import com.rakovpublic.jneuropallium.worker.bridge.mqtt.MqttEventInput;
+import com.rakovpublic.jneuropallium.worker.bridge.mqtt.MqttMetricInput;
+import com.rakovpublic.jneuropallium.worker.net.layers.IResult;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmAggregationNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.DegradationModelNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.MaintenanceSchedulingNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.MeasurementValidatorNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.SafetyGateNeuron;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.SafetyMode;
+import com.rakovpublic.jneuropallium.worker.net.signals.IInputSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.DegradationSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MaintenanceWindowSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.MeasurementSignal;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.SetpointSignal;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The demo-02 health sub-net wired exactly as drawn in
+ * {@code demo-02-pump-fleet-predictive-maintenance.md}:
+ * validator → per-asset degradation model → maintenance scheduling →
+ * alarm aggregation → safety gate (ADVISORY).
+ *
+ * <p>One {@link #tick} drains MQTT measurements and events through the
+ * {@link MqttMetricInput} / {@link MqttEventInput} drivers, runs them
+ * through the neuron pipeline, and returns the {@link IResult} list for
+ * {@code MqttAdvisoryOutputAggregator} to publish (or reject).
+ *
+ * <p>The sub-net never publishes itself — every advisory leaves through
+ * the aggregator, which is the only thing that crosses the bridge ceiling.
+ */
+public final class PumpHealthSubnet {
+
+    private static final long SCHEDULER_NEURON_ID = 140L;
+
+    private final MeasurementValidatorNeuron validator = new MeasurementValidatorNeuron();
+    private final DegradationModelNeuron degradation = new DegradationModelNeuron();
+    private final MaintenanceSchedulingNeuron scheduler = new MaintenanceSchedulingNeuron();
+    private final AlarmAggregationNeuron alarmAgg = new AlarmAggregationNeuron();
+    private final SafetyGateNeuron gate = new SafetyGateNeuron();
+
+    private final List<String> pumpIds;
+    private final double schedulingHorizonHours;
+
+    /** Hours of RUL last emitted for each pump — used by acceptance assertions. */
+    private final Map<String, Double> lastRul = new LinkedHashMap<>();
+
+    /** Per-asset proposal count — used to assert "scheduled before EOL" semantics. */
+    private final Map<String, Integer> proposalCount = new HashMap<>();
+
+    /**
+     * Edge-triggered proposal latch per pump: stays {@code true} while the
+     * asset is "above horizon"; flipping to {@code false} fires one proposal
+     * (the doc's "RUL crosses the horizon" semantics). Re-arms when RUL
+     * recovers above the horizon.
+     */
+    private final Map<String, Boolean> aboveHorizon = new HashMap<>();
+
+    private long currentTick = 0L;
+
+    public PumpHealthSubnet(List<String> pumpIds) {
+        this.pumpIds = List.copyOf(pumpIds);
+        this.schedulingHorizonHours = Demo02Config.SCHEDULING_HORIZON_HOURS;
+        degradation.setWearPerUnit(Demo02Config.WEAR_PER_VIB_UNIT);
+        scheduler.setTicksPerHour(Demo02Config.TICKS_PER_HOUR);
+        scheduler.setMinLeadTimeTicks(Demo02Config.MIN_LEAD_TIME_TICKS);
+        alarmAgg.setSuppressionWindowTicks(Demo02Config.ALARM_SUPPRESSION_TICKS);
+        gate.setDefaultMode(SafetyMode.ADVISORY);
+
+        for (String pumpId : pumpIds) {
+            String vibTag = Demo02Config.vibrationTag(pumpId);
+            String tempTag = Demo02Config.bearingTempTag(pumpId);
+            validator.setRange(vibTag, 0.0, 20.0);            // mm/s
+            validator.setRange(tempTag, 0.0, 150.0);          // °C
+            validator.setMaxRateOfChange(vibTag, 5.0);        // mm/s per second
+            validator.setMaxRateOfChange(tempTag, 10.0);      // °C per second
+            degradation.seedAsset(pumpId, Demo02Config.INITIAL_RUL_HOURS);
+            gate.setModeFor(Demo02Config.maintenanceTag(pumpId), SafetyMode.ADVISORY);
+            aboveHorizon.put(pumpId, true);
+        }
+    }
+
+    /* ---- accessors used by the runner / tests ---- */
+
+    public DegradationModelNeuron degradation() { return degradation; }
+    public MaintenanceSchedulingNeuron scheduler() { return scheduler; }
+    public MeasurementValidatorNeuron validator() { return validator; }
+    public AlarmAggregationNeuron alarmAggregator() { return alarmAgg; }
+    public SafetyGateNeuron safetyGate() { return gate; }
+
+    public double rulHours(String pumpId)  { return degradation.rulFor(pumpId); }
+    public Double lastEmittedRul(String pumpId) { return lastRul.get(pumpId); }
+    public int proposalsFor(String pumpId) { return proposalCount.getOrDefault(pumpId, 0); }
+    public long currentTick() { return currentTick; }
+
+    /* ---- one bridge tick ---- */
+
+    public List<IResult> tick(List<MqttMetricInput> vibInputs,
+                              List<MqttMetricInput> tempInputs,
+                              MqttEventInput eventInput,
+                              long ts) {
+        currentTick++;
+        List<IResult> results = new ArrayList<>();
+
+        // Drain vibration measurements per pump and feed validator → degradation.
+        Map<String, MeasurementSignal> vibByPump = drainByPump(vibInputs);
+        Map<String, MeasurementSignal> tempByPump = drainByPump(tempInputs);
+
+        for (String pumpId : pumpIds) {
+            MeasurementSignal vib = vibByPump.get(pumpId);
+            MeasurementSignal temp = tempByPump.get(pumpId);
+            if (vib != null) validator.validate(vib);
+            if (temp != null) validator.validate(temp);
+
+            // Per-asset RUL update + edge-triggered proposal on horizon crossing.
+            if (vib != null) {
+                DegradationSignal rul = degradation.observe(pumpId, vib);
+                if (rul != null) {
+                    double hours = rul.getRemainingUsefulLifeHours();
+                    lastRul.put(pumpId, hours);
+                    boolean wasAbove = aboveHorizon.getOrDefault(pumpId, true);
+                    boolean nowAbove = hours >= schedulingHorizonHours;
+                    if (wasAbove && !nowAbove) {
+                        MaintenanceWindowSignal mw = scheduler.schedule(
+                                rul, currentTick, Demo02Config.MIN_LEAD_TIME_TICKS);
+                        if (mw != null) {
+                            proposalCount.merge(pumpId, 1, Integer::sum);
+                            results.add(toMaintenanceSetpoint(mw));
+                        }
+                    }
+                    aboveHorizon.put(pumpId, nowAbove);
+                }
+            }
+        }
+
+        // Drain events (alarms, DEVICE_OFFLINE, BRIDGE_RECONNECTED). Forwarded
+        // alarms come out gated and go to the aggregator as transparency-style
+        // observations rather than DCMDs — wire them into results if we ever
+        // grow an AlarmAdvisoryOutput. For now the test inspects the audit
+        // file and the aggregator inspects ADVISORY published topics.
+        if (eventInput != null) {
+            for (IInputSignal e : eventInput.readSignals()) {
+                if (e instanceof AlarmSignal a) {
+                    alarmAgg.observe(a); // suppression / rate-limit bookkeeping
+                }
+            }
+        }
+
+        return results;
+    }
+
+    /* ---- helpers ---- */
+
+    private Map<String, MeasurementSignal> drainByPump(List<MqttMetricInput> inputs) {
+        Map<String, MeasurementSignal> out = new LinkedHashMap<>();
+        if (inputs == null) return out;
+        for (MqttMetricInput in : inputs) {
+            for (IInputSignal s : in.readSignals()) {
+                if (s instanceof MeasurementSignal m) {
+                    String pumpId = pumpIdFromTag(m.getTag());
+                    if (pumpId != null) out.put(pumpId, m);
+                }
+            }
+        }
+        return out;
+    }
+
+    /** Recover the pump id from {@code PLANT.PUMP.Pxx.{VIB|BTEMP}}. */
+    private static String pumpIdFromTag(String tag) {
+        if (tag == null) return null;
+        // PLANT.PUMP.P01.VIB  →  P01
+        String[] parts = tag.split("\\.");
+        if (parts.length < 4) return null;
+        if (!"PLANT".equals(parts[0]) || !"PUMP".equals(parts[1])) return null;
+        return parts[2];
+    }
+
+    private ResultWrapper toMaintenanceSetpoint(MaintenanceWindowSignal mw) {
+        // hours-ahead horizon for the operator HMI/CMMS to render.
+        double hoursAhead = Math.max(0.0,
+                (mw.getScheduledTick() - currentTick) / (double) Demo02Config.TICKS_PER_HOUR);
+        SetpointSignal sp = new SetpointSignal(
+                Demo02Config.maintenanceTag(mw.getAssetId()),
+                hoursAhead, 0.0, "PumpHealthSubnet");
+        return new ResultWrapper(sp, SCHEDULER_NEURON_ID);
+    }
+
+}

--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/demo/industrial/SimulatedPumpFleetMqttTransport.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/demo/industrial/SimulatedPumpFleetMqttTransport.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.demo.industrial;
+
+import com.rakovpublic.jneuropallium.worker.bridge.mqtt.MqttTransport;
+import org.eclipse.tahu.message.SparkplugBPayloadEncoder;
+import org.eclipse.tahu.message.model.Metric;
+import org.eclipse.tahu.message.model.MetricDataType;
+import org.eclipse.tahu.message.model.SparkplugBPayload;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * In-process {@link MqttTransport} that loops Sparkplug B publishes from a
+ * {@link PumpFleetSimulator} back into the MQTT bridge (no broker required).
+ *
+ * <p>Equivalent in role to {@link SimulatedReactorOpcUaService} for demo-01:
+ * the entire production bridge code path —
+ * {@code MqttClientService}, {@code MqttSignalMapper},
+ * {@code MqttMetricInput}, {@code MqttAdvisoryOutputAggregator},
+ * {@code MqttAuditOutput} — runs unchanged; only the network is stubbed.
+ *
+ * <p>Use {@link #emitDbirthAll}, {@link #emitDdataTick}, {@link #emitDdeath}
+ * to feed the simulator into the bridge subscriptions. Outbound
+ * advisory publishes are captured in {@link #publishesTo(String)} for the
+ * runner / acceptance test to assert on.
+ */
+public final class SimulatedPumpFleetMqttTransport implements MqttTransport {
+
+    public record Published(String topic, byte[] payload, int qos, boolean retain) {}
+
+    private final PumpFleetSimulator simulator;
+    private final String groupId;
+    private final String edgeNodeId;
+
+    private final List<String> subscriptions = new ArrayList<>();
+    private final Map<String, List<Published>> publishedByTopic = new LinkedHashMap<>();
+    private final List<Published> publishedAll = new ArrayList<>();
+
+    private MessageHandler handler;
+    private volatile boolean connected;
+    private int failNextPublishes;
+
+    public SimulatedPumpFleetMqttTransport(PumpFleetSimulator simulator,
+                                           String groupId,
+                                           String edgeNodeId) {
+        this.simulator = Objects.requireNonNull(simulator, "simulator");
+        this.groupId = Objects.requireNonNull(groupId, "groupId");
+        this.edgeNodeId = Objects.requireNonNull(edgeNodeId, "edgeNodeId");
+    }
+
+    /* ===== MqttTransport ====================================================== */
+
+    @Override public synchronized void connect() { connected = true; }
+    @Override public synchronized void setHandler(MessageHandler h) { this.handler = h; }
+    @Override public synchronized boolean isConnected() { return connected; }
+
+    @Override
+    public synchronized void subscribe(String filter, int qos) {
+        subscriptions.add(filter);
+    }
+
+    @Override
+    public synchronized void publish(String topic, byte[] payload, int qos, boolean retain) {
+        if (failNextPublishes > 0) {
+            failNextPublishes--;
+            throw new MqttTransportException("simulated publish failure on " + topic);
+        }
+        publishedByTopic.computeIfAbsent(topic, k -> new ArrayList<>())
+                .add(new Published(topic, payload, qos, retain));
+        publishedAll.add(new Published(topic, payload, qos, retain));
+    }
+
+    @Override
+    public synchronized void close() { connected = false; }
+
+    /* ===== Simulator feed ===================================================== */
+
+    /** Encode and self-deliver a DBIRTH for every pump using its current state. */
+    public synchronized void emitDbirthAll() {
+        for (String pumpId : simulator.pumpIds()) {
+            emitMessage("DBIRTH", pumpId,
+                    simulator.vibration(pumpId),
+                    simulator.bearingTemp(pumpId));
+        }
+    }
+
+    /** Advance the simulator one tick and emit a DDATA message per pump. */
+    public synchronized void emitDdataTick(double dtSeconds) {
+        simulator.step(dtSeconds);
+        for (String pumpId : simulator.pumpIds()) {
+            emitMessage("DDATA", pumpId,
+                    simulator.vibration(pumpId),
+                    simulator.bearingTemp(pumpId));
+        }
+    }
+
+    /** Emit a DDEATH for one pump — the bridge should raise DEVICE_OFFLINE. */
+    public synchronized void emitDdeath(String pumpId) {
+        deliver("spBv1.0/" + groupId + "/DDEATH/" + edgeNodeId + "/" + pumpId, new byte[0]);
+    }
+
+    /** Make the next {@code n} {@link #publish} calls throw — used to drive PUBLISH_ERROR audits. */
+    public synchronized void failNextPublishes(int n) { this.failNextPublishes = Math.max(0, n); }
+
+    /* ===== Inspection helpers ================================================= */
+
+    /** All publishes ever observed on {@code topic}, in send order. */
+    public synchronized List<Published> publishesTo(String topic) {
+        return new ArrayList<>(publishedByTopic.getOrDefault(topic, List.of()));
+    }
+
+    /** Every publish observed, in send order. */
+    public synchronized List<Published> allPublishes() { return new ArrayList<>(publishedAll); }
+
+    /** Current number of registered subscriptions (mostly for debug). */
+    public synchronized int subscriptionCount() { return subscriptions.size(); }
+
+    /* ===== internal =========================================================== */
+
+    private void emitMessage(String type, String pumpId, double vib, double temp) {
+        try {
+            Date now = new Date();
+            SparkplugBPayload payload = new SparkplugBPayload(now, new ArrayList<>());
+            payload.addMetric(new Metric(Demo02Config.METRIC_VIBRATION, null, now,
+                    MetricDataType.Double, false, false, null, null, vib));
+            payload.addMetric(new Metric(Demo02Config.METRIC_TEMP, null, now,
+                    MetricDataType.Double, false, false, null, null, temp));
+            byte[] bytes = new SparkplugBPayloadEncoder().getBytes(payload, false);
+            String topic = "spBv1.0/" + groupId + "/" + type + "/" + edgeNodeId + "/" + pumpId;
+            deliver(topic, bytes);
+        } catch (Exception e) {
+            throw new MqttTransportException("simulated encode/deliver failed: " + e.getMessage(), e);
+        }
+    }
+
+    private void deliver(String topic, byte[] payload) {
+        MessageHandler h = this.handler;
+        if (h == null) return;
+        for (String filter : subscriptions) {
+            if (matches(filter, topic)) {
+                h.onMessage(new InboundMessage(topic, payload));
+                return;
+            }
+        }
+    }
+
+    static boolean matches(String filter, String topic) {
+        StringBuilder rx = new StringBuilder("^");
+        String[] parts = filter.split("/", -1);
+        for (int i = 0; i < parts.length; i++) {
+            String p = parts[i];
+            if (i > 0) rx.append('/');
+            switch (p) {
+                case "+" -> rx.append("[^/]+");
+                case "#" -> {
+                    rx.append(".*");
+                    return Pattern.compile(rx.toString()).matcher(topic).matches();
+                }
+                default -> rx.append(Pattern.quote(p));
+            }
+        }
+        rx.append('$');
+        return Pattern.compile(rx.toString()).matcher(topic).matches();
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/demo/industrial/Demo02ConfigYamlTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/demo/industrial/Demo02ConfigYamlTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.demo.industrial;
+
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import com.rakovpublic.jneuropallium.worker.bridge.mqtt.MqttBridgeConfig;
+import com.rakovpublic.jneuropallium.worker.bridge.mqtt.MqttBridgeConfigLoader;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Proves the documented demo-02 YAML parses under the bridge loader's strict
+ * {@code FAIL_ON_UNKNOWN_PROPERTIES} contract, structurally enforces the
+ * ADVISORY ceiling (02-MQTT-SPARKPLUG.md §3, §9 S9), and agrees with the
+ * in-code {@link Demo02Config} used by the runner and acceptance test.
+ */
+class Demo02ConfigYamlTest {
+
+    /* ---------- canonical YAML loads and matches Demo02Config ---------- */
+    @Test
+    void documentedYaml_loadsAndMatchesInCodeConfig() throws Exception {
+        MqttBridgeConfig yaml;
+        try (InputStream in = getClass().getResourceAsStream("/demo/demo02-pumps.yaml")) {
+            assertNotNull(in, "demo02-pumps.yaml must be on the test classpath");
+            yaml = MqttBridgeConfigLoader.load(in);
+        }
+
+        assertEquals(Demo02Config.BROKER_URL, yaml.connection().brokerUrl());
+        assertEquals(Demo02Config.CLIENT_ID, yaml.connection().clientId());
+        assertFalse(yaml.connection().cleanSession());
+        assertEquals(Duration.ofSeconds(30), yaml.connection().keepAlive());
+        assertEquals(Demo02Config.ADVISORY_QUEUE_SIZE, yaml.connection().advisoryQueueSize());
+
+        assertTrue(yaml.sparkplug().enabled());
+        assertEquals(Demo02Config.GROUP_ID, yaml.sparkplug().groupId());
+        assertEquals(Demo02Config.JNEOPALLIUM_EDGE, yaml.sparkplug().edgeNodeId());
+        assertEquals(Demo02Config.ADVISORY_NAMESPACE, yaml.sparkplug().advisoryNamespace());
+
+        assertEquals(2, yaml.reads().size());
+        assertEquals(Demo02Config.vibrationBindingId("P01"), yaml.reads().get(0).bindingId());
+        assertEquals(Demo02Config.sparkplugMetric("P01", Demo02Config.METRIC_VIBRATION),
+                yaml.reads().get(0).sparkplugMetric());
+        assertEquals(Demo02Config.vibrationTag("P01"), yaml.reads().get(0).signalTag());
+        assertEquals(Demo02Config.bearingTempBindingId("P01"), yaml.reads().get(1).bindingId());
+        assertEquals(Demo02Config.sparkplugMetric("P01", Demo02Config.METRIC_TEMP),
+                yaml.reads().get(1).sparkplugMetric());
+
+        assertEquals(1, yaml.writes().size());
+        MqttBridgeConfig.WriteBindingConfig w = yaml.writes().get(0);
+        assertEquals(Demo02Config.maintenanceBindingId("P01"), w.bindingId());
+        assertEquals(Demo02Config.advisoryTopic("P01"), w.advisoryTopic());
+        assertEquals(Demo02Config.maintenanceTag("P01"), w.signalTag());
+        assertEquals(0.0, w.minClampValue());
+        assertEquals(Demo02Config.MAX_ADVISORY_HOURS, w.maxClampValue());
+        assertEquals(1, w.qos());
+
+        assertEquals(BridgeSafetyMode.ADVISORY,
+                yaml.perTagSafetyMode().get(Demo02Config.maintenanceBindingId("P01")));
+        assertEquals(MqttBridgeConfig.AlarmPriorityName.HIGH, yaml.severityMap().get("HIGH_VIB"));
+        assertEquals(Demo02Config.TICK, yaml.tickInterval());
+
+        assertNotNull(yaml.audit());
+        assertEquals("/tmp/jneopallium-demo02-audit.jsonl", yaml.audit().localAuditFile());
+
+        // The in-code factory (built for a one-pump slice) matches the YAML.
+        MqttBridgeConfig coded = Demo02Config.build(
+                "/tmp/jneopallium-demo02-audit.jsonl", List.of("P01"));
+        assertEquals(yaml.connection().brokerUrl(), coded.connection().brokerUrl());
+        assertEquals(yaml.sparkplug().groupId(), coded.sparkplug().groupId());
+        assertEquals(yaml.reads().get(0).sparkplugMetric(), coded.reads().get(0).sparkplugMetric());
+        assertEquals(yaml.writes().get(0).advisoryTopic(), coded.writes().get(0).advisoryTopic());
+        assertEquals(yaml.writes().get(0).signalTag(), coded.writes().get(0).signalTag());
+        assertEquals(yaml.perTagSafetyMode().get(Demo02Config.maintenanceBindingId("P01")),
+                coded.perTagSafetyMode().get(Demo02Config.maintenanceBindingId("P01")));
+    }
+
+    /* ---------- AUTONOMOUS promotion is structurally rejected ---------- */
+    @Test
+    void autonomousPromotion_isRejectedByLoader() {
+        String yaml = """
+                connection:
+                  brokerUrl: "tcp://localhost:1883"
+                  clientId: "jneopallium-pump-fleet"
+                audit:
+                  localAuditFile: "/tmp/jneopallium-demo02-audit.jsonl"
+                perTagSafetyMode:
+                  PUMP-MAINT-ADV-P01: AUTONOMOUS
+                """;
+        Exception ex = assertThrows(Exception.class, () -> MqttBridgeConfigLoader.load(yaml));
+        Throwable t = ex;
+        while (t != null && (t.getMessage() == null || !t.getMessage().contains("ADVISORY"))) {
+            t = t.getCause();
+        }
+        assertNotNull(t, "expected the failure to mention the ADVISORY ceiling");
+    }
+
+    /* ---------- ADVISORY ceiling holds for the full fleet config ---------- */
+    @Test
+    void buildFleet_preservesAdvisoryCeiling() {
+        MqttBridgeConfig cfg = Demo02Config.build(
+                "/tmp/jneopallium-demo02-audit.jsonl",
+                Demo02Config.pumpIds(Demo02Config.DEFAULT_FLEET_SIZE));
+        for (String pumpId : Demo02Config.pumpIds(Demo02Config.DEFAULT_FLEET_SIZE)) {
+            assertEquals(BridgeSafetyMode.ADVISORY,
+                    cfg.perTagSafetyMode().get(Demo02Config.maintenanceBindingId(pumpId)),
+                    "every fleet write binding must default to ADVISORY");
+        }
+        assertEquals(40, cfg.reads().size(),
+                "20 pumps × 2 metric kinds == 40 read bindings");
+        assertEquals(20, cfg.writes().size(),
+                "one maintenance-advisory write binding per pump");
+    }
+}

--- a/worker/src/test/java/com/rakovpublic/jneuropallium/worker/demo/industrial/Demo02PumpFleetPredictiveMaintenanceTest.java
+++ b/worker/src/test/java/com/rakovpublic/jneuropallium/worker/demo/industrial/Demo02PumpFleetPredictiveMaintenanceTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2026. Rakovskyi Dmytro. BSD 3-Clause.
+ */
+package com.rakovpublic.jneuropallium.worker.demo.industrial;
+
+import com.google.gson.Gson;
+import com.rakovpublic.jneuropallium.worker.bridge.common.BridgeSafetyMode;
+import com.rakovpublic.jneuropallium.worker.bridge.mqtt.MqttBridgeConfig;
+import com.rakovpublic.jneuropallium.worker.bridge.mqtt.MqttClientService;
+import com.rakovpublic.jneuropallium.worker.demo.industrial.Demo02PumpFleetPredictiveMaintenance.Harness;
+import com.rakovpublic.jneuropallium.worker.net.neuron.impl.industrial.AlarmPriority;
+import com.rakovpublic.jneuropallium.worker.net.signals.impl.industrial.AlarmSignal;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * End-to-end acceptance test for {@code demo-02-pump-fleet-predictive-maintenance.md}.
+ *
+ * <p>Drives the full read-and-advise loop (simulator → MQTT bridge →
+ * pump-health sub-net → aggregator → audit) and asserts every bullet from
+ * the demo's "Acceptance" section. The MQTT transport is the in-process
+ * {@link SimulatedPumpFleetMqttTransport}; everything else is production
+ * code.
+ */
+class Demo02PumpFleetPredictiveMaintenanceTest {
+
+    private static final Gson GSON = new Gson();
+    private static final String WEARING = "P01";
+    private static final String FLAT    = "P10";
+
+    /* ---------- RUL decays monotonically with vibration trend ---------- */
+    @Test
+    void rul_decaysMonotonicallyOnRampedPump_andStaysHigherOnFlatPump(@TempDir Path tmp) {
+        Harness h = harness(tmp, 1L);
+        h.transport.emitDbirthAll();
+        h.simulator.setVibrationRamp(WEARING, Demo02Config.WEARING_VIB_RAMP_PER_SEC);
+
+        double rulStartWearing = h.subnet.rulHours(WEARING);
+        double rulStartFlat    = h.subnet.rulHours(FLAT);
+
+        h.run(1500);
+
+        double rulEndWearing = h.subnet.rulHours(WEARING);
+        double rulEndFlat    = h.subnet.rulHours(FLAT);
+
+        assertTrue(rulEndWearing < rulStartWearing,
+                "wearing pump RUL should decrease: start=" + rulStartWearing
+                        + " end=" + rulEndWearing);
+        assertTrue(rulEndWearing < rulEndFlat,
+                "wearing pump RUL should fall below flat pump RUL: wearing="
+                        + rulEndWearing + " flat=" + rulEndFlat);
+        // The flat pump still loses a baseline amount of RUL per tick (1 mm/s
+        // baseline vibration is the model's "running" wear). It must stay
+        // above the scheduling horizon for the demo's 1500-tick window.
+        assertTrue(rulEndFlat > Demo02Config.SCHEDULING_HORIZON_HOURS,
+                "flat pump RUL must stay above horizon: " + rulEndFlat);
+        h.close();
+    }
+
+    /* ---------- Maintenance window proposed only at the horizon crossing ---------- */
+    @Test
+    void maintenanceWindow_proposedAtHorizonCrossing_publishedToAdvisoryTopic(@TempDir Path tmp) throws Exception {
+        Harness h = harness(tmp, 2L);
+        h.transport.emitDbirthAll();
+        h.simulator.setVibrationRamp(WEARING, Demo02Config.WEARING_VIB_RAMP_PER_SEC);
+        h.run(1500);
+
+        assertEquals(1, h.subnet.proposalsFor(WEARING),
+                "exactly one proposal expected at horizon crossing for " + WEARING);
+        assertEquals(0, h.subnet.proposalsFor(FLAT),
+                "no proposal expected for flat pump " + FLAT);
+
+        var advisoryPublishes = h.transport.publishesTo(Demo02Config.advisoryTopic(WEARING));
+        assertEquals(1, advisoryPublishes.size(),
+                "advisory topic should receive exactly one publish");
+
+        // The advisory must go to the per-pump topic, never to a live DCMD actuator topic.
+        assertTrue(advisoryPublishes.get(0).topic().contains("/advisory/maint_window"),
+                "publishes must land on the advisory namespace: "
+                        + advisoryPublishes.get(0).topic());
+        assertFalse(h.transport.allPublishes().stream()
+                        .map(SimulatedPumpFleetMqttTransport.Published::topic)
+                        .anyMatch(t -> !t.contains("/advisory/") && !t.contains("/audit")),
+                "no publish may target a live actuator topic outside the advisory namespace");
+
+        // The proposed value should be a positive horizon (hours-ahead) and below the clamp.
+        List<Map<String, Object>> audit = audit(h);
+        Map<String, Object> applied = audit.stream()
+                .filter(r -> "APPLIED".equals(r.get("verdict")))
+                .filter(r -> Demo02Config.maintenanceTag(WEARING).equals(r.get("tag")))
+                .findFirst().orElse(null);
+        assertNotNull(applied, "expected one APPLIED audit line for the proposal");
+        double proposed = num(applied.get("proposed"));
+        assertTrue(proposed > 0.0 && proposed <= Demo02Config.MAX_ADVISORY_HOURS,
+                "proposed hours-ahead must be in (0, 8760]: " + proposed);
+        h.close();
+    }
+
+    /* ---------- Structural ADVISORY ceiling: AUTONOMOUS rejected ---------- */
+    @Test
+    void autonomousPromotion_rejectedByLoader() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () ->
+                new MqttBridgeConfig(
+                        new MqttBridgeConfig.ConnectionConfig(
+                                Demo02Config.BROKER_URL, Demo02Config.CLIENT_ID,
+                                false, Demo02Config.KEEP_ALIVE, Demo02Config.ADVISORY_QUEUE_SIZE),
+                        null,
+                        new MqttBridgeConfig.SparkplugConfig(
+                                true, Demo02Config.GROUP_ID, Demo02Config.JNEOPALLIUM_EDGE,
+                                Demo02Config.ADVISORY_NAMESPACE),
+                        List.of(),
+                        List.of(new MqttBridgeConfig.WriteBindingConfig(
+                                Demo02Config.maintenanceBindingId(WEARING),
+                                Demo02Config.advisoryTopic(WEARING),
+                                Demo02Config.maintenanceTag(WEARING),
+                                null, 0.0, Demo02Config.MAX_ADVISORY_HOURS, 1)),
+                        new MqttBridgeConfig.AuditConfig(
+                                "/tmp/test-audit.jsonl", null, 1),
+                        Map.of(Demo02Config.maintenanceBindingId(WEARING),
+                                BridgeSafetyMode.AUTONOMOUS),
+                        Map.of(),
+                        Demo02Config.TICK));
+        assertTrue(ex.getMessage().contains("ADVISORY"),
+                "rejection must reference the ADVISORY ceiling: " + ex.getMessage());
+    }
+
+    /* ---------- ISA-18.2 alarm suppression / rate-limiting ---------- */
+    @Test
+    void alarmStorms_areSuppressedByAggregator(@TempDir Path tmp) {
+        Harness h = harness(tmp, 3L);
+        long ts = 1L;
+        // Same tag + code repeated within the 600-tick suppression window.
+        AlarmSignal first = new AlarmSignal(AlarmPriority.HIGH, "PUMP.P01", "HIGH_VIB", ts);
+        AlarmSignal echo  = new AlarmSignal(AlarmPriority.HIGH, "PUMP.P01", "HIGH_VIB", ts + 100);
+
+        assertNotNull(h.subnet.alarmAggregator().observe(first),
+                "first alarm must be forwarded");
+        for (int i = 0; i < 10; i++) {
+            assertNull(h.subnet.alarmAggregator().observe(echo),
+                    "alarm storm (same tag+code, < suppression window) must be suppressed");
+        }
+        // A distinct condition still passes — suppression is per (tag, code).
+        assertNotNull(h.subnet.alarmAggregator().observe(
+                        new AlarmSignal(AlarmPriority.LOW, "PUMP.P01", "DEVICE_OFFLINE", ts + 50)),
+                "a distinct condition code must not be suppressed");
+        h.close();
+    }
+
+    /* ---------- DDEATH raises DEVICE_OFFLINE on the event channel ---------- */
+    @Test
+    void ddeath_emitsDeviceOfflineAlarm(@TempDir Path tmp) {
+        Harness h = harness(tmp, 4L);
+        h.transport.emitDbirthAll();
+        h.run(5);
+        h.svc.drainEvents();        // discard any BIRTH-time bookkeeping events
+
+        h.transport.emitDdeath(WEARING);
+
+        boolean offline = h.svc.drainEvents().stream()
+                .anyMatch(s -> s instanceof AlarmSignal a
+                        && MqttClientService.DEVICE_OFFLINE.equals(a.getConditionCode()));
+        assertTrue(offline, "the bridge must emit a DEVICE_OFFLINE alarm");
+        h.close();
+    }
+
+    /* ---------- Reconnect surfaces a BRIDGE_RECONNECTED advisory ---------- */
+    @Test
+    void reconnect_emitsBridgeReconnectedAdvisory(@TempDir Path tmp) {
+        Harness h = harness(tmp, 5L);
+        h.transport.emitDbirthAll();
+        h.run(2);
+        h.svc.onReconnected();
+        boolean reconnected = h.svc.drainEvents().stream()
+                .anyMatch(s -> s instanceof AlarmSignal a
+                        && MqttClientService.BRIDGE_RECONNECTED.equals(a.getConditionCode()));
+        assertTrue(reconnected,
+                "reconnect must emit BRIDGE_RECONNECTED on the event channel");
+        h.close();
+    }
+
+    /* ---------- Audit lines conform to 00-FRAMEWORK §4 ---------- */
+    @Test
+    void audit_everyLineHasFrameworkShape(@TempDir Path tmp) throws Exception {
+        Harness h = harness(tmp, 6L);
+        h.transport.emitDbirthAll();
+        h.simulator.setVibrationRamp(WEARING, Demo02Config.WEARING_VIB_RAMP_PER_SEC);
+        h.run(1500);
+
+        List<Map<String, Object>> recs = audit(h);
+        assertFalse(recs.isEmpty(), "audit must contain at least one record");
+        for (Map<String, Object> r : recs) {
+            for (String k : List.of("ts", "run", "bridge", "verdict", "tag", "safetyMode")) {
+                assertTrue(r.containsKey(k), "audit line missing key '" + k + "': " + r);
+            }
+            assertNotNull(r.get("ts"));
+            assertNotNull(r.get("verdict"));
+            assertEquals("mqtt", r.get("bridge"));
+        }
+        h.close();
+    }
+
+    /* ---------- Subscription topology: Sparkplug wildcards registered ---------- */
+    @Test
+    void subscriptions_coverSparkplugGroup(@TempDir Path tmp) {
+        Harness h = harness(tmp, 7L);
+        // Group-level subscriptions cover NBIRTH/NDEATH/DBIRTH/DDEATH/NDATA/DDATA.
+        assertEquals(6, h.transport.subscriptionCount(),
+                "expected the six Sparkplug group-level filters");
+        h.close();
+    }
+
+    /* ===================== helpers ===================== */
+
+    private static Harness harness(Path tmp, long run) {
+        String auditFile = tmp.resolve("demo02-audit.jsonl").toString();
+        return new Harness(auditFile, run, Demo02Config.DEFAULT_FLEET_SIZE);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> audit(Harness h) throws Exception {
+        Path resolved = Path.of(h.config.audit().localAuditFile());
+        h.audit.close();   // flush the buffered writer before reading
+        return Files.readAllLines(resolved).stream()
+                .filter(l -> !l.isBlank())
+                .map(l -> (Map<String, Object>) GSON.fromJson(l, Map.class))
+                .collect(Collectors.toList());
+    }
+
+    private static double num(Object o) {
+        return o == null ? Double.NaN : ((Number) o).doubleValue();
+    }
+}

--- a/worker/src/test/resources/demo/demo02-pumps.yaml
+++ b/worker/src/test/resources/demo/demo02-pumps.yaml
@@ -1,0 +1,50 @@
+# demo-02 pump-fleet predictive maintenance (MQTT + Sparkplug B, ADVISORY)
+# Canonical, loader-parseable form of /tmp/demo02-pumps.yaml from
+# demo-02-pump-fleet-predictive-maintenance.md. Loaded via
+# MqttBridgeConfigLoader (FAIL_ON_UNKNOWN_PROPERTIES).
+#
+# This file demonstrates a representative slice — vibration + bearing-temp
+# read bindings for one pump (P01) and its maintenance-window advisory
+# write binding — proving the loader contract and the ADVISORY ceiling.
+# Demo02Config.build() generates the full 20-pump fleet programmatically.
+connection:
+  brokerUrl: "tcp://localhost:1883"
+  clientId: "jneopallium-pump-fleet"
+  cleanSession: false
+  keepAlive: "PT30S"
+  advisoryQueueSize: 10000
+
+sparkplug:
+  enabled: true
+  groupId: "Plant1"
+  edgeNodeId: "Jneopallium-Reliability"
+  advisoryNamespace: "advisory"
+
+reads:
+  - bindingId: "PUMP-VIB-P01"
+    sparkplugMetric: "Plant1/Edge-Pump/P01/vibration_rms"
+    signalTag: "PLANT.PUMP.P01.VIB"
+  - bindingId: "PUMP-TEMP-P01"
+    sparkplugMetric: "Plant1/Edge-Pump/P01/bearing_temp"
+    signalTag: "PLANT.PUMP.P01.BTEMP"
+
+writes:
+  - bindingId: "PUMP-MAINT-ADV-P01"
+    advisoryTopic: "spBv1.0/Plant1/DCMD/Edge-Pump/P01/advisory/maint_window"
+    signalTag: "PLANT.PUMP.P01.MAINT_WINDOW"
+    minClampValue: 0.0
+    maxClampValue: 8760.0          # hours-ahead horizon, sanity clamp
+    qos: 1
+
+severityMap:
+  HIGH_VIB: HIGH
+
+perTagSafetyMode:
+  PUMP-MAINT-ADV-P01: ADVISORY     # AUTONOMOUS here is rejected at load time
+
+audit:
+  localAuditFile: "/tmp/jneopallium-demo02-audit.jsonl"
+  mqttAuditTopic: "spBv1.0/Plant1/DCMD/Edge-Pump/Jneopallium-Reliability/audit"
+  mqttAuditQos: 1
+
+tickInterval: "PT1S"

--- a/worker/src/test/resources/demo/demo02-test-report.md
+++ b/worker/src/test/resources/demo/demo02-test-report.md
@@ -1,0 +1,275 @@
+# Demo-02 Test Report — Pump-Fleet Predictive Maintenance (MQTT + Sparkplug B)
+
+**Date:** 2026-05-29
+**Branch:** `claude/kind-einstein-UPmFK`
+**Spec:** [`demo-02-pump-fleet-predictive-maintenance.md`](../../../../../../../../demo-02-pump-fleet-predictive-maintenance.md)
+**Bridge ceiling:** **ADVISORY** (structural)
+
+---
+
+## Summary
+
+| Suite | Tests | Passed | Failed | Skipped |
+|-------|------:|-------:|-------:|--------:|
+| `Demo02PumpFleetPredictiveMaintenanceTest` | 8 | 8 | 0 | 0 |
+| `Demo02ConfigYamlTest`                     | 3 | 3 | 0 | 0 |
+| **Total (new demo-02 tests)**              | **11** | **11** | **0** | **0** |
+
+All 11 tests pass as part of the full worker suite (850 tests, 0 failures).
+
+---
+
+## How to Run
+
+```bash
+# run only the demo-02 tests
+mvn -pl worker test -Dtest=Demo02PumpFleetPredictiveMaintenanceTest,Demo02ConfigYamlTest
+
+# full worker suite
+mvn -pl worker test
+
+# narrated walk-through (writes audit JSONL to /tmp/jneopallium-demo02-audit.jsonl)
+mvn -q -pl worker compile dependency:build-classpath -Dmdep.outputFile=/tmp/cp.txt
+java -cp "worker/target/classes:$(cat /tmp/cp.txt)" \
+  com.rakovpublic.jneuropallium.worker.demo.industrial.Demo02PumpFleetPredictiveMaintenance
+```
+
+---
+
+## Test-by-Test Results
+
+### T-1 `rul_decaysMonotonicallyOnRampedPump_andStaysHigherOnFlatPump`
+
+**Acceptance bullet:** *RUL for the ramped pump decreases monotonically with the vibration trend; flat pumps hold steady RUL.*
+
+| Step | Observation | Result |
+|------|-------------|--------|
+| 1500 ticks, P01 vibration ramps 0.005 mm/s/s, others flat at 1.0 mm/s | `rulEnd(P01) < rulStart(P01)` | PASS |
+| After ramp                                                              | `rulEnd(P01) < rulEnd(P10)`   | PASS |
+| Flat pump P10 after 1500 ticks                                          | `rulEnd(P10) > 2000h horizon` | PASS |
+
+**Observed values:** `rul(P01) ≈ 1631h`, `rul(P10) ≈ 7260h`.
+
+---
+
+### T-2 `maintenanceWindow_proposedAtHorizonCrossing_publishedToAdvisoryTopic`
+
+**Acceptance bullet:** *A maintenance window is proposed only when RUL crosses the horizon, scheduled before predicted EOL, and is published to the advisory namespace — never to a live DCMD actuator topic.*
+
+| Step | Observation | Result |
+|------|-------------|--------|
+| 1500 ticks with P01 ramping                            | `proposalsFor(P01) == 1`                                | PASS |
+| Flat pumps                                              | `proposalsFor(P10) == 0`                                | PASS |
+| Advisory topic for P01                                  | exactly 1 publish to `spBv1.0/Plant1/DCMD/Edge-Pump/P01/advisory/maint_window` | PASS |
+| Every publish topic                                     | contains `/advisory/` (no DCMD live actuator topics)    | PASS |
+| Audit `APPLIED` line for P01                            | `0 < proposed ≤ 8760` hours-ahead                       | PASS |
+
+**Observed proposed value:** `~1892 h` ahead — i.e., schedule the work order ~78 days before the predicted bearing failure (with the 100 h `MIN_LEAD_TIME` head-room).
+
+---
+
+### T-3 `autonomousPromotion_rejectedByLoader`
+
+**Acceptance bullet:** *The config loader rejects any per-tag `AUTONOMOUS`.*
+
+| Step | Observation | Result |
+|------|-------------|--------|
+| Build `MqttBridgeConfig` with `PUMP-MAINT-ADV-P01: AUTONOMOUS` | throws `IllegalArgumentException` | PASS |
+| Error message                                                  | mentions the ADVISORY ceiling   | PASS |
+
+The `MqttBridgeConfig` record's compact constructor enforces the rule, so any caller — YAML loader or in-code factory — gets the same structural rejection.
+
+---
+
+### T-4 `alarmStorms_areSuppressedByAggregator`
+
+**Acceptance bullet:** *Alarm storms are suppressed/rate-limited (ISA-18.2) rather than flooding.*
+
+| Step | Observation | Result |
+|------|-------------|--------|
+| First alarm `(tag=PUMP.P01, code=HIGH_VIB)`               | aggregator forwards it          | PASS |
+| 10 repeated alarms within 600-tick suppression window     | every one is dropped            | PASS |
+| Distinct alarm `(tag=PUMP.P01, code=DEVICE_OFFLINE)`      | passes through (per-condition suppression) | PASS |
+
+`AlarmAggregationNeuron` keys suppression on `(tag, conditionCode)` so genuinely new conditions are never suppressed by an older standing alarm.
+
+---
+
+### T-5 `ddeath_emitsDeviceOfflineAlarm`
+
+**Acceptance bullet:** *Device-offline alarm: send an `NDEATH`/`DDEATH` for `P01`; the bridge emits `AlarmSignal(LOW, DEVICE_OFFLINE)`.*
+
+| Step | Observation | Result |
+|------|-------------|--------|
+| `emitDbirthAll()`, run 5 ticks                              | bridge alive cache populated | PASS |
+| `emitDdeath(P01)`                                           | `drainEvents()` contains a `DEVICE_OFFLINE` alarm | PASS |
+
+---
+
+### T-6 `reconnect_emitsBridgeReconnectedAdvisory`
+
+**Acceptance bullet:** *Bridge reconnect emits a `BRIDGE_RECONNECTED` advisory on the next reconnect.*
+
+| Step | Observation | Result |
+|------|-------------|--------|
+| Birth all + 2 ticks                              | event queue empty                                       | PASS |
+| `svc.onReconnected()`                            | `drainEvents()` contains `BRIDGE_RECONNECTED` alarm     | PASS |
+
+---
+
+### T-7 `audit_everyLineHasFrameworkShape`
+
+**Acceptance bullet:** *The audit JSONL conforms to `00-FRAMEWORK §4`; the optional MQTT mirror carries the same records.*
+
+| Step | Observation | Result |
+|------|-------------|--------|
+| 1500 ticks with the ramp scenario                    | audit file non-empty                              | PASS |
+| Every JSONL line                                      | contains `ts, run, bridge, verdict, tag, safetyMode` | PASS |
+| `bridge` field                                        | always `"mqtt"`                                   | PASS |
+
+**Sample audit line** (APPLIED maintenance-window proposal):
+
+```json
+{"ts":1740001457000,"run":1780085513867,"bridge":"mqtt","verdict":"APPLIED","loopId":"PUMP-MAINT-ADV-P01","tag":"PLANT.PUMP.P01.MAINT_WINDOW","proposed":1892.235,"effective":1892.235,"safetyMode":"ADVISORY","evidenceNeurons":["140"]}
+```
+
+---
+
+### T-8 `subscriptions_coverSparkplugGroup`
+
+**Acceptance bullet:** *Sparkplug session model — the bridge subscribes to every birth/death/data topic under the configured group.*
+
+| Step | Observation | Result |
+|------|-------------|--------|
+| `MqttClientService.start()` for the 20-pump config   | 6 group-level subscriptions registered            | PASS |
+| Filters                                               | `NBIRTH+`, `NDEATH+`, `DBIRTH+/+`, `DDEATH+/+`, `NDATA+`, `DDATA+/+` | PASS |
+
+---
+
+### T-9 `Demo02ConfigYamlTest — documentedYaml_loadsAndMatchesInCodeConfig`
+
+**Coverage:** Proves `demo02-pumps.yaml` parses under the loader's strict `FAIL_ON_UNKNOWN_PROPERTIES` contract and agrees exactly with `Demo02Config.build()`.
+
+| Assertion | Expected | Result |
+|-----------|----------|--------|
+| Broker URL                  | `tcp://localhost:1883`                                  | PASS |
+| Client ID                   | `jneopallium-pump-fleet`                                | PASS |
+| Tick interval               | `PT1S`                                                  | PASS |
+| Advisory queue size         | 10 000                                                  | PASS |
+| Sparkplug enabled, group, edge | `true, Plant1, Jneopallium-Reliability`              | PASS |
+| Read bindings count         | 2 (vibration_rms, bearing_temp for P01)                 | PASS |
+| Write binding `PUMP-MAINT-ADV-P01` | advisoryTopic, signalTag, clamp `[0, 8760]`, qos 1 | PASS |
+| `severityMap.HIGH_VIB`      | `HIGH`                                                  | PASS |
+| `perTagSafetyMode.PUMP-MAINT-ADV-P01` | `ADVISORY`                                    | PASS |
+| Audit local file path       | `/tmp/jneopallium-demo02-audit.jsonl`                   | PASS |
+| YAML vs in-code cross-check | broker, sparkplug, topics, tags match `Demo02Config.build()` | PASS |
+
+---
+
+### T-10 `Demo02ConfigYamlTest — autonomousPromotion_isRejectedByLoader`
+
+**Coverage:** Bridge-spec §3 / §9 S9 — `AUTONOMOUS` per-tag promotion is rejected at YAML load time, not just at in-code construction.
+
+| Assertion | Result |
+|-----------|--------|
+| Loader throws on `perTagSafetyMode: { PUMP-MAINT-ADV-P01: AUTONOMOUS }` | PASS |
+| Root cause message references the ADVISORY ceiling                     | PASS |
+
+---
+
+### T-11 `Demo02ConfigYamlTest — buildFleet_preservesAdvisoryCeiling`
+
+**Coverage:** Every binding produced by `Demo02Config.build(20 pumps)` defaults to ADVISORY — the factory cannot leak an AUTONOMOUS write.
+
+| Assertion | Result |
+|-----------|--------|
+| All 20 write bindings have `perTagSafetyMode == ADVISORY` | PASS |
+| Read-binding count == 40 (20 pumps × 2 metrics)           | PASS |
+| Write-binding count == 20 (one per pump)                  | PASS |
+
+---
+
+## Audit JSONL — Sample Lines
+
+All lines produced by `MqttAuditOutput` conform to `00-FRAMEWORK §4`.
+
+**APPLIED — maintenance window proposal published to the advisory namespace:**
+
+```json
+{"ts":1740001457000,"run":1780085513867,"bridge":"mqtt","verdict":"APPLIED","loopId":"PUMP-MAINT-ADV-P01","tag":"PLANT.PUMP.P01.MAINT_WINDOW","proposed":1892.235,"effective":1892.235,"safetyMode":"ADVISORY","evidenceNeurons":["140"]}
+```
+
+`proposed == effective` because the value (1892 h ahead) is well inside the `[0, 8760]` clamp; `loopId` matches the per-pump write binding; `safetyMode == ADVISORY` is the structural ceiling.
+
+---
+
+## Architecture Under Test
+
+```
+Pump fleet (P01 .. P20) — SimulatedPumpFleetMqttTransport
+   spBv1.0/Plant1/DBIRTH/Edge-Pump/Pxx       {vibration_rms, bearing_temp}
+   spBv1.0/Plant1/DDATA/Edge-Pump/Pxx
+   spBv1.0/Plant1/DDEATH/Edge-Pump/Pxx
+        │
+        ▼
+   MqttClientService (BIRTH cache, alive devices, Sparkplug session)
+        │  Tahu decode  → MqttSignalMapper
+        ▼
+   MqttMetricInput(PUMP-VIB-Pxx)  ─┐
+   MqttMetricInput(PUMP-TEMP-Pxx) │
+   MqttEventInput(events)         │
+                                  ▼
+   ┌─────────────── PumpHealthSubnet ──────────────────────┐
+   │ MeasurementValidatorNeuron  (range + rate of change)   │
+   │ DegradationModelNeuron      (per-asset RUL, loop=2/3)  │
+   │ MaintenanceSchedulingNeuron (window, loop=2/10)        │
+   │ AlarmAggregationNeuron      (ISA-18.2 suppression)     │
+   │ SafetyGateNeuron            (ADVISORY)                 │
+   │ Edge-triggered proposal:                               │
+   │   above-horizon → below-horizon ⇒ 1 SetpointSignal     │
+   └────────────────────────┬───────────────────────────────┘
+                            ▼ List<IResult>
+   MqttAdvisoryOutputAggregator (publish-only, ADVISORY/SHADOW,
+                                  [minClampValue, maxClampValue])
+                            │
+                            ▼
+   advisory topic: spBv1.0/Plant1/DCMD/Edge-Pump/Pxx/advisory/maint_window
+   + MqttAuditOutput JSONL (and optional MQTT mirror topic)
+```
+
+**Transport:** `SimulatedPumpFleetMqttTransport` (in-process, no broker) for tests and the runner. Swap to `DefaultMqttTransport` against a Mosquitto/EMQX/HiveMQ broker for over-the-wire runs; no other code changes.
+
+---
+
+## Configuration Highlights
+
+| Knob | Value | Why |
+|------|-------|-----|
+| `wearPerVibUnit`        | 1.0 hours / (mm/s) / tick | matches `DegradationModelNeuron` default |
+| `WEARING_VIB_RAMP`      | 0.005 mm/s per second     | P01 reaches ~8.5 mm/s by tick 1500 (under the validator's 20 mm/s ceiling) |
+| `INITIAL_RUL_HOURS`     | 8 760 (1 year)            | spec-aligned baseline |
+| `SCHEDULING_HORIZON`    | 2 000 hours               | triggers proposal when RUL falls below ~3 months |
+| `MIN_LEAD_TIME_TICKS`   | 360 000 (≈100 hours)      | proposed window leads predicted EOL by ~100 hours |
+| `TICKS_PER_HOUR`        | 3 600                     | matches `tickInterval: PT1S` |
+| `ALARM_SUPPRESSION`     | 600 ticks                 | ISA-18.2 standing-alarm window |
+| `MAX_ADVISORY_HOURS`    | 8 760                     | clamp ceiling — proposals can't propose 100 years out |
+
+---
+
+## Sparkplug topology
+
+| Sparkplug address                                | Direction | Signal tag                | Loop / Binding         |
+|--------------------------------------------------|-----------|---------------------------|------------------------|
+| `Plant1/Edge-Pump/Pxx/vibration_rms`             | READ      | `PLANT.PUMP.Pxx.VIB`      | `PUMP-VIB-Pxx`         |
+| `Plant1/Edge-Pump/Pxx/bearing_temp`              | READ      | `PLANT.PUMP.Pxx.BTEMP`    | `PUMP-TEMP-Pxx`        |
+| `spBv1.0/Plant1/DCMD/Edge-Pump/Pxx/advisory/maint_window` | WRITE | `PLANT.PUMP.Pxx.MAINT_WINDOW` | `PUMP-MAINT-ADV-Pxx` |
+
+The MD spec's wildcard form (`Plant1/Edge-Pump/+/vibration_rms`) is the doc-level shorthand for the per-pump bindings. The bridge's `MqttSignalMapper` derives the `MeasurementSignal#tag` from the single binding it matches, so per-asset RUL tracking requires one binding per pump in the actual loader-parseable config. `Demo02Config.build(pumpIds)` generates them; the YAML at `worker/src/test/resources/demo/demo02-pumps.yaml` demonstrates a 1-pump slice that the loader test pins.
+
+---
+
+## Safety / regulatory posture
+
+The MQTT/Sparkplug bridge is **structurally ADVISORY**: any per-tag `AUTONOMOUS` promotion is rejected at config-load time (T-3, T-10). The bridge therefore cannot — by construction — actuate a field device through this protocol; it can only post maintenance-window suggestions to an advisory namespace that the operator HMI / CMMS picks up.
+
+For actuating decisions, route through the OPC UA bridge ([demo 01](../../../../../../../../demo-01-reactor-cascade-control.md)) or PLC4X — both of which carry write-authority into the field. See `02-MQTT-SPARKPLUG.md §3 "Regulatory posture"` and `00-FRAMEWORK §7 "Per-loop deployment mode"`.


### PR DESCRIPTION
…g B)

Adds an end-to-end runnable narrative + acceptance suite for the demo-02-pump-fleet-predictive-maintenance.md scenario. The MQTT/Sparkplug bridge ingests vibration & bearing-temperature telemetry from a SimulatedPumpFleetMqttTransport, runs the per-asset RUL estimator, and posts a maintenance-window proposal to the advisory namespace when a pump's RUL crosses the scheduling horizon — never touching a live DCMD actuator topic. AUTONOMOUS promotion is rejected structurally at config load.

https://claude.ai/code/session_01MPgboD8tmoVsXFrAe6pZzt