### PR TITLE
Prepare the build for publishing to Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This makes the framework well-suited to:
 
 ## Project Layout
 
-The build is a multi-module Maven project (`com.rakovpublic.jneopallium:wrapper:1.0`). The engine,
+The build is a multi-module Maven project (`io.github.rakovpublic.jneopallium:wrapper:1.0`). The engine,
 the per-domain implementations, the protocol bridges and the demos are each separate Maven
 artifacts, so a deployment (or a "model owner") depends on only the modules its model actually uses.
 
@@ -167,7 +167,7 @@ mvn clean install
 ```
 
 This builds every module in the reactor (engine, foundation, domains, bridges, demos) and installs
-the artifacts to your local Maven repository under `com.rakovpublic.jneopallium`.
+the artifacts to your local Maven repository under `io.github.rakovpublic.jneopallium`.
 
 ### Using as a Dependency
 
@@ -177,13 +177,13 @@ published — currently install locally, see [Roadmap](#roadmap) for Maven Centr
 ```xml
 <!-- The engine + neuron/signal contracts -->
 <dependency>
-    <groupId>com.rakovpublic.jneopallium</groupId>
+    <groupId>io.github.rakovpublic.jneopallium</groupId>
     <artifactId>worker-core</artifactId>
     <version>1.0-SNAPSHOT</version>
 </dependency>
 <!-- A domain implementation (e.g. industrial); add other domain-*/bridge-* as needed -->
 <dependency>
-    <groupId>com.rakovpublic.jneopallium</groupId>
+    <groupId>io.github.rakovpublic.jneopallium</groupId>
     <artifactId>domain-industrial</artifactId>
     <version>1.0-SNAPSHOT</version>
 </dependency>

--- a/agi-base/pom.xml
+++ b/agi-base/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../pom.xml</relativePath>
@@ -14,6 +14,8 @@
     <artifactId>agi-base</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: agi-base</name>
+    <description>Shared neuromodulatory foundation: the modulatable neuron base together with its signals, enums and model types.</description>
     <!--
       agi-base: the shared neuromodulatory foundation layer. Contains the base
       modulatable neuron (ModulatableNeuron / SimpleSignalChain), the base
@@ -28,7 +30,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridge-api/pom.xml
+++ b/bridge-api/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../pom.xml</relativePath>
@@ -14,6 +14,8 @@
     <artifactId>bridge-api</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-api</name>
+    <description>Shared bridge SPI: the universal write algorithm, audit base, bindings, safety mode, reconnect policy and override registry that every protocol bridge builds on.</description>
     <!--
       bridge-api: the shared bridge SPI (formerly worker/bridge/common). Holds
       the universal write algorithm (AbstractBridgeOutputAggregator), the audit
@@ -29,7 +31,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
@@ -54,7 +56,7 @@
              contracts with the concrete industrial signals. bridge-api's
              compile scope stays free of any domain module. -->
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-industrial</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>test</scope>

--- a/bridges/bridge-canopen/pom.xml
+++ b/bridges/bridge-canopen/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,24 +12,26 @@
     <artifactId>bridge-canopen</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-canopen</name>
+    <description>CANopen bridge: inputs, output aggregators and audit.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-embodiment</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-industrial</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridges/bridge-dicom/pom.xml
+++ b/bridges/bridge-dicom/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,19 +12,21 @@
     <artifactId>bridge-dicom</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-dicom</name>
+    <description>DICOM bridge: inputs, output aggregators and audit.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-clinical</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridges/bridge-ditto/pom.xml
+++ b/bridges/bridge-ditto/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,19 +12,21 @@
     <artifactId>bridge-ditto</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-ditto</name>
+    <description>Eclipse Ditto digital-twin bridge: inputs, output aggregators and audit.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-industrial</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridges/bridge-fhir/pom.xml
+++ b/bridges/bridge-fhir/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,19 +12,21 @@
     <artifactId>bridge-fhir</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-fhir</name>
