### PR TITLE
Ignore JVM crash and deoptimisation dumps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ simulators/jneo-battlespace/**/*.mkv
 __pycache__/
 *.pyc
 
+# JVM crash and deoptimisation dumps, written next to the working directory
+hs_err_pid*.log
+replay_pid*.log
+
 # IDE files
 .idea/
 *.iml


### PR DESCRIPTION
Surefire forks write hs_err_pid*.log next to the working directory when a JVM crashes, and replay_pid*.log alongside it; two of the latter had already been committed to the worker module before it was retired. They are per-run artefacts, not sources.