### PR TITLE
Potential fix for code scanning alert no. 22: Uncontrolled data used in path expression

### DIFF
--- a/worker/src/main/java/com/rakovpublic/jneuropallium/worker/demo/fullrun/runtime/DemoFileStorage.java
+++ b/worker/src/main/java/com/rakovpublic/jneuropallium/worker/demo/fullrun/runtime/DemoFileStorage.java
@@ -26,19 +26,31 @@ public class DemoFileStorage implements IStorage<DemoStorageItem> {
         this.rootPath = rootPath == null || rootPath.isBlank() ? "." : rootPath;
     }
 
+    private Path getNormalizedRootPath() {
+        return Path.of(rootPath).toAbsolutePath().normalize();
+    }
+
+    private Path resolveAndValidatePath(String path) {
+        Path root = getNormalizedRootPath();
+        Path requested = Path.of(path);
+        Path resolved = requested.isAbsolute() ? requested : root.resolve(requested);
+        Path normalizedResolved = resolved.toAbsolutePath().normalize();
+        if (!normalizedResolved.equals(root) && !normalizedResolved.startsWith(root)) {
+            throw new IllegalArgumentException("Invalid path outside of storage root: " + path);
+        }
+        return normalizedResolved;
+    }
+
     @Override
     public DemoStorageItem getItem(String path) {
-        Path requested = Path.of(path);
-        if (!requested.isAbsolute()) {
-            requested = Path.of(rootPath).resolve(requested);
-        }
-        return new DemoStorageItem(requested.normalize());
+        return new DemoStorageItem(resolveAndValidatePath(path));
     }
 
     @Override
     public String read(DemoStorageItem path) {
         try {
-            return Files.readString(path.asPath(), StandardCharsets.UTF_8);
+            Path safePath = resolveAndValidatePath(path.getPath());
+            return Files.readString(safePath, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new IllegalStateException("Cannot read " + path.getPath(), e);
         }


### PR DESCRIPTION
Potential fix for [https://github.com/rakovpublic/jneopallium/security/code-scanning/22](https://github.com/rakovpublic/jneopallium/security/code-scanning/22)

Use a **safe-root canonicalization + containment check** in `DemoFileStorage`, and route all file operations through it.

Best fix (without changing intended behavior):  
1. Canonicalize `rootPath` once per operation (`Path.of(rootPath).toAbsolutePath().normalize()`).
2. Resolve the requested path against root (or keep absolute input), then normalize and convert to absolute.
3. Reject if resolved path is not equal to root and does not start with root (prevents `..` escape and absolute path escape).
4. Use this validated path in `getItem` and in `read` (and ideally all file ops, but we only edit shown region safely).

Edit file:  
- `worker/src/main/java/com/rakovpublic/jneuropallium/worker/demo/fullrun/runtime/DemoFileStorage.java`  
Add helper methods for safe resolution and containment, and update `getItem` and `read` to use them.

No changes are required in controller/service/model files for this specific sink fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