+    <description>HL7 FHIR bridge: inputs, output aggregators and audit.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-clinical</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridges/bridge-fmi/pom.xml
+++ b/bridges/bridge-fmi/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,19 +12,21 @@
     <artifactId>bridge-fmi</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-fmi</name>
+    <description>FMI/FMU co-simulation bridge: inputs, output aggregators and audit.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-industrial</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridges/bridge-iec61850/pom.xml
+++ b/bridges/bridge-iec61850/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,19 +12,21 @@
     <artifactId>bridge-iec61850</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-iec61850</name>
+    <description>IEC 61850 substation bridge: inputs, output aggregators and audit.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-industrial</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridges/bridge-kafka/pom.xml
+++ b/bridges/bridge-kafka/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,24 +12,26 @@
     <artifactId>bridge-kafka</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-kafka</name>
+    <description>Apache Kafka bridge: inputs, output aggregators and audit.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-security</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridges/bridge-lsl/pom.xml
+++ b/bridges/bridge-lsl/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,34 +12,36 @@
     <artifactId>bridge-lsl</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-lsl</name>
+    <description>Lab Streaming Layer bridge: inputs, output aggregators and audit.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-affect</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-bci</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-embodiment</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-industrial</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridges/bridge-lti/pom.xml
+++ b/bridges/bridge-lti/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,19 +12,21 @@
     <artifactId>bridge-lti</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-lti</name>
+    <description>LTI and xAPI learning-tools bridge: inputs, output aggregators and audit.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-tutoring</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridges/bridge-mavlink/pom.xml
+++ b/bridges/bridge-mavlink/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,39 +12,41 @@
     <artifactId>bridge-mavlink</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-mavlink</name>
+    <description>MAVLink bridge: inputs, output aggregators and audit.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-embodiment</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-industrial</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-security</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-swarm</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridges/bridge-mqtt/pom.xml
+++ b/bridges/bridge-mqtt/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,24 +12,26 @@
     <artifactId>bridge-mqtt</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-mqtt</name>
+    <description>MQTT bridge with Sparkplug B payloads: inputs, output aggregators and audit.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-industrial</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridges/bridge-nengo/pom.xml
+++ b/bridges/bridge-nengo/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,24 +12,26 @@
     <artifactId>bridge-nengo</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-nengo</name>
+    <description>Nengo bridge: inputs, output aggregators and audit.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-industrial</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridges/bridge-opcua/pom.xml
+++ b/bridges/bridge-opcua/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,6 +12,8 @@
     <artifactId>bridge-opcua</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-opcua</name>
+    <description>OPC UA bridge: inputs, output aggregators and audit.</description>
     <!--
       OPC UA bridge (Eclipse Milo). Holds the OPC UA inputs, the client/signal
       mapper, the bridge config and the command/audit outputs. Historically
@@ -23,12 +25,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-industrial</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridges/bridge-otel/pom.xml
+++ b/bridges/bridge-otel/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,14 +12,16 @@
     <artifactId>bridge-otel</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-otel</name>
+    <description>OpenTelemetry export bridge: traces, metrics and logs.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridges/bridge-plc4x/pom.xml
+++ b/bridges/bridge-plc4x/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,19 +12,21 @@
     <artifactId>bridge-plc4x</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-plc4x</name>
+    <description>Apache PLC4X bridge: inputs, output aggregators and audit.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-industrial</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridges/bridge-ros2/pom.xml
+++ b/bridges/bridge-ros2/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,34 +12,36 @@
     <artifactId>bridge-ros2</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: bridge-ros2</name>
+    <description>ROS 2 / DDS bridge: inputs, output aggregators and audit.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-embodiment</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-industrial</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-swarm</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/bridges/pom.xml
+++ b/bridges/pom.xml
@@ -4,13 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>bridges</artifactId>
     <packaging>pom</packaging>
+    <name>Jneopallium :: bridges</name>
+    <description>Aggregator for the per-protocol bridge modules.</description>
     <!-- Aggregator for the per-protocol bridge modules. -->
     <modules>
         <module>bridge-canopen</module>

--- a/demos/demo-adfraud/pom.xml
+++ b/demos/demo-adfraud/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -14,19 +14,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <!-- The advertising-fraud model layers reference ai.neurons.base classes
              (e.g. SimpleSignalChain) by name at runtime. -->
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-adfraud</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
@@ -67,4 +67,18 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- The demos are runnable examples, not something to depend on, so they stay out of
+             Maven Central. This has to be declared per module: demos/pom.xml only aggregates
+             them, their parent is the root pom, so a profile there is not inherited. Scoping
+             it to the release profile leaves the GitLab package-registry deploy, which does
+             publish the demo jars, exactly as it was. -->
+        <profile>
+            <id>release</id>
+            <properties>
+                <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/demos/demo-autonomousai/pom.xml
+++ b/demos/demo-autonomousai/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -14,18 +14,18 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <!-- Reuses the shared demo runtime helpers (DemoJsonContext / DemoFileStorage). -->
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>demo-fullrun</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-agi</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
@@ -66,4 +66,18 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- The demos are runnable examples, not something to depend on, so they stay out of
+             Maven Central. This has to be declared per module: demos/pom.xml only aggregates
+             them, their parent is the root pom, so a profile there is not inherited. Scoping
+             it to the release profile leaves the GitLab package-registry deploy, which does
+             publish the demo jars, exactly as it was. -->
+        <profile>
+            <id>release</id>
+            <properties>
+                <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/demos/demo-autonomousmind/pom.xml
+++ b/demos/demo-autonomousmind/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -14,18 +14,18 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <!-- Reuses the shared demo runtime helpers (DemoJsonContext / DemoFileStorage). -->
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>demo-fullrun</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-agi</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
@@ -66,4 +66,18 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- The demos are runnable examples, not something to depend on, so they stay out of
+             Maven Central. This has to be declared per module: demos/pom.xml only aggregates
+             them, their parent is the root pom, so a profile there is not inherited. Scoping
+             it to the release profile leaves the GitLab package-registry deploy, which does
+             publish the demo jars, exactly as it was. -->
+        <profile>
+            <id>release</id>
+            <properties>
+                <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/demos/demo-cluster/pom.xml
+++ b/demos/demo-cluster/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -16,14 +16,14 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <!-- The neuron, signal and weight classes of the model are shared with the full-run
              demos; only the processor and the result runner are specific to this demo. -->
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>demo-fullrun</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
@@ -47,4 +47,18 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- The demos are runnable examples, not something to depend on, so they stay out of
+             Maven Central. This has to be declared per module: demos/pom.xml only aggregates
+             them, their parent is the root pom, so a profile there is not inherited. Scoping
+             it to the release profile leaves the GitLab package-registry deploy, which does
+             publish the demo jars, exactly as it was. -->
+        <profile>
+            <id>release</id>
+            <properties>
+                <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/demos/demo-fullrun/pom.xml
+++ b/demos/demo-fullrun/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -14,7 +14,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
@@ -55,4 +55,18 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- The demos are runnable examples, not something to depend on, so they stay out of
+             Maven Central. This has to be declared per module: demos/pom.xml only aggregates
+             them, their parent is the root pom, so a profile there is not inherited. Scoping
+             it to the release profile leaves the GitLab package-registry deploy, which does
+             publish the demo jars, exactly as it was. -->
+        <profile>
+            <id>release</id>
+            <properties>
+                <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/demos/demo-industrial/pom.xml
+++ b/demos/demo-industrial/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -14,32 +14,32 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-mqtt</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-opcua</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-industrial</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-agi</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
@@ -80,4 +80,18 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- The demos are runnable examples, not something to depend on, so they stay out of
+             Maven Central. This has to be declared per module: demos/pom.xml only aggregates
+             them, their parent is the root pom, so a profile there is not inherited. Scoping
+             it to the release profile leaves the GitLab package-registry deploy, which does
+             publish the demo jars, exactly as it was. -->
+        <profile>
+            <id>release</id>
+            <properties>
+                <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/demos/demo-industrialfmi/pom.xml
+++ b/demos/demo-industrialfmi/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -14,33 +14,33 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <!-- Reuses the shared demo runtime helpers (DemoJsonContext / DemoFileStorage). -->
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>demo-fullrun</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-mqtt</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-opcua</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-industrial</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
@@ -48,17 +48,17 @@
              from these protocol bridges (verified by the production-loadable test);
              they are resolved by name at runtime, not imported. -->
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-fmi</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-kafka</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-plc4x</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
@@ -99,4 +99,18 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- The demos are runnable examples, not something to depend on, so they stay out of
+             Maven Central. This has to be declared per module: demos/pom.xml only aggregates
+             them, their parent is the root pom, so a profile there is not inherited. Scoping
+             it to the release profile leaves the GitLab package-registry deploy, which does
+             publish the demo jars, exactly as it was. -->
+        <profile>
+            <id>release</id>
+            <properties>
+                <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/demos/demo-uavsingle/pom.xml
+++ b/demos/demo-uavsingle/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -14,27 +14,27 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-api</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>bridge-mavlink</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-agi</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
@@ -75,4 +75,18 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- The demos are runnable examples, not something to depend on, so they stay out of
+             Maven Central. This has to be declared per module: demos/pom.xml only aggregates
+             them, their parent is the root pom, so a profile there is not inherited. Scoping
+             it to the release profile leaves the GitLab package-registry deploy, which does
+             publish the demo jars, exactly as it was. -->
+        <profile>
+            <id>release</id>
+            <properties>
+                <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/demos/pom.xml
+++ b/demos/pom.xml
@@ -4,13 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>demos</artifactId>
     <packaging>pom</packaging>
+    <name>Jneopallium :: demos</name>
+    <description>Aggregator for the runnable demo modules.</description>
     <!-- Aggregator for the runnable demo modules. -->
     <modules>
         <module>demo-adfraud</module>
@@ -22,4 +24,16 @@
         <module>demo-industrialfmi</module>
         <module>demo-uavsingle</module>
     </modules>
+
+    <profiles>
+        <!-- Keeps this aggregator POM itself out of Maven Central. Note that the demo modules
+             do NOT inherit this: their parent is the root pom and this one only aggregates
+             them, so each demo module declares the same profile. -->
+        <profile>
+            <id>release</id>
+            <properties>
+                <maven.deploy.skip>true</maven.deploy.skip>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/docs/publishing-to-maven-central.md
+++ b/docs/publishing-to-maven-central.md
@@ -1,0 +1,149 @@
+# Publishing to Maven Central
+
+The build is configured for Maven Central. Everything Central needs but a normal build does
+not — sources, javadoc, PGP signatures and the portal upload — lives in the **`release`
+profile** in the root `pom.xml`, so `mvn install`, `mvn test` and the GitLab package-registry
+deploy behave exactly as they did before.
+
+```bash
+mvn -Prelease deploy
+```
+
+What follows is the part that is not in the repository: the account, the namespace, the signing
+key and the token. Those are tied to the project owner's identity and can only be done by them.
+
+---
+
+## 1. What is already done
+
+| Central requirement | Where |
+|---|---|
+| `name`, `description` on every published artifact | each module's `pom.xml` (not inherited in Maven, so declared per module) |
+| `url`, `licenses`, `developers`, `scm` | root `pom.xml`, inherited by every module |
+| groupId under a verifiable namespace | `io.github.rakovpublic.jneopallium` |
+| sources jar | `maven-source-plugin` in the `release` profile |
+| javadoc jar | `maven-javadoc-plugin` in the `release` profile (`doclint` off — Central requires the jar to exist, not that every symbol is documented) |
+| PGP signatures | `maven-gpg-plugin` in the `release` profile |
+| upload | `central-publishing-maven-plugin`, `autoPublish=false` so nothing goes live without a confirmation |
+| scope | demos and `integration-tests` set `maven.deploy.skip` **inside the `release` profile only**, so they still publish to GitLab |
+
+## 2. What only you can do
+
+### 2.1 Central account
+
+Register at <https://central.sonatype.com> (sign in with GitHub). This is the current path —
+the old OSSRH / `oss.sonatype.org` route was retired.
+
+### 2.2 Verify the `io.github.rakovpublic` namespace
+
+In the portal, add the namespace `io.github.rakovpublic`. It will give you a verification code
+such as `abc123xyz`. Create a **public repository with exactly that name** under
+<https://github.com/rakovpublic>, then press Verify. The repository can be deleted afterwards.
+
+Verification is what entitles the account to publish anything starting with
+`io.github.rakovpublic`, which is why the groupId is
+`io.github.rakovpublic.jneopallium` — a subgroup of the verified namespace.
+
+### 2.3 Signing key
+
+Central requires every artifact to be signed, and the public key to be resolvable.
+
+```bash
+gpg --gen-key                                   # RSA, 4096, your name and email
+gpg --list-secret-keys --keyid-format=long      # note the key id
+gpg --keyserver keyserver.ubuntu.com --send-keys <KEY_ID>
+```
+
+Keep the private key and its passphrase to yourself — they are not something to paste into a
+chat, a pom, or a repository. The build reads the passphrase from the gpg agent or from the
+`MAVEN_GPG_PASSPHRASE` environment variable.
+
+Back the key up. Losing it means future releases cannot be signed with the same identity.
+
+### 2.4 Portal token
+
+In the portal: *Account → Generate User Token*. It gives a username/password pair. Put it in
+`~/.m2/settings.xml` under the server id the plugin expects:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>central</id>
+      <username>TOKEN_USERNAME</username>
+      <password>TOKEN_PASSWORD</password>
+    </server>
+  </servers>
+</settings>
+```
+
+Do not commit this file.
+
+---
+
+## 3. Releasing
+
+Central does not accept `-SNAPSHOT` for a release, and a version can never be re-published, so
+the version is set explicitly for the release and then moved back to a snapshot.
+
+```bash
+# 1. set the release version across the reactor
+mvn versions:set -DnewVersion=1.0.0 -DprocessAllModules=true
+mvn versions:commit
+
+# 2. build, sign and upload
+export MAVEN_GPG_PASSPHRASE='...'      # or let the gpg agent prompt
+mvn -Prelease clean deploy
+
+# 3. confirm in the portal, then tag
+git tag -a v1.0.0 -m "1.0.0"
+git push origin v1.0.0
+
+# 4. back to development
+mvn versions:set -DnewVersion=1.0.1-SNAPSHOT -DprocessAllModules=true
+mvn versions:commit
+```
+
+With `autoPublish=false` the upload lands in the portal as a *validated* deployment and waits
+there. Look at it, then press **Publish**. It reaches `repo1.maven.org` within about half an
+hour and appears on search.maven.org later the same day.
+
+If validation fails the portal says which rule was broken and the deployment can be dropped and
+re-uploaded under the same version — nothing is public until you publish it.
+
+## 4. What gets published
+
+| Published | Skipped |
+|---|---|
+| `wrapper` (root POM), `worker-core`, `agi-base`, `bridge-api`, `master` | `demos` and all `demo-*` modules |
+| `domains` + the 14 `domain-*` modules | `integration-tests` |
+| `bridges` + the 16 `bridge-*` modules | |
+
+Aggregator POMs have to be published because the modules inherit from them; a consumer cannot
+resolve `worker-core` without `wrapper`.
+
+`master` is a war rather than a library. It is published because it is the cluster coordinator
+and part of the deliverable, not a demo. To leave it out, add the same `release`-profile
+`maven.deploy.skip` block to `master/pom.xml` that `demos/pom.xml` uses.
+
+## 5. Consuming the result
+
+```xml
+<dependency>
+    <groupId>io.github.rakovpublic.jneopallium</groupId>
+    <artifactId>worker-core</artifactId>
+    <version>1.0.0</version>
+</dependency>
+```
+
+## 6. Notes
+
+- **The groupId changed** from `com.rakovpublic.jneopallium` to
+  `io.github.rakovpublic.jneopallium`. That is a consequence of verifying via GitHub rather than
+  a domain. Publishing under `com.rakovpublic` instead would require control of
+  `rakovpublic.com` and a DNS TXT record; if you own it, the groupId can be changed back and
+  everything else here still applies.
+- **The GitLab publish keeps working** and now uses the new groupId. Nothing in
+  `.gitlab-ci.yml`, the root `distributionManagement` or the deploy command changed.
+- **Javadoc lint is off.** Turning `doclint` back on is worth doing eventually, but it fails on
+  a lot of pre-existing javadoc and would block a release today.

--- a/domains/domain-adfraud/pom.xml
+++ b/domains/domain-adfraud/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,9 +12,11 @@
     <artifactId>domain-adfraud</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: domain-adfraud</name>
+    <description>Advertising-fraud detection neurons, signals and processors.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/domains/domain-affect/pom.xml
+++ b/domains/domain-affect/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,14 +12,16 @@
     <artifactId>domain-affect</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: domain-affect</name>
+    <description>Affective-state neurons, signals and processors.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/domains/domain-agi/pom.xml
+++ b/domains/domain-agi/pom.xml
@@ -4,21 +4,23 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>domain-agi</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <name>Jneopallium :: domain-agi</name>
+    <description>Higher cognitive neurons and processors: attention, memory, learning, action selection and harm gating.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/domains/domain-bci/pom.xml
+++ b/domains/domain-bci/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,14 +12,16 @@
     <artifactId>domain-bci</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: domain-bci</name>
+    <description>Brain-computer interface neurons, signals and processors.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/domains/domain-clinical/pom.xml
+++ b/domains/domain-clinical/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,14 +12,16 @@
     <artifactId>domain-clinical</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: domain-clinical</name>
+    <description>Clinical decision-support neurons, signals and processors.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/domains/domain-curiosity/pom.xml
+++ b/domains/domain-curiosity/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,14 +12,16 @@
     <artifactId>domain-curiosity</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: domain-curiosity</name>
+    <description>Curiosity and novelty-drive neurons, signals and processors.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/domains/domain-embodiment/pom.xml
+++ b/domains/domain-embodiment/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,14 +12,16 @@
     <artifactId>domain-embodiment</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: domain-embodiment</name>
+    <description>Embodiment and proprioception neurons, signals and processors.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/domains/domain-glia/pom.xml
+++ b/domains/domain-glia/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,14 +12,16 @@
     <artifactId>domain-glia</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: domain-glia</name>
+    <description>Glial support neurons, signals and processors.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/domains/domain-industrial/pom.xml
+++ b/domains/domain-industrial/pom.xml
@@ -4,21 +4,23 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>domain-industrial</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <name>Jneopallium :: domain-industrial</name>
+    <description>Industrial process-control neurons, signals and processors, including self-supervised maintenance.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/domains/domain-llm/pom.xml
+++ b/domains/domain-llm/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,9 +12,11 @@
     <artifactId>domain-llm</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: domain-llm</name>
+    <description>Large-language-model integration neurons, signals and processors.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/domains/domain-security/pom.xml
+++ b/domains/domain-security/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,14 +12,16 @@
     <artifactId>domain-security</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: domain-security</name>
+    <description>Cybersecurity neurons, signals and processors.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/domains/domain-sleep/pom.xml
+++ b/domains/domain-sleep/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,14 +12,16 @@
     <artifactId>domain-sleep</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: domain-sleep</name>
+    <description>Sleep and consolidation neurons, signals and processors.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/domains/domain-swarm/pom.xml
+++ b/domains/domain-swarm/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,14 +12,16 @@
     <artifactId>domain-swarm</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: domain-swarm</name>
+    <description>Swarm-robotics neurons, signals and processors.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/domains/domain-tutoring/pom.xml
+++ b/domains/domain-tutoring/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../../pom.xml</relativePath>
@@ -12,14 +12,16 @@
     <artifactId>domain-tutoring</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: domain-tutoring</name>
+    <description>Adaptive-tutoring neurons, signals and processors.</description>
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/domains/pom.xml
+++ b/domains/pom.xml
@@ -4,13 +4,15 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>domains</artifactId>
     <packaging>pom</packaging>
+    <name>Jneopallium :: domains</name>
+    <description>Aggregator for the per-domain neuron, signal and processor implementations.</description>
     <!-- Aggregator for the per-domain neuron/signal/processor implementation modules. -->
     <modules>
         <module>domain-adfraud</module>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
         <relativePath>../pom.xml</relativePath>
@@ -14,6 +14,8 @@
     <artifactId>integration-tests</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: integration-tests</name>
+    <description>Cross-module integration tests. Not published.</description>
     <!--
       Test-only module for cross-module (cross-domain) integration tests that
       cannot live in a single domain jar. Currently holds ModuleProcessorsTest,
@@ -23,55 +25,55 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>agi-base</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-affect</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-bci</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-curiosity</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-embodiment</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-glia</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-sleep</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>domain-tutoring</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>test</scope>
@@ -125,4 +127,10 @@
             </plugin>
         </plugins>
     </build>
+
+    <properties>
+        <!-- Cross-module tests; there is nothing here for a consumer to depend on, so this
+             module is not published to any repository. -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
 </project>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -6,19 +6,20 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
     </parent>
     <artifactId>master</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>war</packaging>
+    <description>Cluster coordinator: partitions each layer across the registered workers, holds the run configuration and serves the results.</description>
     <name>jneuronnet.master</name>
     <url>https://github.com/rakovpublic/jneopallium</url>
 
     <dependencies>
         <dependency>
-            <groupId>com.rakovpublic.jneopallium</groupId>
+            <groupId>io.github.rakovpublic.jneopallium</groupId>
             <artifactId>worker-core</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,10 +5,46 @@
                              http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.rakovpublic.jneopallium</groupId>
+    <groupId>io.github.rakovpublic.jneopallium</groupId>
     <artifactId>wrapper</artifactId>
     <version>1.0</version>
     <packaging>pom</packaging>
+
+    <!-- name, url, licenses, developers and scm below are required by Maven Central.
+         url, licenses, developers, organization and scm are inherited by every module;
+         name and description are not, so each published module declares its own. -->
+    <name>Jneopallium</name>
+    <description>
+        Jneopallium is a neuron-network framework whose units are programs rather than
+        activation functions: neurons carry their own signal processors, weights and axon
+        wiring, and the engine routes typed signals between them layer by layer. The build is
+        split into a processing engine, per-domain neuron implementations and per-protocol
+        bridges so that a model depends only on the code it uses.
+    </description>
+    <url>https://github.com/rakovpublic/jneopallium</url>
+
+    <licenses>
+        <license>
+            <name>BSD 3-Clause License</name>
+            <url>https://github.com/rakovpublic/jneopallium/blob/master/LICENSE.MD</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>rakovpublic</id>
+            <name>Dmytro Rakovskyi</name>
+            <url>https://github.com/rakovpublic</url>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/rakovpublic/jneopallium.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/rakovpublic/jneopallium.git</developerConnection>
+        <url>https://github.com/rakovpublic/jneopallium</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <modules>
         <module>master</module>
@@ -60,6 +96,12 @@
         <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
         <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
+
+        <!-- Only used by the `release` profile (Maven Central publishing). -->
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.8.0</maven-javadoc-plugin.version>
+        <maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>
+        <central-publishing-plugin.version>0.5.0</central-publishing-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -167,4 +209,88 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <!--
+          Maven Central publishing. Everything Central needs but a normal build does not -
+          sources, javadoc, PGP signatures and the portal upload - lives here, so the default
+          build and the GitLab package-registry deploy behave exactly as before.
+
+              mvn -Prelease deploy
+
+          See docs/publishing-to-maven-central.md for the full procedure, including the steps
+          that can only be done by the account owner.
+        -->
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${maven-source-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals><goal>jar-no-fork</goal></goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven-javadoc-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals><goal>jar</goal></goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <!-- Central requires a javadoc jar to exist, not that the sources
+                                 are fully documented. doclint would fail the release on missing
+                                 tags in code that predates this requirement. -->
+                            <doclint>none</doclint>
+                            <quiet>true</quiet>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals><goal>sign</goal></goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <!-- Take the passphrase from the gpg agent or the
+                                 MAVEN_GPG_PASSPHRASE environment variable; never from a pom. -->
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <!-- Credentials come from a server entry with this id in
+                                 settings.xml, holding the Central portal user token. -->
+                            <publishingServerId>central</publishingServerId>
+                            <!-- Upload and validate, then wait for the release to be
+                                 confirmed in the portal rather than releasing automatically. -->
+                            <autoPublish>false</autoPublish>
+                            <waitUntil>validated</waitUntil>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/worker-core/pom.xml
+++ b/worker-core/pom.xml
@@ -6,13 +6,15 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.rakovpublic.jneopallium</groupId>
+        <groupId>io.github.rakovpublic.jneopallium</groupId>
         <artifactId>wrapper</artifactId>
         <version>1.0</version>
     </parent>
     <artifactId>worker-core</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <name>Jneopallium :: worker-core</name>
+    <description>Processing engine and the neuron, signal, layer and storage contracts. Every other module builds on this one.</description>
     <!--
       worker-core: the lightweight processing engine and definition/contract
       layer. Contains only the network engine, neuron/signal interfaces, the


### PR DESCRIPTION
The artifacts could not be published as they were: no pom declared a name, description, url, license, developer or scm, none of which Central accepts as missing, and there were no sources jars, javadoc jars or signatures.

groupId moves from com.rakovpublic.jneopallium to
io.github.rakovpublic.jneopallium. Central only accepts artifacts whose groupId sits under a verified namespace, and io.github.rakovpublic is verified through the GitHub account rather than through a DNS record on a domain. Java packages are untouched - they spell it jneuropallium, so nothing in the source changed.

Everything Central needs but a normal build does not - sources, javadoc, signatures and the portal upload - lives in a `release` profile, so `mvn install`, `mvn test` and the GitLab package-registry deploy behave exactly as before. Publishing is `mvn -Prelease deploy`, with autoPublish off so an upload waits for confirmation in the portal instead of going straight to the world.

Scope is libraries plus the master: the demos and integration-tests are kept out. The demo skip has to be declared per demo module - demos/pom.xml only aggregates them, their parent is the root pom, so a profile there is not inherited, which is a mistake that silently publishes everything. It is scoped to the release profile so GitLab, which does publish the demo jars, is unaffected. integration-tests is skipped unconditionally, matching what the GitLab mirror already does.

Verified: default build green, and `-Prelease -Dgpg.skip=true` produces a jar, a sources jar and a javadoc jar for all 38 published modules. Signing and the upload itself cannot be verified here - they need the owner's key and token. Procedure in docs/publishing-to-maven-central.md.